### PR TITLE
Update ops README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 * **Decoupled Encoder-Decoder Training**: Separates vision encoder and LLM into independent tasks, eliminating encoder-induced pipeline bubbles and preventing ViT computation from blocking LLM throughput.
 * **DP Load Balancing**: Leverages a load-aware data redistribution algorithm to optimize data parallel imbalances caused by data packing, improving multi-node scaling efficiency.
 * **MoE A2A Optimization**: Overlaps All2All communication, activation offloading, and computation to optimize memory usage and communication in large-scale MoE models, achieving lower memory footprint than upstream Megatron-LM.
-* **Custom Fused Operators**: High-performance fused operators like FusedDSA, which integrates flashmla and indexer forward operators with custom backward operators (essential for training) to accelerate DSA model training. Currently the TileLang-based operators are open-sourced; CUDA kernel implementations are available for free on Baidu Baige Platform.
+* **Custom Fused Operators**: High-performance fused operators like FusedDSA, which integrates flashmla and indexer forward operators with custom backward operators (essential for training) to accelerate DSA model training. Currently the TileLang-based operators are open-sourced.
 * **Adaptive FP8 precision**: End-to-end FP8 training support for both LLMs and VLMs, further enhanced with adaptive FP8 that automatically determines whether to enable FP8 per operator based on GEMM shape and computational efficiency to maximize training performance.
 * **Flexible Checkpoint Conversion**: Supports both **offline bidirectional Megatron ↔ HuggingFace weight conversion** and **native online HuggingFace checkpoint load/save**, eliminating format barriers throughout the training workflow.
 * **Versatile Pipeline & Tools**: Out-of-the-box support for Pretrain, MidTrain, SFT, and LoRA, with built-in tools for dataset processing such as format conversion and packing.
@@ -145,7 +145,7 @@ LoongForge/
 │   ├── convert_checkpoint/       # HuggingFace ↔ Megatron checkpoint conversion
 │   ├── data_preprocess/          # Data preprocessing utilities
 │   └── dist_checkpoint/          # Distributed checkpoint utilities
-├── ops/                          # Custom fused operators (TileLang open-sourced; CUDA available on Baidu Baige Platform)
+├── ops/                          # Custom fused operators (TileLang open-sourced)
 ├── patches/                      # TransformerEngine patch files
 ├── docker/                       # Dockerfiles (GPU & XPU)
 ├── tests/                        # E2E test suite (YAML-driven)

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@
 * **Decoupled Encoder-Decoder Training**: Separates vision encoder and LLM into independent tasks, eliminating encoder-induced pipeline bubbles and preventing ViT computation from blocking LLM throughput.
 * **DP Load Balancing**: Leverages a load-aware data redistribution algorithm to optimize data parallel imbalances caused by data packing, improving multi-node scaling efficiency.
 * **MoE A2A Optimization**: Overlaps All2All communication, activation offloading, and computation to optimize memory usage and communication in large-scale MoE models, achieving lower memory footprint than upstream Megatron-LM.
-* **Custom Fused Operators**: High-performance fused operators like FusedDSA, which integrates flashmla and indexer forward operators with custom backward operators (essential for training) to accelerate DSA model training.
+* **Custom Fused Operators**: High-performance fused operators like FusedDSA, which integrates flashmla and indexer forward operators with custom backward operators (essential for training) to accelerate DSA model training. Currently the TileLang-based operators are open-sourced; CUDA kernel implementations are available for free on Baidu Baige Platform.
 * **Adaptive FP8 precision**: End-to-end FP8 training support for both LLMs and VLMs, further enhanced with adaptive FP8 that automatically determines whether to enable FP8 per operator based on GEMM shape and computational efficiency to maximize training performance.
 * **Flexible Checkpoint Conversion**: Supports both **offline bidirectional Megatron ↔ HuggingFace weight conversion** and **native online HuggingFace checkpoint load/save**, eliminating format barriers throughout the training workflow.
 * **Versatile Pipeline & Tools**: Out-of-the-box support for Pretrain, MidTrain, SFT, and LoRA, with built-in tools for dataset processing such as format conversion and packing.
@@ -145,7 +145,7 @@ LoongForge/
 │   ├── convert_checkpoint/       # HuggingFace ↔ Megatron checkpoint conversion
 │   ├── data_preprocess/          # Data preprocessing utilities
 │   └── dist_checkpoint/          # Distributed checkpoint utilities
