### PR TITLE
    Support Pi05 SFT training with DDP

### DIFF
--- a/docs/source/vla_tutorial/quick_start_pi05_training.md
+++ b/docs/source/vla_tutorial/quick_start_pi05_training.md
@@ -1,0 +1,167 @@
+# Quick Start: Pi0.5 Training
+
+This document will guide you through the quick start process for **Pi0.5** SFT training under the LoongForge framework.
+
+## 1. Data Preparation
+
+### 1.1 Dataset Format
+
+VLA training uses robot manipulation trajectory data. Each sample typically contains multimodal observations (images, language instructions) and action sequences. LoongForge expects data to be organized in the **[LeRobot dataset v3.0](https://huggingface.co/docs/lerobot/lerobot-dataset-v3)** format, where the path passed via `--data-path` points to the root of your dataset.
+
+LeRobot dataset v3.0 stores episodes as Parquet files with standardized fields for observations, actions, and metadata. The directory structure typically looks like:
+
+### 1.2 Dataset Parameter Description
+
+* `--data-path`: Dataset root directory path.
+* `--chat-template empty`: VLA models use the `empty` chat template, as action prediction does not rely on conversational prompt templates.
+* `--split 100,0,0`: Ratio split for train/validation/test. Typically all data is used for training.
+* `--num-workers`: Number of data loading worker processes (default 16).
+
+
+## 2. Model Weight Preparation
+
+### 2.2 Convert HF Weights to torch Format
+
+Convert HuggingFace weights to PyTorch format for LoongForge training:
+
+```bash
+# Set input/output paths
+export LOAD=/path/to/pi05_huggingface/
+export SAVE=/path/to/pi05_torch/
+
+sh examples/pi05/checkpoint_convert/convert_pi05_hf_to_torch.sh
+```
+
+After conversion, the checkpoint directory structure will be:
+
+```
+pi05_torch/
+├── latest_checkpointed_iteration.txt
+└── release
+    └── mp_rank_00
+        └── model_optim_rng.pt
+```
+
+## 3. Start SFT Training
+
+### 3.1 Parameter Configuration Description
+
+Based on supporting open-source Megatron parameters, LoongForge adds more convenient training startup parameters. Detailed configuration can be found in the `loongforge/train/arguments.py` file. Key Pi0.5-specific parameters are as follows:
+
+**Model & Parallelism:**
+
+* `--model-name pi05`: Selects the Pi0.5 model family, mapping to `configs/models/pi05/pi05.yaml`.
+
+
+* `--training-phase sft`: Explicitly enables SFT training phase.
+* `--ckpt-format torch`: Checkpoint format compatible with FSDP DTensor sharding.
+* `--finetune`: Signals that this is a fine-tuning run (resets optimizer/scheduler state from the loaded checkpoint unless overridden).
+* `--no-load-optim` / `--no-load-rng`: Do not restore optimizer or RNG state from checkpoint, starting fresh.
+
+* `export CUDA_DEVICE_MAX_CONNECTIONS=8`: Required by FSDP; avoids deadlocks from connection limits.
+* `export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True`: Enables expandable CUDA memory segments to reduce OOM errors during training.
+
+### 3.2 SFT Training Script
+
+The full Pi0.5 SFT training script is located at [examples/pi05/finetuning/sft_pi05.sh](../../../examples/pi05/finetuning/sft_pi05.sh). Below is an annotated version:
+
+```bash
+#!/usr/bin/env bash
+
+
+# ── Path Configuration ─────────────────────────────────────────────────────
+MEGATRON_PATH=${MEGATRON_PATH:-"/workspace/Loong-Megatron"}
+LOONGFORGE_PATH=${LOONGFORGE_PATH:-"/workspace/LoongForge"}
+DATA_PATH=${DATA_PATH:-"/workspace/libero/"}
+export TOKENIZER_PATH=${TOKENIZER_PATH:-"/workspace/paligemma-3b-pt-224/"}
+CHECKPOINT_PATH=${CHECKPOINT_PATH:-"/workspace/ckpt/"}
+TENSORBOARD_PATH=${TENSORBOARD_PATH:-"/mnt/cluster/LoongForge/tensorboard-log/pi05/"}
+
+# ── Environment Variables ───────────────────────────────────────────────────
+export CUDA_DEVICE_MAX_CONNECTIONS=8   # Required by FSDP
+export USE_BF16_BUFFER=false           # DTensor does not support BF16 buffer
+export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True  # Reduce OOM risk
+
+# ── Distributed Launch (defaults to single node) ───────────────────────────
+GPUS_PER_NODE=${GPUS_PER_NODE:-1}
+MASTER_ADDR=${MASTER_ADDR:-"localhost"}
+MASTER_PORT=${MASTER_PORT:-"6000"}
+NNODES=${WORLD_SIZE:-"1"}
+NODE_RANK=${RANK:-"0"}
+
+DISTRIBUTED_ARGS=(
+    --nproc_per_node $GPUS_PER_NODE
+    --nnodes $NNODES
+    --node_rank $NODE_RANK
+    --master_addr $MASTER_ADDR
+    --master_port $MASTER_PORT
+)
+
+# ── Data & Tokenizer ────────────────────────────────────────────────────────
+DATA_ARGS=(
+  --tokenizer-type HFTokenizer
+  --hf-tokenizer-path $TOKENIZER_PATH
+  --data-path $DATA_PATH
+  --split 100,0,0
+  --chat-template empty        # VLA does not use conversational prompt templates
+  --num-workers 16
+)
+
+# ── Core Training Hyperparameters ───────────────────────────────────────────
+TRAINING_ARGS=(
+    --training-phase sft
+    --micro-batch-size 16
+    --global-batch-size 128
+    --train-iters 30000
+    --seq-length 762
+    --max-position-embeddings 762
+    --tensor-model-parallel-size 1
+    --pipeline-model-parallel-size 1
+    --no-masked-softmax-fusion
+    --ckpt-format fsdp_dtensor
+    --load $CHECKPOINT_PATH
+    --no-load-optim
+    --no-load-rng
+    --seed 1234
+    --lr 2.5e-8
+    --min-lr 0
+    --lr-decay-style cosine
+    --lr-warmup-iters 0
+    --lr-decay-iters 30000
+    --clip-grad 1.0
+    --adam-beta1 0.9
+    --adam-eps 1e-8
+    --adam-beta2 0.95
+    --weight-decay 0.01
+    --no-strict-fsdp-dtensor-load
+    --finetune
+    --bf16
+    --use-precision-aware-optimizer
+    --exp-avg-dtype bf16
+    --exp-avg-sq-dtype bf16
+    --num-distributed-optimizer-instances 1
+    --save $CHECKPOINT_PATH
+    --save-interval 30000
+)
+
+# ── Model & Distributed Backend ─────────────────────────────────────────────
+MODEL_CONFIG_ARGS=(
+    --model-name pi05
+    --use-distributed-optimizer
+    --distributed-backend nccl
+)
+
+# ── Logging ─────────────────────────────────────────────────────────────────
+LOGGING_ARGS=(
+    --log-interval 1
+)
+
+# ── Launch ───────────────────────────────────────────────────────────────────
+PYTHONPATH=$MEGATRON_PATH:$LOONGFORGE_PATH:${PYTHONPATH:-} \
+    torchrun ${DISTRIBUTED_ARGS[@]} \
+    $LOONGFORGE_PATH/loongforge/train.py \
+    ${MODEL_CONFIG_ARGS[@]} \
+    ${DATA_ARGS[@]} \
+    ${TRAINING_ARGS[@]} \
+    ${LOGGING_ARGS[@]}
+```

--- a/docs/source/vla_tutorial/quick_start_pi05_training.md
+++ b/docs/source/vla_tutorial/quick_start_pi05_training.md
@@ -110,15 +110,15 @@ DATA_ARGS=(
 # ── Core Training Hyperparameters ───────────────────────────────────────────
 TRAINING_ARGS=(
     --training-phase sft
-    --micro-batch-size 16
-    --global-batch-size 128
+    --micro-batch-size 12
+    --global-batch-size 96
     --train-iters 30000
     --seq-length 762
     --max-position-embeddings 762
     --tensor-model-parallel-size 1
     --pipeline-model-parallel-size 1
     --no-masked-softmax-fusion
-    --ckpt-format fsdp_dtensor
+    --ckpt-format torch
     --load $CHECKPOINT_PATH
     --no-load-optim
     --no-load-rng
@@ -133,11 +133,10 @@ TRAINING_ARGS=(
     --adam-eps 1e-8
     --adam-beta2 0.95
     --weight-decay 0.01
-    --no-strict-fsdp-dtensor-load
     --finetune
     --bf16
     --use-precision-aware-optimizer
-    --exp-avg-dtype bf16
+    --exp-avg-dtype fp32
     --exp-avg-sq-dtype bf16
     --num-distributed-optimizer-instances 1
     --save $CHECKPOINT_PATH

--- a/docs/source/vla_tutorial/quick_start_vla_training.md
+++ b/docs/source/vla_tutorial/quick_start_vla_training.md
@@ -1,2 +1,0 @@
-# Quick Start: VLA Model Training
-Coming soon!

--- a/examples/pi05/checkpoint_convert/convert_pi05_hf_to_torch.sh
+++ b/examples/pi05/checkpoint_convert/convert_pi05_hf_to_torch.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Convert Pi05 HuggingFace checkpoint to PyTorch format.
+#
+# This script converts Pi05 safetensors weights from HuggingFace format to a single
+# PyTorch checkpoint file (.pt) compatible with Megatron-LM training.
+#
+# Usage:
+#   # Using default paths (edit LOAD/SAVE below)
+#   bash convert_pi05_hf_to_torch.sh
+#
+#   # Using environment variables
+#   LOAD=/path/to/hf_model SAVE=/path/to/output bash convert_pi05_hf_to_torch.sh
+#
+# Output structure:
+#   ${SAVE}/
+#     ├── latest_checkpointed_iteration.txt  # contains "release"
+#     └── release/
+#         └── mp_rank_00/
+#             └── model_optim_rng.pt          # Megatron checkpoint
+
+set -euo pipefail
+
+LOONGFORGE_PATH=${LOONGFORGE_PATH:-"/workspace/LoongForge"}
+SCRIPT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)
+PYTHON_BIN=${PYTHON_BIN:-"python3"}
+
+# Input/Output paths - modify as needed
+LOAD=${LOAD:-"/workspace/pi05_huggingface/"}
+SAVE=${SAVE:-"/workspace/pi05_torch/"}
+
+# Conversion options
+DTYPE=${DTYPE:-"fp32"}
+PREFIX_ADD=${PREFIX_ADD:-"model."}
+
+echo "=========================================="
+echo "Pi05 HuggingFace to PyTorch Checkpoint Convert"
+echo "=========================================="
+echo "Input:  ${LOAD}"
+echo "Output: ${SAVE}"
+echo "Dtype:  ${DTYPE}"
+echo "Prefix: ${PREFIX_ADD}"
+echo "=========================================="
+
+# Create output directory structure
+mkdir -p "${SAVE}/release/mp_rank_00"
+
+# Run conversion
+"${PYTHON_BIN}" "${LOONGFORGE_PATH}/tools/convert_checkpoint/pi05/convert_hf_to_torch.py" \
+    --input "${LOAD}" \
+    --output "${SAVE}/release/mp_rank_00/model_optim_rng.pt" \
+    --dtype "${DTYPE}" \
+    --prefix-add "${PREFIX_ADD}" \
+    --megatron-format
+
+# Write checkpoint marker file
+echo release > "${SAVE}/latest_checkpointed_iteration.txt"
+
+echo ""
+echo "=========================================="
+echo "Conversion complete!"
+echo "Checkpoint saved to: ${SAVE}"
+echo "=========================================="

--- a/examples/pi05/finetuning/sft_pi05.sh
+++ b/examples/pi05/finetuning/sft_pi05.sh
@@ -15,7 +15,7 @@ export USE_BF16_BUFFER=false #Dtensor not support
 export PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True # avoid OOM
 
 # Distributed launch (defaults single node)
-GPUS_PER_NODE=${GPUS_PER_NODE:-1}
+GPUS_PER_NODE=${GPUS_PER_NODE:-8}
 MASTER_ADDR=${MASTER_ADDR:-"localhost"}
 MASTER_PORT=${MASTER_PORT:-"6000"}
 NNODES=${WORLD_SIZE:-"1"}
@@ -40,8 +40,6 @@ DATA_ARGS=(
 
 # Core training args — pi05 trainer only needs minimal Megatron flags
 TRAINING_ARGS=(
-    --use-megatron-fsdp
-    --data-parallel-sharding-strategy optim
     --training-phase sft
     --micro-batch-size 16
     --global-batch-size 128
@@ -69,11 +67,9 @@ TRAINING_ARGS=(
     --no-strict-fsdp-dtensor-load
     --finetune
     --bf16
-    --grad-reduce-in-bf16
     --use-precision-aware-optimizer
     --exp-avg-dtype bf16
     --exp-avg-sq-dtype bf16
-    --main-grads-dtype bf16
     --num-distributed-optimizer-instances 1
     --save $CHECKPOINT_PATH
     --save-interval 30000

--- a/examples/pi05/finetuning/sft_pi05.sh
+++ b/examples/pi05/finetuning/sft_pi05.sh
@@ -41,8 +41,8 @@ DATA_ARGS=(
 # Core training args — pi05 trainer only needs minimal Megatron flags
 TRAINING_ARGS=(
     --training-phase sft
-    --micro-batch-size 16
-    --global-batch-size 128
+    --micro-batch-size 12
+    --global-batch-size 96
     --train-iters 30000
     --seq-length 762
     --max-position-embeddings 762
@@ -64,11 +64,10 @@ TRAINING_ARGS=(
     --adam-eps 1e-8
     --adam-beta2 0.95
     --weight-decay 0.01
-    --no-strict-fsdp-dtensor-load
     --finetune
     --bf16
     --use-precision-aware-optimizer
-    --exp-avg-dtype bf16
+    --exp-avg-dtype fp32
     --exp-avg-sq-dtype bf16
     --num-distributed-optimizer-instances 1
     --save $CHECKPOINT_PATH

--- a/loongforge/models/embodied/pi05/configuration_pi05.py
+++ b/loongforge/models/embodied/pi05/configuration_pi05.py
@@ -20,6 +20,7 @@
 
 from dataclasses import dataclass, field
 import os
+from typing import Callable, Optional
 from lerobot.configs.policies import PreTrainedConfig
 from lerobot.configs.types import FeatureType, NormalizationMode, PolicyFeature
 from lerobot.optim.optimizers import AdamWConfig
@@ -142,6 +143,8 @@ class PI05Config(PreTrainedConfig):
     # generate some random number on CPU to align the loss on XPU with that on GPU
     random_fallback_cpu: bool = False
 
+    param_sync_func: Optional[Callable] = None
+    grad_sync_func: Optional[Callable] = None
 
     def __post_init__(self):
         """Run basic validations and fill derived Megatron parameters."""

--- a/tools/convert_checkpoint/pi05/convert_hf_to_torch.py
+++ b/tools/convert_checkpoint/pi05/convert_hf_to_torch.py
@@ -1,0 +1,248 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""
+Convert HuggingFace safetensors checkpoint to PyTorch (single-file) format.
+
+This script converts HuggingFace model weights from .safetensors format to a single
+PyTorch checkpoint file (.pt) compatible with Megatron-LM training.
+
+Usage:
+    # Basic conversion
+    python convert_hf_to_torch.py \
+        --input /path/to/hf_model_dir \
+        --output /path/to/output/mp_rank_00/model_optim_rng.pt
+
+    # With dtype conversion and Megatron format
+    python convert_hf_to_torch.py \
+        --input /path/to/hf_model_dir \
+        --output /path/to/output/mp_rank_00/model_optim_rng.pt \
+        --dtype fp32 \
+        --prefix-add "model." \
+        --megatron-format
+
+    # Dry run to check keys without saving
+    python convert_hf_to_torch.py \
+        --input /path/to/hf_model_dir \
+        --dry-run
+"""
+
+import argparse
+import glob
+import os
+import sys
+from collections import OrderedDict
+
+import torch
+
+try:
+    from safetensors import safe_open
+except ImportError:
+    print("ERROR: safetensors library required. Install with: pip install safetensors")
+    sys.exit(1)
+
+
+def find_safetensor_files(input_path: str) -> list[str]:
+    """Find all safetensors files in the given path, sorted by name."""
+    if os.path.isfile(input_path):
+        if not input_path.endswith(".safetensors"):
+            print(f"WARNING: File {input_path} is not in .safetensors format")
+        return [input_path]
+
+    if os.path.isdir(input_path):
+        patterns = [
+            os.path.join(input_path, "*.safetensors"),
+            os.path.join(input_path, "**", "*.safetensors"),
+        ]
+        files = []
+        for pat in patterns:
+            files.extend(glob.glob(pat, recursive=True))
+        # Deduplicate and sort
+        files = sorted(set(files))
+        if not files:
+            print(f"ERROR: No .safetensors files found in {input_path}")
+            sys.exit(1)
+        return files
+
+    print(f"ERROR: {input_path} does not exist")
+    sys.exit(1)
+
+
+def load_safetensors(files: list[str], device: str = "cpu") -> OrderedDict:
+    """Load and merge state_dict from one or more safetensors files."""
+    merged = OrderedDict()
+    total_files = len(files)
+
+    for idx, fpath in enumerate(files, 1):
+        fname = os.path.basename(fpath)
+        print(f"  [{idx}/{total_files}] Loading {fname} ...")
+
+        with safe_open(fpath, framework="pt", device=device) as f:
+            for key in f.keys():
+                if key in merged:
+                    print(f"  WARNING: Duplicate key '{key}', later file will overwrite")
+                merged[key] = f.get_tensor(key)
+
+    return merged
+
+
+def print_summary(state_dict: OrderedDict, show_all: bool = False):
+    """Print state_dict summary."""
+    total_params = len(state_dict)
+    total_elements = 0
+    dtype_counts: dict[str, int] = {}
+
+    for name, tensor in state_dict.items():
+        total_elements += tensor.numel()
+        dt = str(tensor.dtype)
+        dtype_counts[dt] = dtype_counts.get(dt, 0) + 1
+
+    print(f"\n{'='*60}")
+    print("State Dict Summary:")
+    print(f"{'='*60}")
+    print(f"  Number of tensors:    {total_params}")
+    print(f"  Total elements:       {total_elements:,}")
+    print(f"  BF16 size estimate:   {total_elements * 2 / 1024**3:.2f} GB")
+    print(f"  FP32 size estimate:   {total_elements * 4 / 1024**3:.2f} GB")
+    print(f"  Data type distribution: {dtype_counts}")
+
+    if show_all:
+        print(f"\n{'='*60}")
+        print("All Parameters:")
+        print(f"{'='*60}")
+        for name in sorted(state_dict.keys()):
+            t = state_dict[name]
+            print(f"  {name:80s}  {str(t.shape):>30s}  {t.dtype}")
+
+
+def build_arg_parser():
+    """Build argument parser."""
+    parser = argparse.ArgumentParser(
+        description="Convert HuggingFace safetensors checkpoint to Megatron DDP format"
+    )
+    parser.add_argument(
+        "--input", type=str, required=True,
+        help="Path to safetensors file or directory containing multiple shards"
+    )
+    parser.add_argument(
+        "--output", type=str, default=None,
+        help="Output .pt file path (default: <input_dir>/model_weights.pt)"
+    )
+    parser.add_argument(
+        "--dtype", type=str, default=None, choices=["fp32", "fp16", "bf16"],
+        help="Target data type (default: preserve original)"
+    )
+    parser.add_argument(
+        "--dry-run", action="store_true",
+        help="Print key list and summary only, do not save"
+    )
+    parser.add_argument(
+        "--show-all", action="store_true",
+        help="Print all parameter names and shapes"
+    )
+    parser.add_argument(
+        "--prefix-remove", type=str, default=None,
+        help="Remove prefix from parameter names, e.g. 'model.' changes 'model.layer1.weight' to 'layer1.weight'"
+    )
+    parser.add_argument(
+        "--prefix-add", type=str, default=None,
+        help="Add prefix to all parameter names, e.g. 'module.' changes 'layer1.weight' to 'module.layer1.weight'"
+    )
+    parser.add_argument(
+        "--megatron-format", action="store_true",
+        help="Output in Megatron checkpoint format: {'model': state_dict, 'iteration': 0, ...}, "
+             "compatible with Megatron load_checkpoint"
+    )
+    parser.add_argument(
+        "--iteration", type=int, default=0,
+        help="Iteration value for --megatron-format checkpoint (default: 0)"
+    )
+    return parser
+
+
+def main():
+    args = build_arg_parser().parse_args()
+
+    # Set default output path
+    if args.output is None:
+        if os.path.isdir(args.input):
+            args.output = os.path.join(args.input, "model_weights.pt")
+        else:
+            args.output = args.input.replace(".safetensors", ".pt")
+
+    # 1. Find all safetensors files
+    print(f"Scanning input path: {args.input}")
+    files = find_safetensor_files(args.input)
+    print(f"Found {len(files)} safetensors file(s):")
+    for f in files:
+        size_mb = os.path.getsize(f) / 1024**2
+        print(f"  {os.path.basename(f):50s}  ({size_mb:.1f} MB)")
+
+    # 2. Load and merge
+    print("\nLoading weights ...")
+    state_dict = load_safetensors(files)
+    print(f"Loading complete, {len(state_dict)} parameters loaded")
+
+    # 3. Process prefix
+    if args.prefix_remove:
+        prefix = args.prefix_remove
+        new_sd = OrderedDict()
+        removed = 0
+        for key, val in state_dict.items():
+            if key.startswith(prefix):
+                new_sd[key[len(prefix):]] = val
+                removed += 1
+            else:
+                new_sd[key] = val
+        state_dict = new_sd
+        print(f"Removed prefix '{prefix}': affected {removed} parameters")
+
+    if args.prefix_add:
+        prefix = args.prefix_add
+        new_sd = OrderedDict()
+        for key, val in state_dict.items():
+            new_sd[prefix + key] = val
+        state_dict = new_sd
+        print(f"Added prefix '{prefix}': affected {len(state_dict)} parameters")
+
+    # 4. Optional: dtype conversion
+    if args.dtype:
+        dtype_map = {"fp32": torch.float32, "fp16": torch.float16, "bf16": torch.bfloat16}
+        target_dtype = dtype_map[args.dtype]
+        print(f"Converting data type to {args.dtype} ...")
+        for key in state_dict:
+            if state_dict[key].is_floating_point():
+                state_dict[key] = state_dict[key].to(target_dtype)
+
+    # 5. Print summary
+    print_summary(state_dict, show_all=args.show_all or args.dry_run)
+
+    # 6. Save
+    if args.dry_run:
+        print("\n[dry-run] Not saving file")
+    else:
+        os.makedirs(os.path.dirname(os.path.abspath(args.output)), exist_ok=True)
+
+        if args.megatron_format:
+            # Wrap into Megatron load_checkpoint expected format:
+            #   state_dict['model']      -> model weights
+            #   state_dict['iteration']  -> training step
+            #   state_dict['checkpoint_version'] -> version
+            save_obj = {
+                'model': state_dict,
+                'iteration': args.iteration,
+                'checkpoint_version': 3.0,
+                'num_floating_point_operations_so_far': 0,
+            }
+            print(f"\nSaving as Megatron format (iteration={args.iteration}): {args.output} ...")
+        else:
+            save_obj = state_dict
+            print(f"\nSaving to: {args.output} ...")
+
+        torch.save(save_obj, args.output)
+        size_gb = os.path.getsize(args.output) / 1024**3
+        print(f"Save complete! File size: {size_gb:.2f} GB")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION


## Is your feature request related to a problem? Please describe.
  Currently LoongForge lacks complete out-of-the-box support for Pi0.5 SFT training with the DDP backend. Users who want to
  fine-tune Pi0.5 need to manually prepare checkpoints, adapt launch arguments, and infer the expected training setup from
  scattered model/configuration code.

## Describe the solution you'd like
  This PR adds Pi0.5 SFT training support with the DDP backend and provides the required checkpoint conversion workflow.

  Main changes:
  - Add Pi0.5 HuggingFace safetensors to Megatron torch checkpoint conversion script:
    - `tools/convert_checkpoint/pi05/convert_hf_to_torch.py`
  - Add a user-facing conversion wrapper:
    - `examples/pi05/checkpoint_convert/convert_pi05_hf_to_torch.sh`

  - Update Pi0.5 SFT launch script:
    - `examples/pi05/finetuning/sft_pi05.sh`
    - Switches the training path to DDP distributed training.
    - Updates batch settings for 8-GPU default usage.
    - Keeps precision-aware optimizer configuration for Pi0.5 SFT.
  - Update Pi0.5 configuration:
    - `loongforge/models/embodied/pi05/configuration_pi05.py`
    - Adds optional `param_sync_func` and `grad_sync_func` hooks
  - Add Pi0.5 training documentation:
    - `docs/source/vla_tutorial/quick_start_pi05_training.md`
    - Documents LeRobot v3.0 dataset expectation, checkpoint conversion, and SFT launch parameters.
  - Replace the placeholder VLA quick start page with Pi0.5 quick start content:
    - `docs/source/vla_tutorial/quick_start_vla_training.md`

  Expected usage flow:
  1. Prepare Pi0.5 HuggingFace checkpoint and LeRobot v3.0 dataset.
  2. Convert HF safetensors checkpoint to LoongForge/Megatron torch checkpoint:
```bash
     export LOAD=/path/to/pi05_huggingface/
     export SAVE=/path/to/pi05_torch/
     sh examples/pi05/checkpoint_convert/convert_pi05_hf_to_torch.sh
```
  3. Launch Pi0.5 SFT training with DDP backend:
```
     bash examples/pi05/finetuning/sft_pi05.sh
```

## Describe alternatives you've considered
  I considered using the FSDP training path for Pi0.5 SFT. LoongForge now supports both FSDP and DDP backends for this
  model, but this PR makes DDP the default example path because it is simpler to launch, easier to debug, and better
  aligned with the current Pi0.5 SFT quick-start workflow.

  The FSDP path can still be used when users need sharded data-parallel training, while the DDP path provides a more
  straightforward default for getting Pi0.5 SFT running.

## Test Result：
training with ddp
<img width="3504" height="1298" alt="image" src="https://github.com/user-attachments/assets/423e7670-31b5-4cde-8122-28f1a3ec691f" />
loss precision compare with lerobot
<img width="1544" height="1032" alt="image" src="https://github.com/user-attachments/assets/cb4e1561-a487-4217-80a7-de6681b0f243" />

