### PR TITLE
Add Loong-Megatron as third_party submodule (loong-main/core_v0.15.0)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "third_party/Loong-Megatron"]
 	path = third_party/Loong-Megatron
 	url = https://github.com/baidu-baige/Loong-Megatron.git
+	branch = loong-main/core_v0.15.0


### PR DESCRIPTION
## What does this PR do?                                                                    
                                                                                            
  Add Loong-Megatron as a git submodule under `third_party/Loong-Megatron`, tracking the      
  `loong-main/core_v0.15.0` branch.                                                           
                                                                                              
  ## Changes                                                  
                                            
  - Added `.gitmodules` entry for `third_party/Loong-Megatron`
  - Submodule points to `baidu-baige/Loong-Megatron` at branch `loong-main/core_v0.15.0`

  ## Usage

  Clone with submodule:

  ```bash
  git clone --recurse-submodules <repo-url>

  Or init after clone:

  git submodule update --init --recursive