-├── ops/                          # Custom fused CUDA/C++ operators (sparse MLA, lightning indexer)
+├── ops/                          # Custom fused operators (TileLang open-sourced; CUDA available on Baidu Baige Platform)
 ├── patches/                      # TransformerEngine patch files
 ├── docker/                       # Dockerfiles (GPU & XPU)
 ├── tests/                        # E2E test suite (YAML-driven)

--- a/ops/README.md
+++ b/ops/README.md
@@ -1,68 +1,20 @@
-# DeepTraining
+# Custom Fused Operators
 
 ## Introduction
 
-DeepTraining is library of optimized kernels, powering the models training. This repository contains the following implementations:
+This directory contains custom fused operators that power LoongForge's training acceleration, including Sparse MLA Attention and Lightning Indexer implementations.
 
-**Kernels**
+Currently, only the **TileLang-based operators** (`tilelang_ops/`) are open-sourced. The CUDA kernel implementations are not included in this release; they are available for free on Baidu Baige Platform.
 
-*These kernels power DeepSeek Sparse Attention (DSA), as introduced in [this paper](https://github.com/deepseek-ai/DeepSeek-V3.2-Exp).*
+## TileLang Operators
 
-- Sparse Attention forward
-- Sparse Attention backward
-- Lihtning Indexer backward
+The `tilelang_ops/` directory provides the following operators built on [TileLang](https://github.com/tile-ai/tilelang):
 
-#### Test & benchmark MLA prefill (Sparse):
+- **Sparse MLA Forward** (`sparse_mla_fwd.py`)
+- **Sparse MLA Backward** (`sparse_mla_bwd.py`)
+- **Lightning Indexer** (`lightning_indexer.py`)
 
-```bash
-python tests/test_flash_mla_sparse_prefill.py
-```
+### Requirements
 
-#### Test & benchmark Indexer backward:
-
-```bash
-python lightning_indexer_bwd/tests/test_autograd.py
-```
-
-## Requirements
-
-- SM90 / SM100 (See the support matrix below)
-- CUDA 12.8 and above (CUDA 12.9+ is required for SM100 kernels)
-- PyTorch 2.0 and above
-
-## Installation
-### Install sparse mla fwd
-Sparse MLA forward is dependent on FlashMLA. Please manually clone FlashMLA first:
-
-```bash
-cd cuda_source/sparse_mla_fwd
-git clone https://github.com/deepseek-ai/FlashMLA.git FlashMLA
-cd FlashMLA
-git checkout 47c35a712362f11bc235854ead51819ad76f5a81
-git submodule update --init --recursive
-cd ../
-pip install -v .
-```
-
-### Install sparse mla bwd
-Sparse MLA backward is dependent on FlashMLA. Please manually clone FlashMLA first:
-
-```bash
-cd cuda_source/sparse_mla_bwd
-git clone https://github.com/deepseek-ai/FlashMLA.git FlashMLA
-cd FlashMLA
-git checkout 47c35a712362f11bc235854ead51819ad76f5a81
-git submodule update --init --recursive
-cd ../
-pip install -v .
-```
-
-### Install lightning indexer bwd
-Lightning Indexer backward is dependent on DeepGEMM. Please manually clone DeepGEMM first, then run install.sh which will automatically install deep_gemm:
-
-```bash
-cd cuda_source/lightning_indexer_bwd
-mkdir -p vendor
-git clone --recurse-submodules https://github.com/deepseek-ai/DeepGEMM.git vendor/DeepGEMM
-sh install.sh  # deep_gemm will be installed automatically
+See `requirements.txt` for dependencies.
 ```


### PR DESCRIPTION
## What does this PR do?                              
Update `ops/README.md` and main `README.md` to reflect that only TileLang-based operators are open-sourced; CUDA kernel implementations are not included in this release.
                                                                              
  ## Changes                                       
  - Rewrote `ops/README.md`: removed CUDA kernel installation instructions (FlashMLA, DeepGEMM etc.), documented the open-sourced TileLang operators (Sparse MLA Forward/Backward, Lightning Indexer)
  - Updated main `README.md`: aligned ops-related descriptions in Key Features and Architecture Overview sections