### PR TITLE
[docker, ops, train] feat: INT4 QAT support for MoE expert layers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,7 @@ swanlog/
 *.prof
 nsys_*/
 nsight_*/
+
+# ops build
+ops/cuda_source/int4_qat/build/
+ops/cuda_source/int4_qat/*.egg-info

--- a/.gitignore
+++ b/.gitignore
@@ -99,3 +99,7 @@ nsight_*/
 
 # Local AI coding assistant rules
 /.comate/
+
+# ops build
+ops/cuda_source/int4_qat/build/
+ops/cuda_source/int4_qat/*.egg-info

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -23,10 +23,21 @@ repos:
       - id: insert-license
         alias: spdx-check
         name: SPDX header check
-        files: '\.(py|sh|cu|cpp|h)$'
+        files: '\.(py|sh)$'
         exclude: '^(third_party|patches|tests/datasets)/'
         args:
           - --license-filepath=.license-header.txt
           - --use-current-year
           - --detect-license-in-X-top-lines=10
           - --no-extra-eol
+      - id: insert-license
+        alias: spdx-check
+        name: SPDX header check (C/C++/CUDA)
+        files: '\.(cu|cpp|h)$'
+        exclude: '^(third_party|patches|tests/datasets)/'
+        args:
+          - --license-filepath=.license-header.txt
+          - --use-current-year
+          - --detect-license-in-X-top-lines=10
+          - --no-extra-eol
+          - --comment-style=//

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -178,6 +178,15 @@ RUN set -exuo pipefail && \
 
 
 # =========================================================
+# INT4 QAT CUDA Kernels (fake quantization for QAT)
+# =========================================================
+RUN set -exuo pipefail && \
+    echo "Installing INT4 QAT CUDA kernels..." && \
+    cd /workspace/LoongForge/ops/cuda_source/int4_qat && \
+    pip install --no-build-isolation . && \
+    echo "INT4 QAT install completed"
+
+# =========================================================
 # Megatron Symlink
 # Scripts reference /workspace/Loong-Megatron; the actual location is
 # /workspace/LoongForge/third_party/Loong-Megatron (git submodule).

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -288,6 +288,15 @@ RUN --mount=type=secret,id=source_manifest,required=false \
 
 
 # =========================================================
+# INT4 QAT CUDA Kernels (fake quantization for QAT)
+# =========================================================
+RUN set -exuo pipefail && \
+    echo "Installing INT4 QAT CUDA kernels..." && \
+    cd /workspace/LoongForge/ops/cuda_source/int4_qat && \
+    pip install --no-build-isolation . && \
+    echo "INT4 QAT install completed"
+
+# =========================================================
 # Megatron Symlink
 # Scripts reference /workspace/Loong-Megatron; the actual location is
 # /workspace/LoongForge/third_party/Loong-Megatron (git submodule).

--- a/loongforge/train/arguments.py
+++ b/loongforge/train/arguments.py
@@ -264,6 +264,33 @@ def _add_extra_model_args(parser: argparse.ArgumentParser):
     )
 
     group.add_argument(
+        '--enable-int4-qat',
+        action='store_true',
+        help="Enable INT4 Quantization-Aware Training (QAT) for expert linear layers. "
+             "Only applies to TEGroupedLinear modules matching the filter. "
+             "Default: False"
+    )
+
+    group.add_argument(
+        '--int4-qat-group-size',
+        type=int,
+        default=32,
+        help="Group size for INT4 QAT quantization. Smaller groups give better "
+             "accuracy at the cost of more quantization parameters. "
+             "Default: 32"
+    )
+
+    group.add_argument(
+        '--int4-qat-filter-regex',
+        type=str,
+        default=None,
+        help="Regular expression pattern to match module paths for INT4 QAT wrapping. "
+             "Only modules whose full path matches the regex are wrapped. "
+             "Example: '.*mlp\\.experts\\.linear_fc1$' quantizes only fc1 experts. "
+             "Default: None (uses built-in default regex for MoE expert FC layers)"
+    )
+
+    group.add_argument(
         "--allow-missing-adapter-checkpoint",
         action="store_true",
         help="Allow model loading to proceed even when adapter checkpoint is missing. "

--- a/loongforge/train/arguments.py
+++ b/loongforge/train/arguments.py
@@ -337,6 +337,33 @@ def _add_extra_model_args(parser: argparse.ArgumentParser):
     )
 
     group.add_argument(
+        '--enable-int4-qat',
+        action='store_true',
+        help="Enable INT4 Quantization-Aware Training (QAT) for expert linear layers. "
+             "Only applies to TEGroupedLinear modules matching the filter. "
+             "Default: False"
+    )
+
+    group.add_argument(
+        '--int4-qat-group-size',
+        type=int,
+        default=32,
+        help="Group size for INT4 QAT quantization. Smaller groups give better "
+             "accuracy at the cost of more quantization parameters. "
+             "Default: 32"
+    )
+
+    group.add_argument(
+        '--int4-qat-filter-regex',
+        type=str,
+        default=None,
+        help="Regular expression pattern to match module paths for INT4 QAT wrapping. "
+             "Only modules whose full path matches the regex are wrapped. "
+             "Example: '.*mlp\\.experts\\.linear_fc1$' quantizes only fc1 experts. "
+             "Default: None (uses built-in default regex for MoE expert FC layers)"
+    )
+
+    group.add_argument(
         "--allow-missing-adapter-checkpoint",
         action="store_true",
         help="Allow model loading to proceed even when adapter checkpoint is missing. "

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -432,6 +432,39 @@ def pretrain(
             add_hooks(tmp_model, args, prefix)
             index += 1
 
+    # INT4 QAT setup
+    if getattr(args, 'enable_int4_qat', False):
+        try:
+            from int4_qat.weight_transform import apply_int4_qat
+            group_size = getattr(args, 'int4_qat_group_size', 32)
+            filter_regex = getattr(args, 'int4_qat_filter_regex', None)
+            models = model if isinstance(model, (list, tuple)) else [model]
+            total_wrapped = 0
+            for m in models:
+                kwargs = dict(group_size=group_size, sym=True)
+                if filter_regex is not None:
+                    kwargs['filter_regex'] = filter_regex
+                _, count = apply_int4_qat(m, **kwargs)
+                total_wrapped += count
+            if total_wrapped == 0:
+                print_rank_0(
+                    "[INT4 QAT] WARNING: --enable-int4-qat is set but NO modules were wrapped. "
+                    "Check that the model contains MoE expert layers and that "
+                    f"--int4-qat-filter-regex='{filter_regex or 'default'}' matches "
+                    "the expected module names. QAT is effectively disabled for this run."
+                )
+            else:
+                print_rank_0(
+                    f"[INT4 QAT] Wrapped {total_wrapped} expert linears "
+                    f"(group_size={group_size})"
+                )
+        except ImportError:
+            print_rank_0("[INT4 QAT] Warning: int4_qat package not installed, skipping QAT")
+        except Exception as e:
+            raise RuntimeError(
+                f"[INT4 QAT] Failed to enable INT4 QAT (--enable-int4-qat was set): {e}"
+            ) from e
+
     timers("model-and-optimizer-setup").stop()
     print_datetime("after model, optimizer, and learning rate scheduler are built")
     config = get_model_config(model[0])

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -493,6 +493,39 @@ def pretrain(
             add_hooks(tmp_model, args, prefix)
             index += 1
 
+    # INT4 QAT setup
+    if getattr(args, 'enable_int4_qat', False):
+        try:
+            from int4_qat.weight_transform import apply_int4_qat
+            group_size = getattr(args, 'int4_qat_group_size', 32)
+            filter_regex = getattr(args, 'int4_qat_filter_regex', None)
+            models = model if isinstance(model, (list, tuple)) else [model]
+            total_wrapped = 0
+            for m in models:
+                kwargs = dict(group_size=group_size, sym=True)
+                if filter_regex is not None:
+                    kwargs['filter_regex'] = filter_regex
+                _, count = apply_int4_qat(m, **kwargs)
+                total_wrapped += count
+            if total_wrapped == 0:
+                print_rank_0(
+                    "[INT4 QAT] WARNING: --enable-int4-qat is set but NO modules were wrapped. "
+                    "Check that the model contains MoE expert layers and that "
+                    f"--int4-qat-filter-regex='{filter_regex or 'default'}' matches "
+                    "the expected module names. QAT is effectively disabled for this run."
+                )
+            else:
+                print_rank_0(
+                    f"[INT4 QAT] Wrapped {total_wrapped} expert linears "
+                    f"(group_size={group_size})"
+                )
+        except ImportError:
+            print_rank_0("[INT4 QAT] Warning: int4_qat package not installed, skipping QAT")
+        except Exception as e:
+            raise RuntimeError(
+                f"[INT4 QAT] Failed to enable INT4 QAT (--enable-int4-qat was set): {e}"
+            ) from e
+
     timers("model-and-optimizer-setup").stop()
     print_datetime("after model, optimizer, and learning rate scheduler are built")
     config = get_model_config(model[0])

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -3,6 +3,10 @@
 #
 # Modified from Megatron-LM under the BSD 3-Clause License.
 # Copyright (c) 2025, NVIDIA CORPORATION. All rights reserved.
+# ruff: noqa: E402
+# Import order is intentional: logging is configured and the start time is
+# captured before heavy imports, and tools/ is added to sys.path before the
+# dist_checkpoint imports below.
 
 """Pretrain utilities."""
 
@@ -49,7 +53,7 @@ from megatron.core.num_microbatches_calculator import (
 from megatron.core.fp8_utils import correct_amax_history_if_needed
 from megatron.core.transformer.module import Float16Module
 from megatron.core.enums import ModelType
-from megatron.core import mpu, tensor_parallel
+from megatron.core import tensor_parallel
 from megatron.training.utils import to_empty_if_meta_device
 from megatron.core.distributed import (
     DistributedDataParallelConfig,
@@ -81,7 +85,6 @@ from megatron.training.global_vars import get_energy_monitor
 from megatron.core.parallel_state import update_pg_timeout
 
 from megatron.training import (
-    get_signal_handler,
     get_timers,
     get_tensorboard_writer,
     get_wandb_writer,
@@ -94,7 +97,6 @@ from megatron.training.initialize import (
     set_jit_fusion_options,
 )
 from .checkpointing import (
-    load_checkpoint,
     save_checkpoint,
     checkpoint_exists,
 )
@@ -138,8 +140,6 @@ from loongforge.data.dp_balance.train_hooks import (
 
 
 # Add project root to Python path
-import sys
-import os
 project_root = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 if project_root not in sys.path:
     sys.path.insert(0, project_root)
@@ -328,14 +328,17 @@ def add_hooks(model, args, prefix):
         f"Set up Log Tensor Hook:\n" f"  name pattern: {args.log_tensor_name_pattern}\n"
     )
     rank = torch.distributed.get_rank()
-    log_fn = lambda string: print(f"[Rank {rank}] {string}")
+
+    def log_fn(string):
+        print(f"[Rank {rank}] {string}")
+
     matched_modules = register_hooks(model, args, rank, log_fn, prefix)
     if len(matched_modules) > 0:
         print_rank_0(
             f"For log tensor name pattern: {args.log_tensor_name_pattern}, find the following layers:"
         )
-        for l in matched_modules:
-            print_rank_0(f"  {l}")
+        for module_name in matched_modules:
+            print_rank_0(f"  {module_name}")
     else:
         print_rank_0(
             f"No layers found for the log tensor name pattern: {args.log_tensor_name_pattern}"
@@ -448,10 +451,6 @@ def pretrain(
         try:
             from nvidia_resiliency_ext.checkpointing.local.ckpt_managers.local_manager import (
                 LocalCheckpointManager,
-            )
-            from nvidia_resiliency_ext.checkpointing.local.replication.group_utils import (
-                parse_group_sequence,
-                GroupWrapper,
             )
             from nvidia_resiliency_ext.checkpointing.local.replication.strategies import (
                 CliqueReplicationStrategy,
@@ -651,7 +650,7 @@ def pretrain(
             write_to_tensorboard=not args.skip_train,
             non_loss_data_func=non_loss_data_func,
         )
-    
+
     # Save HF checkpoint at the end of training if --save-hf is enabled
     save_hf_enabled = getattr(args, 'save_hf', 'false').lower() == 'true'
     if save_hf_enabled and iteration == args.train_iters:
@@ -685,31 +684,31 @@ def check_vlm_peft_config(model_config):
         and model_config.image_encoder.freeze
         and peft_config.apply_to_image_encoder
     ):
-        raise ValueError(f"Cannot freeze image encoder when using PEFT.")
+        raise ValueError("Cannot freeze image encoder when using PEFT.")
     if (
         model_config.image_projector is not None
         and model_config.image_projector.freeze
         and peft_config.apply_to_image_projector
     ):
-        raise ValueError(f"Cannot freeze image projector when using PEFT.")
+        raise ValueError("Cannot freeze image projector when using PEFT.")
     if (
         model_config.foundation is not None
         and model_config.foundation.freeze
         and peft_config.apply_to_foundation
     ):
-        raise ValueError(f"Cannot freeze foundation model when using PEFT.")
+        raise ValueError("Cannot freeze foundation model when using PEFT.")
     if (
         model_config.video_encoder is not None
         and model_config.video_encoder.freeze
         and peft_config.apply_to_video_encoder
     ):
-        raise ValueError(f"Cannot freeze video encoder when using PEFT.")
+        raise ValueError("Cannot freeze video encoder when using PEFT.")
     if (
         model_config.video_projector is not None
         and model_config.video_projector.freeze
         and peft_config.apply_to_video_projector
     ):
-        raise ValueError(f"Cannot freeze video projector when using PEFT.")
+        raise ValueError("Cannot freeze video projector when using PEFT.")
     target_prefix = []
     if peft_config.apply_to_foundation:
         target_prefix.append("foundation")
@@ -855,7 +854,7 @@ def get_model(
 
             # Directly call load_checkpoint_from path in order to avoid
             # the load directory overriding the pretrained checkpoint path
-            # This is needed to initialize the base model weights first, 
+            # This is needed to initialize the base model weights first,
             # and then conditionally load adapter states after
             _load_checkpoint_from_path(
                 load_dir=args.pretrained_checkpoint,
@@ -919,7 +918,7 @@ def get_model(
             param_pattern = [param_pattern]
 
         config = get_model_config(model[0])
-       
+
         model = [Float16Module(config, model_module) for model_module in model]
         fp32_training_weights = param_pattern
         #covert fp32
@@ -1207,9 +1206,9 @@ def setup_model_and_optimizer(
         timers("load-checkpoint").stop(barrier=True)
         timers.log(["load-checkpoint"])
 
-        #For models such as GLM-5, the model structure is similar to DeepSeek, 
-        #but the weights are different from DeepSeek. 
-        #MTP does not have separate embedding weights, and in pipeline scenarios, 
+        #For models such as GLM-5, the model structure is similar to DeepSeek,
+        #but the weights are different from DeepSeek.
+        #MTP does not have separate embedding weights, and in pipeline scenarios,
         #weights need to be copied from the first PP stage.
         if args.should_get_embedding_weights_for_mtp:
             _p2p_embedding_weights_for_mtp(unwrapped_model, args)
@@ -1515,11 +1514,11 @@ def train_step(
     timers = get_timers()
 
     if args.enable_full_hetero_dp:
-        import itertools, copy
+        import itertools
+        import copy
         from loongforge.train.initialize import (
             get_num_micro_batches_per_decoder_dp,
             get_num_real_micro_batches_per_decoder_dp,
-            change_parallel_state,
         )
         from loongforge.train.pretrain.pretrain_vlm import (
             get_batch, get_embedding_list,
@@ -1563,7 +1562,6 @@ def train_step(
         for round in range(encoder_rounds):
             batch_list.clear()
             front = pp_layer * tp_size + round * model_size
-            all_mock_in_range = (front >= num_real_microbatch)
             for tp_idx in range(tp_size):
                 global_mb_idx = front + tp_idx
                 if global_mb_idx >= num_real_microbatch:
@@ -1644,7 +1642,7 @@ def train_step(
 
             embedding_list.append(
                 gather_variable_shape_embeddings(
-                    combined_embeddings, 
+                    combined_embeddings,
                     group=mpu.get_model_parallel_group()
                 )
             )
@@ -1652,7 +1650,7 @@ def train_step(
             if visual_pos_masks is not None:
                 visual_pos_masks_list.append(
                     gather_variable_shape_embeddings(
-                        visual_pos_masks, 
+                        visual_pos_masks,
                         group=mpu.get_model_parallel_group()
                     )
                 )
@@ -1870,7 +1868,7 @@ def train_step(
 
         for _round_key in list(local_model.vit_contexts.keys()):
             del local_model.vit_contexts[_round_key]
-        
+
         clear_full_hetero_info()
 
     should_checkpoint, should_exit, exit_code = (

--- a/ops/cuda_source/int4_qat/README.md
+++ b/ops/cuda_source/int4_qat/README.md
@@ -1,0 +1,78 @@
+# INT4 Fake Quantization for QAT
+
+GPU-accelerated INT4 fake quantization kernels for Quantization-Aware Training (QAT) of MoE expert weights.
+
+## Install
+
+```bash
+cd LoongForge/ops/cuda_source/int4_qat
+pip install -e .
+```
+
+Requires: PyTorch with CUDA support, NVCC matching the PyTorch CUDA version.
+
+To verify:
+
+```bash
+python -c "from int4_qat import fake_int4_quant; print('OK')"
+```
+
+## Usage
+
+### In training (via LoongForge)
+
+Pass CLI arguments to `train.py`:
+
+```bash
+--enable-int4-qat           # Enable INT4 QAT
+--int4-qat-group-size 32    # Group size (default: 32)
+```
+
+This automatically applies fake INT4 quantization to `TEGroupedLinear` (MoE expert) weights during training forward, with STE gradient passthrough.
+
+### Standalone API
+
+```python
+import torch
+from int4_qat import fake_int4_quant, fake_int4_quantize_dequantize
+
+w = torch.randn(256, 1024, device="cuda", dtype=torch.bfloat16)
+
+# Low-level: quantize only → integer codes + scale + zero
+q, scale, zero = fake_int4_quant(w, block_size=[1, 32], sym=True)
+
+# Mid-level: quantize + dequantize → fake-quantized BF16 tensor
+w_fq = fake_int4_quantize_dequantize(w, group_size=32, sym=True)
+```
+
+For training, use `apply_int4_qat()` which patches `TEGroupedLinear` modules with STE-enabled fake quantization:
+
+```python
+from int4_qat import apply_int4_qat
+
+transform, count = apply_int4_qat(model, group_size=32, sym=True)
+# Patches _get_weight_tensors on matching modules (MoE expert FC layers by default)
+```
+
+## CUDA Kernels
+
+Three dispatch paths in `csrc/fake_int4_quant.cu`, selected by block size:
+
+| Kernel | Block Size | Use Case |
+|--------|-----------|----------|
+| `int4_quant_1x32_kernel` | `[1, 32]` | Per-row grouping (most common for weight quant) |
+| `int4_quant_32x1_kernel` | `[32, 1]` | Transpose / per-column grouping |
+| `int4_quant_common_kernel` | arbitrary | Generic, requires `block_m * block_n % 32 == 0` |
+
+Quantization modes:
+- **Symmetric** (`sym=True`): range `[-7, 7]`, `scale = max(|x|) / 7`
+- **Asymmetric** (`sym=False`): range `[0, 15]`, `scale = (max - min) / 15`, with zero-point
+
+If the CUDA extension is not built, all APIs fall back to a pure PyTorch implementation automatically.
+
+## Tests
+
+```bash
+cd LoongForge/ops/cuda_source/int4_qat
+pytest tests/ -v
+```

--- a/ops/cuda_source/int4_qat/README.md
+++ b/ops/cuda_source/int4_qat/README.md
@@ -70,6 +70,15 @@ Quantization modes:
 
 If the CUDA extension is not built, all APIs fall back to a pure PyTorch implementation automatically.
 
+## Tensor-parallel sharding requirement
+
+Zero-padding is only applied at the true tail of a tensor. If a weight is
+TP-sharded along `in_features` (e.g. row-parallel style, `partition_dim=1`),
+the local shard size must be a multiple of `group_size` — `apply_int4_qat()`
+raises at setup time otherwise, because a quantization group straddling a
+TP boundary would require a cross-rank amax reduction (not implemented).
+Sharding along `out_features` (column-parallel) is unaffected.
+
 ## Tests
 
 ```bash

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
@@ -1,0 +1,383 @@
+/*
+ * Original INT4 fake-quantization CUDA kernel.
+ *
+ * This kernel was originally derived from the `slime` library
+ * (https://github.com/yangzhch6/slime/tree/master/smoothquant) and adapted
+ * for this project.  The core quantize-only logic (warp-reduce per-group
+ * scale/zero, symmetric/asymmetric modes) is preserved; dispatch helpers
+ * and pybind11 bindings have been added to integrate with the
+ * `int4_qat` package.
+ *
+ * Thanks to the authors of `slime` for the reference implementation.
+ */
+
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+
+#define FINAL_MASK 0xFFFFFFFF
+
+__device__ __host__ __forceinline__
+int ceil_div(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+__device__ __forceinline__
+float warpReduceMax(float val) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+        val = fmaxf(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+    return val;
+}
+
+
+__device__ __forceinline__
+float warpReduceMin(float val) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+        val = fminf(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+    return val;
+}
+
+// almost all int4 use blocksize = [1, 32]
+template<typename scalar_t>
+__global__
+void int4_quant_1x32_kernel(
+    const scalar_t* __restrict__ x,
+    scalar_t* __restrict__ out,
+    scalar_t* out_scale,
+    scalar_t* out_zero,
+    const int M, const int N,
+    const int stride_xm, const int stride_xn,
+    const int stride_om, const int stride_on,
+    const int stride_osm, const int stride_osn,
+    const int stride_ozm, const int stride_ozn,
+    bool sym
+) {
+    constexpr int WARPS_PER_BLOCK = 8;
+    const int needed_warps = ceil_div(N, 32);
+    
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane_id = tid & 0x1F;
+    constexpr float SYM_CONS = 1.0f / 7.0f;
+    constexpr float ASYM_CONS = 1.0f / 15.0f;
+    
+    const int row = blockIdx.x;
+
+    for (int item = warp_id; item < needed_warps; item += WARPS_PER_BLOCK) {
+        const int col = item * 32 + lane_id;
+        float val = 0.0f;
+
+        if (col < N) {
+            val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
+        }
+        
+        float scale = 0.0f;
+        float zero = 0.0f;
+        
+        if (sym) {
+            float abs_val = fabsf(val);
+            
+            float block_max = warpReduceMax(abs_val);
+            
+            scale = fmaxf(block_max * SYM_CONS, 1e-5f);
+
+            val = rintf(val / scale);
+        } else {
+            float block_min = warpReduceMin(val);
+            float block_max = warpReduceMax(val);
+
+            scale = fmaxf((block_max - block_min) * ASYM_CONS, 1e-5f);
+            zero = fminf(fmaxf(-rintf(block_min / scale), 0.0f), 15.0f);
+            
+            val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
+        }
+
+        if (col < N) {
+            out[row * stride_om + col * stride_on] = static_cast<scalar_t>(val);
+            out_scale[row * stride_osm + item * stride_osn] = static_cast<scalar_t>(scale);
+            if(!sym) {
+                out_zero[row * stride_ozm + item * stride_ozn] = static_cast<scalar_t>(zero);
+            }
+        }
+    }
+}
+
+// for some transpose case, blocksize = [32, 1]
+template<typename scalar_t>
+__global__
+void int4_quant_32x1_kernel(
+    const scalar_t* __restrict__ x,
+    scalar_t* __restrict__ out,
+    scalar_t* out_scale,
+    scalar_t* out_zero,
+    const int M, const int N,
+    const int stride_xm, const int stride_xn,
+    const int stride_om, const int stride_on,
+    const int stride_osm, const int stride_osn,
+    const int stride_ozm, const int stride_ozn,
+    bool sym
+) {
+    constexpr int WARPS_PER_BLOCK = 8;
+    const int start_row = blockIdx.x * 32;
+    const int end_row = min((blockIdx.x + 1) * 32, M);
+    
+    const int tid = threadIdx.x;
+    const int warp_id = tid >> 5;
+    const int lane_id = tid & 0x1F;
+    constexpr float SYM_CONS = 1.0f / 7.0f;
+    constexpr float ASYM_CONS = 1.0f / 15.0f;
+    
+    for (int item = warp_id; item < N; item += WARPS_PER_BLOCK) {
+        const int col = item;
+        const int row = start_row + lane_id;
+
+        float val = 0.0f;
+
+        if (row < end_row) {
+            val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
+        }
+    
+        float scale = 0.0f;
+        float zero = 0.0f;
+        
+        if (sym) {
+            float abs_val = fabsf(val);
+            
+            float block_max = warpReduceMax(abs_val);
+            
+            scale = fmaxf(block_max * SYM_CONS, 1e-5f);
+
+            val = rintf(val / scale);
+        } else {
+            float block_min = warpReduceMin(val);
+            float block_max = warpReduceMax(val);
+
+            scale = fmaxf((block_max - block_min) * ASYM_CONS, 1e-5f);
+            zero = fminf(fmaxf(-rintf(block_min / scale), 0.0f), 15.0f);
+            
+            val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
+        }
+
+        if (row < end_row) {
+            out[row * stride_om + col * stride_on] = static_cast<scalar_t>(val);
+            out_scale[blockIdx.x * stride_osm + item * stride_osn] = static_cast<scalar_t>(scale);
+            if (!sym) {
+                out_zero[blockIdx.x * stride_ozm + item * stride_ozn] = static_cast<scalar_t>(zero);
+            }
+        }
+    }
+}
+
+template<typename scalar_t>
+__global__ void int4_quant_common_kernel(
+    const scalar_t* __restrict__ x,
+    scalar_t* __restrict__ out,
+    scalar_t* out_scale,
+    scalar_t* out_zero,
+    const int M, const int N,
+    const int stride_xm, const int stride_xn,
+    const int stride_om, const int stride_on,
+    const int stride_osm, const int stride_osn,
+    const int stride_ozm, const int stride_ozn,
+    const int BLOCK_M, const int BLOCK_N,
+    bool sym
+) {
+    const int start_row = blockIdx.x * BLOCK_M;
+    const int WARPS_PER_BLOCK = blockDim.x >> 5;
+    
+    const int warp_id = threadIdx.x >> 5;
+    const int lane_id = threadIdx.x & 0x1F;
+    constexpr float SYM_CONS = 1.0f / 7.0f;
+    constexpr float ASYM_CONS = 1.0f / 15.0f;
+    constexpr int WARP_SIZE = 32;
+    
+    const int needed_warps = ceil_div(N, BLOCK_N);
+    const int iters = ceil_div(BLOCK_M * BLOCK_N, 32);
+    int warp_rows = 1;
+
+    if (BLOCK_N <= WARP_SIZE) {
+        warp_rows = WARP_SIZE / BLOCK_N;
+    }
+    
+    for (int item = warp_id; item < needed_warps; item += WARPS_PER_BLOCK) {
+        float local_max = -INFINITY;
+        float local_min = INFINITY;
+
+        float val = 0.0f;
+        float scale, zero = 0.0f;
+
+        const int row_off = lane_id / BLOCK_N;
+        const int col_off = lane_id % BLOCK_N;
+        int row, col = 0;
+        
+        for (int i = 0; i < iters; ++i) {
+            if (BLOCK_N <= WARP_SIZE) {
+                row = start_row + i * warp_rows + row_off;
+                col = item * BLOCK_N + col_off;
+            } else {
+                int flat_idx = i * WARP_SIZE + lane_id;
+                row = start_row + flat_idx / BLOCK_N;
+                col = item * BLOCK_N + flat_idx % BLOCK_N;
+            }
+
+            if (row < M && col < N) {
+                val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
+            } else {
+                val = 0.0f;
+            }
+
+            if (sym) {
+                local_max = fmaxf(local_max, fabsf(val));
+            } else {
+                local_max = fmaxf(local_max, val);
+                local_min = fminf(local_min, val);
+            }
+        }
+
+        if (sym) {
+            float block_max = warpReduceMax(local_max);
+            scale = fmaxf(block_max * SYM_CONS, 1e-5f);
+        } else {
+            float block_max = warpReduceMax(local_max);
+            float block_min = warpReduceMin(local_min);
+            scale = fmaxf((block_max - block_min) * ASYM_CONS, 1e-5f);
+            zero = fminf(fmaxf(-rintf(block_min / scale), 0.0f), 15.0f);
+        }
+
+        for (int i = 0; i < iters; ++i) {
+            if (BLOCK_N <= WARP_SIZE) {
+                row = start_row + i * warp_rows + row_off;
+                col = item * BLOCK_N + col_off;
+            } else {
+                int flat_idx = i * WARP_SIZE + lane_id;
+                row = start_row + flat_idx / BLOCK_N;
+                col = item * BLOCK_N + flat_idx % BLOCK_N;
+            }
+
+            if (row < M && col < N) {
+                float val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
+                if (sym) {
+                    val = rintf(val / scale);
+                } else {
+                    val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
+                }
+                
+                out[row * stride_om + col * stride_on] = static_cast<scalar_t>(val);
+                out_scale[blockIdx.x * stride_osm + item * stride_osn] = static_cast<scalar_t>(scale);
+                if (!sym) {
+                    out_zero[blockIdx.x * stride_ozm + item * stride_ozn] = static_cast<scalar_t>(zero);
+                }
+            }
+        }
+    }
+}
+
+// dispatch
+template<typename scalar_t>
+void launch_int4_quant_kernel(
+    const scalar_t* x,
+    scalar_t* out,
+    scalar_t* out_scale,
+    scalar_t* out_zero,
+    int M, int N,
+    const int stride_xm, const int stride_xn,
+    const int stride_om, const int stride_on,
+    const int stride_osm, const int stride_osn,
+    const int stride_ozm, const int stride_ozn,
+    int block_m, int block_n,
+    bool sym,
+    cudaStream_t stream
+) {
+    constexpr int WARPS_PER_BLOCK = 8;
+    constexpr int THREADS_PER_BLOCK = WARPS_PER_BLOCK * 32;  // 256
+
+    if (block_m == 1 && block_n == 32) {
+        dim3 grid(M);
+        dim3 block(THREADS_PER_BLOCK);
+        
+        int4_quant_1x32_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            x, out, out_scale, out_zero, M, N,
+            stride_xm, stride_xn,
+            stride_om, stride_on,
+            stride_osm, stride_osn,
+            stride_ozm, stride_ozn,
+            sym
+        );
+    } else if (block_m == 32 && block_n == 1) {
+        dim3 grid(ceil_div(M, block_m));
+        dim3 block(THREADS_PER_BLOCK);
+
+        int4_quant_32x1_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            x, out, out_scale, out_zero, M, N,
+            stride_xm, stride_xn,
+            stride_om, stride_on,
+            stride_osm, stride_osn,
+            stride_ozm, stride_ozn,
+            sym
+        );
+    } else {
+        dim3 grid(ceil_div(M, block_m));
+        dim3 block(THREADS_PER_BLOCK);
+        int4_quant_common_kernel<scalar_t><<<grid, block, 0, stream>>>(
+            x, out, out_scale, out_zero, M, N,
+            stride_xm, stride_xn,
+            stride_om, stride_on,
+            stride_osm, stride_osn,
+            stride_ozm, stride_ozn,
+            block_m, block_n,
+            sym
+        );
+    }
+}
+
+std::tuple<torch::Tensor, torch::Tensor, torch::Tensor>
+fake_int4_quant_cuda(
+    torch::Tensor& x,
+    std::vector<int64_t>& block_size,
+    bool sym
+) {
+    TORCH_CHECK(x.dim() == 2, "Input must be 2D");
+    TORCH_CHECK(x.is_cuda(), "Input must be on CUDA");
+    
+    int M = x.size(0);
+    int N = x.size(1);
+    int block_m = block_size[0];
+    int block_n = block_size[1];
+
+    TORCH_CHECK(block_m > 0 && block_n > 0, "Block sizes must be positive, got block_m=", block_m, ", block_n=", block_n);
+    TORCH_CHECK((block_m * block_n) % 32 == 0,
+        "block_m * block_n (", block_m * block_n, ") must be divisible by 32. "
+        "But got a ", block_m, "x", block_n, " block.");
+
+    auto out = torch::empty_like(x);
+    auto out_scale = torch::empty({ceil_div(M, block_m), ceil_div(N, block_n)}, x.options());
+    auto out_zero = torch::empty_like(out_scale);
+
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+    
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::ScalarType::BFloat16,
+        x.scalar_type(), "int4_quant_cuda", [&] {
+        launch_int4_quant_kernel<scalar_t>(
+            x.const_data_ptr<scalar_t>(),
+            out.data_ptr<scalar_t>(),
+            out_scale.data_ptr<scalar_t>(),
+            out_zero.data_ptr<scalar_t>(),
+            M, N,
+            x.stride(0), x.stride(1),
+            out.stride(0), out.stride(1),
+            out_scale.stride(0), out_scale.stride(1),
+            out_zero.stride(0), out_zero.stride(1),
+            block_m, block_n,
+            sym,
+            stream
+        );
+    });
+    
+    return std::make_tuple(out, out_scale, out_zero);
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fake_int4_quant_cuda", &fake_int4_quant_cuda, "fake INT4 quantization cuda");
+}

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
@@ -2,7 +2,7 @@
  * Original INT4 fake-quantization CUDA kernel.
  *
  * This kernel was originally derived from the `slime` library
- * (https://github.com/yangzhch6/slime/tree/master/smoothquant) and adapted
+ * (https://github.com/THUDM/slime/blob/main/slime/backends/megatron_utils/kernels/int4_qat/fake_int4_quant_cuda.cu) and adapted
  * for this project.  The core quantize-only logic (warp-reduce per-group
  * scale/zero, symmetric/asymmetric modes) is preserved; dispatch helpers
  * and pybind11 bindings have been added to integrate with the

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
@@ -1,3 +1,5 @@
+// Copyright 2026 The LoongForge Authors.
+// SPDX-License-Identifier: Apache-2.0
 /*
  * Original INT4 fake-quantization CUDA kernel.
  *
@@ -55,13 +57,13 @@ void int4_quant_1x32_kernel(
 ) {
     constexpr int WARPS_PER_BLOCK = 8;
     const int needed_warps = ceil_div(N, 32);
-    
+
     const int tid = threadIdx.x;
     const int warp_id = tid >> 5;
     const int lane_id = tid & 0x1F;
     constexpr float SYM_CONS = 1.0f / 7.0f;
     constexpr float ASYM_CONS = 1.0f / 15.0f;
-    
+
     const int row = blockIdx.x;
 
     for (int item = warp_id; item < needed_warps; item += WARPS_PER_BLOCK) {
@@ -71,15 +73,15 @@ void int4_quant_1x32_kernel(
         if (col < N) {
             val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
         }
-        
+
         float scale = 0.0f;
         float zero = 0.0f;
-        
+
         if (sym) {
             float abs_val = fabsf(val);
-            
+
             float block_max = warpReduceMax(abs_val);
-            
+
             scale = fmaxf(block_max * SYM_CONS, 1e-5f);
 
             val = rintf(val / scale);
@@ -89,7 +91,7 @@ void int4_quant_1x32_kernel(
 
             scale = fmaxf((block_max - block_min) * ASYM_CONS, 1e-5f);
             zero = fminf(fmaxf(-rintf(block_min / scale), 0.0f), 15.0f);
-            
+
             val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
         }
 
@@ -121,13 +123,13 @@ void int4_quant_32x1_kernel(
     constexpr int WARPS_PER_BLOCK = 8;
     const int start_row = blockIdx.x * 32;
     const int end_row = min((blockIdx.x + 1) * 32, M);
-    
+
     const int tid = threadIdx.x;
     const int warp_id = tid >> 5;
     const int lane_id = tid & 0x1F;
     constexpr float SYM_CONS = 1.0f / 7.0f;
     constexpr float ASYM_CONS = 1.0f / 15.0f;
-    
+
     for (int item = warp_id; item < N; item += WARPS_PER_BLOCK) {
         const int col = item;
         const int row = start_row + lane_id;
@@ -137,15 +139,15 @@ void int4_quant_32x1_kernel(
         if (row < end_row) {
             val = static_cast<float>(x[row * stride_xm + col * stride_xn]);
         }
-    
+
         float scale = 0.0f;
         float zero = 0.0f;
-        
+
         if (sym) {
             float abs_val = fabsf(val);
-            
+
             float block_max = warpReduceMax(abs_val);
-            
+
             scale = fmaxf(block_max * SYM_CONS, 1e-5f);
 
             val = rintf(val / scale);
@@ -155,7 +157,7 @@ void int4_quant_32x1_kernel(
 
             scale = fmaxf((block_max - block_min) * ASYM_CONS, 1e-5f);
             zero = fminf(fmaxf(-rintf(block_min / scale), 0.0f), 15.0f);
-            
+
             val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
         }
 
@@ -185,13 +187,13 @@ __global__ void int4_quant_common_kernel(
 ) {
     const int start_row = blockIdx.x * BLOCK_M;
     const int WARPS_PER_BLOCK = blockDim.x >> 5;
-    
+
     const int warp_id = threadIdx.x >> 5;
     const int lane_id = threadIdx.x & 0x1F;
     constexpr float SYM_CONS = 1.0f / 7.0f;
     constexpr float ASYM_CONS = 1.0f / 15.0f;
     constexpr int WARP_SIZE = 32;
-    
+
     const int needed_warps = ceil_div(N, BLOCK_N);
     const int iters = ceil_div(BLOCK_M * BLOCK_N, 32);
     int warp_rows = 1;
@@ -199,7 +201,7 @@ __global__ void int4_quant_common_kernel(
     if (BLOCK_N <= WARP_SIZE) {
         warp_rows = WARP_SIZE / BLOCK_N;
     }
-    
+
     for (int item = warp_id; item < needed_warps; item += WARPS_PER_BLOCK) {
         float local_max = -INFINITY;
         float local_min = INFINITY;
@@ -210,7 +212,7 @@ __global__ void int4_quant_common_kernel(
         const int row_off = lane_id / BLOCK_N;
         const int col_off = lane_id % BLOCK_N;
         int row, col = 0;
-        
+
         for (int i = 0; i < iters; ++i) {
             if (BLOCK_N <= WARP_SIZE) {
                 row = start_row + i * warp_rows + row_off;
@@ -262,7 +264,7 @@ __global__ void int4_quant_common_kernel(
                 } else {
                     val = fminf(fmaxf(rintf(val / scale) + zero, 0.0f), 15.0f);
                 }
-                
+
                 out[row * stride_om + col * stride_on] = static_cast<scalar_t>(val);
                 out_scale[blockIdx.x * stride_osm + item * stride_osn] = static_cast<scalar_t>(scale);
                 if (!sym) {
@@ -295,7 +297,7 @@ void launch_int4_quant_kernel(
     if (block_m == 1 && block_n == 32) {
         dim3 grid(M);
         dim3 block(THREADS_PER_BLOCK);
-        
+
         int4_quant_1x32_kernel<scalar_t><<<grid, block, 0, stream>>>(
             x, out, out_scale, out_zero, M, N,
             stride_xm, stride_xn,
@@ -339,7 +341,7 @@ fake_int4_quant_cuda(
 ) {
     TORCH_CHECK(x.dim() == 2, "Input must be 2D");
     TORCH_CHECK(x.is_cuda(), "Input must be on CUDA");
-    
+
     int M = x.size(0);
     int N = x.size(1);
     int block_m = block_size[0];
@@ -355,7 +357,7 @@ fake_int4_quant_cuda(
     auto out_zero = torch::empty_like(out_scale);
 
     const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
-    
+
     AT_DISPATCH_FLOATING_TYPES_AND(
         at::ScalarType::BFloat16,
         x.scalar_type(), "int4_quant_cuda", [&] {
@@ -374,7 +376,7 @@ fake_int4_quant_cuda(
             stream
         );
     });
-    
+
     return std::make_tuple(out, out_scale, out_zero);
 }
 

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant.cu
@@ -1,5 +1,8 @@
 // Copyright 2026 The LoongForge Authors.
 // SPDX-License-Identifier: Apache-2.0
+//
+// Modified from slime (https://github.com/THUDM/slime) under the Apache-2.0 License.
+// Copyright (c) 2025 Zhipu AI. All rights reserved.
 /*
  * Original INT4 fake-quantization CUDA kernel.
  *

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant_dequant_fused.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant_dequant_fused.cu
@@ -1,0 +1,163 @@
+/*
+ * Fused INT4 fake quantize-dequantize CUDA kernel.
+ *
+ * Performs symmetric INT4 quantization and dequantization in a single GPU pass,
+ * eliminating the intermediate q/scale DRAM round-trip of the two-pass approach.
+ *
+ * Optimized for block_size=[1, 32] (group_size=32) with BF16 MoE expert weights.
+ * Uses multi-row-per-thread coarsening (ROWS_PER_THREAD=4) to hide warp shuffle
+ * latency by interleaving loads across rows.
+ *
+ * Performance (B200, fc1 [262144, 7168], BF16, group_size=32):
+ *   Two-pass baseline:  9.79 ms
+ *   This fused kernel:  2.90 ms  (3.38x speedup)
+ *
+ * Correctness: bit-exact match with the two-pass pipeline. Scale is truncated to
+ * BF16 precision before the dequant multiply to replicate the DRAM BF16 round-trip.
+ *
+ * NOTE: Do NOT compile with --use_fast_math — it changes division rounding and
+ * breaks the bit-exact match with the original quantize kernel.
+ */
+#include <torch/extension.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <cuda_bf16.h>
+
+#define FINAL_MASK 0xFFFFFFFF
+
+__device__ __forceinline__
+int ceil_div_d(int a, int b) {
+    return (a + b - 1) / b;
+}
+
+__device__ __forceinline__
+float warpReduceMax(float val) {
+#pragma unroll
+    for (int mask = 16; mask > 0; mask >>= 1)
+        val = fmaxf(val, __shfl_xor_sync(FINAL_MASK, val, mask, 32));
+    return val;
+}
+
+/* Truncate FP32 → BF16 → FP32 in registers.
+ *
+ * The original two-pass pipeline writes scale to DRAM as BF16, then reads it back
+ * for the dequant multiply.  This truncation replicates that precision loss so the
+ * fused kernel produces bit-identical results. */
+__device__ __forceinline__
+float bf16_trunc(float v) {
+    return __bfloat162float(__float2bfloat16(v));
+}
+
+/* Fused symmetric INT4 quantize-dequantize for one element.
+ *
+ *   qval  = rintf(val / scale)          — same FP32 division as original kernel
+ *   scale = bf16_trunc(scale)           — replicate BF16 DRAM truncation
+ *   out   = qval * scale_bf16           — dequantize in FP32, caller casts to BF16
+ *
+ * qval is an integer in [-7, 7] which is exact in BF16, so no truncation needed. */
+__device__ __forceinline__
+float fused_qd_sym(float val, float scale) {
+    float qval = rintf(val / scale);
+    float scale_bf16 = bf16_trunc(scale);
+    return qval * scale_bf16;
+}
+
+/* ---------------------------------------------------------------------------
+ * Main kernel: fused INT4 fake quant-dequant with multi-row coarsening
+ * ---------------------------------------------------------------------------
+ * Each block covers ROWS_PER_THREAD consecutive rows.  Each warp iterates over
+ * groups of 32 columns, processing all ROWS_PER_THREAD rows per group before
+ * advancing.  This layout has two benefits:
+ *
+ *   1. Loads from row N+1 can overlap with the warp-shuffle reduction of row N,
+ *      hiding the 5-stage serial shuffle latency.
+ *   2. Column address computation is reused across rows (29% fewer INT ops).
+ *
+ * Launch config: grid = ceil(M / ROWS_PER_THREAD), block = 1024 (32 warps).
+ * Best ROWS_PER_THREAD=4 on B200 (28 regs/thread, 95% warp occupancy).
+ */
+template<typename scalar_t, int ROWS_PER_THREAD>
+__global__
+void fused_int4_qd_kernel(
+    const scalar_t* __restrict__ x,
+    scalar_t* __restrict__ out,
+    const int M, const int N
+) {
+    constexpr int WARPS_PER_BLOCK = 32;
+    constexpr float SYM_CONS = 1.0f / 7.0f;
+
+    const int needed_warps = ceil_div_d(N, 32);
+    const int warp_id = threadIdx.x >> 5;
+    const int lane_id = threadIdx.x & 0x1F;
+    const int base_row = blockIdx.x * ROWS_PER_THREAD;
+
+    for (int item = warp_id; item < needed_warps; item += WARPS_PER_BLOCK) {
+        const int col = item * 32 + lane_id;
+
+        /* Load ROWS_PER_THREAD values — interleaved loads hide memory latency. */
+        float vals[ROWS_PER_THREAD];
+#pragma unroll
+        for (int r = 0; r < ROWS_PER_THREAD; r++) {
+            const int row = base_row + r;
+            if (row < M && col < N) {
+                vals[r] = static_cast<float>(x[row * N + col]);
+            } else {
+                vals[r] = 0.0f;
+            }
+        }
+
+        /* Quant-dequant each row.  Shuffles from consecutive rows interleave,
+         * so the scheduler can overlap shuffle stalls with useful work. */
+#pragma unroll
+        for (int r = 0; r < ROWS_PER_THREAD; r++) {
+            float abs_val = fabsf(vals[r]);
+            float block_max = warpReduceMax(abs_val);
+            float scale = fmaxf(block_max * SYM_CONS, 1e-5f);
+
+            float dqval = fused_qd_sym(vals[r], scale);
+
+            const int row = base_row + r;
+            if (row < M && col < N) {
+                out[row * N + col] = static_cast<scalar_t>(dqval);
+            }
+        }
+    }
+}
+
+/* ---------------------------------------------------------------------------
+ * C++ dispatch
+ * ---------------------------------------------------------------------------
+ * Hardcoded ROWS_PER_THREAD=4 (best on B200).  Accepts any 2D contiguous tensor.
+ * group_size is always 32 (warp width); symmetric quantization only. */
+
+static int host_ceil_div(int a, int b) { return (a + b - 1) / b; }
+
+torch::Tensor fused_fake_int4_quantize_dequantize_cuda(torch::Tensor& x) {
+    TORCH_CHECK(x.dim() == 2, "Input must be 2D, got ", x.dim(), "D");
+    TORCH_CHECK(x.is_cuda(), "Input must be on CUDA");
+    TORCH_CHECK(x.is_contiguous(), "Input must be contiguous");
+
+    const int M = x.size(0), N = x.size(1);
+    auto out = torch::empty_like(x);
+    const cudaStream_t stream = at::cuda::getCurrentCUDAStream();
+
+    constexpr int ROWS_PER_THREAD = 4;
+    dim3 grid(host_ceil_div(M, ROWS_PER_THREAD));
+    dim3 block(1024);  /* 32 warps */
+
+    AT_DISPATCH_FLOATING_TYPES_AND(
+        at::ScalarType::BFloat16, x.scalar_type(),
+        "fused_fake_int4_quantize_dequantize_cuda", [&] {
+        fused_int4_qd_kernel<scalar_t, ROWS_PER_THREAD>
+            <<<grid, block, 0, stream>>>(
+                x.const_data_ptr<scalar_t>(),
+                out.data_ptr<scalar_t>(),
+                M, N);
+    });
+    return out;
+}
+
+PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
+    m.def("fused_fake_int4_quantize_dequantize_cuda",
+          &fused_fake_int4_quantize_dequantize_cuda,
+          "Fused INT4 fake quantize-dequantize (symmetric, group_size=32)");
+}

--- a/ops/cuda_source/int4_qat/csrc/fake_int4_quant_dequant_fused.cu
+++ b/ops/cuda_source/int4_qat/csrc/fake_int4_quant_dequant_fused.cu
@@ -1,3 +1,5 @@
+// Copyright 2026 The LoongForge Authors.
+// SPDX-License-Identifier: Apache-2.0
 /*
  * Fused INT4 fake quantize-dequantize CUDA kernel.
  *

--- a/ops/cuda_source/int4_qat/int4_qat/__init__.py
+++ b/ops/cuda_source/int4_qat/int4_qat/__init__.py
@@ -1,0 +1,17 @@
+"""
+INT4 fake quantization for Quantization-Aware Training (QAT).
+
+Provides GPU-accelerated and pure-PyTorch fake INT4 quantization with
+Straight-Through Estimator (STE) for training MoE expert weights.
+"""
+__version__ = "1.0.0"
+
+from int4_qat.interface import (
+    fake_int4_quant,
+    fake_int4_quantize_dequantize,
+)
+from int4_qat.weight_transform import (
+    FakeQuantWeightTransform,
+    _FakeQuantSTE as FakeInt4QuantSTE,
+    apply_int4_qat,
+)

--- a/ops/cuda_source/int4_qat/int4_qat/__init__.py
+++ b/ops/cuda_source/int4_qat/int4_qat/__init__.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 INT4 fake quantization for Quantization-Aware Training (QAT).
 

--- a/ops/cuda_source/int4_qat/int4_qat/interface.py
+++ b/ops/cuda_source/int4_qat/int4_qat/interface.py
@@ -1,0 +1,152 @@
+"""
+Python interface for INT4 fake quantization.
+
+Two levels of API:
+  1. fake_int4_quant()              — low-level: quantize only → (codes, scale, zero)
+  2. fake_int4_quantize_dequantize() — mid-level: quant+dequant → fake-quantized tensor
+"""
+import math
+from typing import List, Optional, Tuple
+
+import torch
+import torch.nn.functional as F
+
+# Try to import the CUDA extension; fall back to None if not built.
+try:
+    import int4_qat.cuda as _C
+except ImportError:
+    _C = None
+
+# Try to import the fused CUDA extension (3.4x faster quant+dequant in one pass).
+try:
+    import int4_qat.cuda_fused as _C_fused
+except ImportError:
+    _C_fused = None
+
+
+def fake_int4_quant(
+    x: torch.Tensor,
+    block_size: List[int],
+    sym: bool = True,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Low-level INT4 quantization (quantize only, no dequant).
+
+    Returns integer codes stored in the original floating dtype.
+
+    Args:
+        x: 2D CUDA tensor [M, N].
+        block_size: [block_m, block_n]. Must satisfy block_m * block_n % 32 == 0.
+        sym: Symmetric ([-7, 7]) or asymmetric ([0, 15]) quantization.
+
+    Returns:
+        (q, scale, zero):
+            q:     [M, N], integer codes in float dtype
+            scale: [ceil(M/block_m), ceil(N/block_n)]
+            zero:  same shape as scale (only meaningful for asymmetric)
+    """
+    if _C is not None:
+        return _C.fake_int4_quant_cuda(x.contiguous(), block_size, sym)
+    else:
+        return _fake_int4_quant_pytorch(x, block_size, sym)
+
+
+def _fake_int4_quant_pytorch(
+    x: torch.Tensor,
+    block_size: List[int],
+    sym: bool,
+) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """Pure PyTorch reference implementation of INT4 quantization."""
+    assert x.dim() == 2, "Input must be 2D"
+    M, N = x.shape
+    block_m, block_n = block_size
+
+    scale_rows = math.ceil(M / block_m)
+    scale_cols = math.ceil(N / block_n)
+
+    # Pad to block-aligned shape
+    M_pad = scale_rows * block_m
+    N_pad = scale_cols * block_n
+    if M_pad > M or N_pad > N:
+        x_pad = torch.zeros(M_pad, N_pad, dtype=x.dtype, device=x.device)
+        x_pad[:M, :N] = x
+    else:
+        x_pad = x
+
+    # Reshape into blocks: [scale_rows, block_m, scale_cols, block_n]
+    x_blocks = x_pad.view(scale_rows, block_m, scale_cols, block_n)
+
+    if sym:
+        abs_max = x_blocks.abs().float().amax(dim=(1, 3))  # [scale_rows, scale_cols]
+        scale = torch.clamp(abs_max / 7.0, min=1e-5).to(x.dtype)
+        # Quantize: divide, round, clamp to [-7, 7]
+        q_blocks = torch.round(
+            x_blocks.float() / scale[:, None, :, None].float()
+        ).clamp(-7, 7).to(x.dtype)
+        zero = torch.zeros_like(scale)
+    else:
+        block_min = x_blocks.float().amin(dim=(1, 3))
+        block_max = x_blocks.float().amax(dim=(1, 3))
+        scale = torch.clamp((block_max - block_min) / 15.0, min=1e-5).to(x.dtype)
+        zero = torch.clamp(
+            torch.round(-block_min / scale.float()), min=0.0, max=15.0
+        ).to(x.dtype)
+        q_blocks = (
+            torch.round(x_blocks.float() / scale[:, None, :, None].float())
+            + zero[:, None, :, None].float()
+        ).clamp(0, 15).to(x.dtype)
+
+    q = q_blocks.view(M_pad, N_pad)[:M, :N].contiguous()
+    return q, scale, zero
+
+
+def fake_int4_quantize_dequantize(
+    weight: torch.Tensor,
+    group_size: int = 128,
+    sym: bool = True,
+) -> torch.Tensor:
+    """Fake INT4 quantize-then-dequantize.
+
+    Quantizes the weight to INT4 codes, then dequantizes back to original dtype.
+    The output has the same shape and dtype as input but values are restricted to
+    the INT4 quantization grid.
+
+    When the fused CUDA kernel is available and conditions are met (symmetric mode,
+    group_size=32, 2D contiguous CUDA tensor), uses a single-pass fused kernel
+    that is ~3.4x faster than the two-pass approach.
+
+    Args:
+        weight: 2D tensor [out_features, in_features].
+        group_size: Quantization group size along in_features (block_size = [1, group_size]).
+        sym: Symmetric or asymmetric quantization.
+
+    Returns:
+        Fake-quantized weight of same shape and dtype.
+    """
+    # Fast path: fused CUDA kernel (single-pass, ~3.4x faster)
+    if (
+        _C_fused is not None
+        and sym
+        and group_size == 32
+        and weight.is_cuda
+        and weight.dim() == 2
+        and weight.is_contiguous()
+    ):
+        return _C_fused.fused_fake_int4_quantize_dequantize_cuda(weight)
+
+    # Fallback: two-pass (quant kernel + PyTorch dequant)
+    M, N = weight.shape
+    block_size = [1, group_size]
+    scale_cols = math.ceil(N / group_size)
+
+    q, scale, zero = fake_int4_quant(weight, block_size, sym)
+
+    # Dequantize: broadcast scale from [M, scale_cols] → [M, N]
+    scale_expanded = scale.unsqueeze(-1).expand(M, scale_cols, group_size)
+    scale_full = scale_expanded.reshape(M, scale_cols * group_size)[:, :N]
+
+    if sym:
+        return (q * scale_full).to(weight.dtype)
+    else:
+        zero_expanded = zero.unsqueeze(-1).expand(M, scale_cols, group_size)
+        zero_full = zero_expanded.reshape(M, scale_cols * group_size)[:, :N]
+        return ((q - zero_full) * scale_full).to(weight.dtype)

--- a/ops/cuda_source/int4_qat/int4_qat/interface.py
+++ b/ops/cuda_source/int4_qat/int4_qat/interface.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 Python interface for INT4 fake quantization.
 
@@ -6,10 +8,9 @@ Two levels of API:
   2. fake_int4_quantize_dequantize() — mid-level: quant+dequant → fake-quantized tensor
 """
 import math
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
 import torch
-import torch.nn.functional as F
 
 # Try to import the CUDA extension; fall back to None if not built.
 try:

--- a/ops/cuda_source/int4_qat/int4_qat/interface.py
+++ b/ops/cuda_source/int4_qat/int4_qat/interface.py
@@ -34,12 +34,17 @@ def fake_int4_quant(
 
     Returns integer codes stored in the original floating dtype.
 
-    Partial blocks (when M % block_m != 0 or N % block_n != 0, e.g. after
-    TP-slicing a weight so its shard is not a multiple of the group size)
-    are zero-padded to the full block size, and the padding participates in
-    the min/max range estimation (mirrors slime upstream).  Symmetric mode
-    is unaffected: |0| never changes a block's abs-max, so partial blocks
+    Partial blocks (when M % block_m != 0 or N % block_n != 0) are
+    zero-padded to the full block size, and the padding participates in the
+    min/max range estimation (mirrors slime upstream).  Symmetric mode is
+    unaffected: |0| never changes a block's abs-max, so partial blocks
     there give bit-identical scales to reducing over the true elements only.
+
+    Note: zero-padding is only valid at the true tail of a tensor.  If a
+    weight is TP-sharded along in_features, the shard size must be a
+    multiple of the group size — apply_int4_qat() raises at setup time
+    otherwise, since a group straddling a TP boundary would need a
+    cross-rank amax reduction (not implemented).
 
     Args:
         x: 2D CUDA tensor [M, N].

--- a/ops/cuda_source/int4_qat/int4_qat/interface.py
+++ b/ops/cuda_source/int4_qat/int4_qat/interface.py
@@ -34,6 +34,13 @@ def fake_int4_quant(
 
     Returns integer codes stored in the original floating dtype.
 
+    Partial blocks (when M % block_m != 0 or N % block_n != 0, e.g. after
+    TP-slicing a weight so its shard is not a multiple of the group size)
+    are zero-padded to the full block size, and the padding participates in
+    the min/max range estimation (mirrors slime upstream).  Symmetric mode
+    is unaffected: |0| never changes a block's abs-max, so partial blocks
+    there give bit-identical scales to reducing over the true elements only.
+
     Args:
         x: 2D CUDA tensor [M, N].
         block_size: [block_m, block_n]. Must satisfy block_m * block_n % 32 == 0.

--- a/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
+++ b/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
@@ -1,0 +1,250 @@
+"""
+Pluggable weight transforms for Quantization-Aware Training (QAT).
+
+Provides:
+  - FakeQuantWeightTransform: callable that fake-quantizes a weight tensor
+    with STE (forward sees quantized values, backward passes gradient through).
+  - apply_int4_qat(): monkey-patch ``_get_weight_tensors`` on matching modules.
+
+The patching approach directly modifies ``_get_weight_tensors`` on the target
+TE module without introducing wrapper ``nn.Module`` instances.  This avoids
+increasing the module-tree depth which can trigger ``RecursionError`` during
+``.train()`` traversal in deep models (DDP → Float16Module → VPP chunks → …).
+"""
+import logging
+import re
+from typing import Optional
+
+import torch
+import torch.nn as nn
+
+from int4_qat.interface import fake_int4_quantize_dequantize
+
+logger = logging.getLogger("int4_qat")
+
+# Default regex matching MoE expert FC layers in DSv3.2.
+_DEFAULT_QAT_REGEX = r'\.mlp\.experts\.linear_fc[12]$'
+
+# TE-internal attributes that must be forwarded from the original weight
+# to the STE-modified weight so that TE's backward kernels work correctly.
+_TE_WEIGHT_ATTRS = (
+    'main_grad',
+    'grad_added_to_main_grad',
+    'get_main_grad',
+    'overwrite_main_grad',
+    'zero_out_wgrad',
+    'allreduce',
+    'sequence_parallel',
+)
+
+
+def _copy_te_attrs(src: torch.Tensor, dst: torch.Tensor) -> None:
+    """Copy TE-required bookkeeping attributes from *src* to *dst*.
+
+    Also installs a writeback hook so that when TE's backward sets
+    ``dst.grad_added_to_main_grad = True``, the flag propagates back to
+    *src* (the real parameter).  Without this, Megatron's
+    ``finalize_model_grads`` would not know that ``main_grad`` was already
+    populated, resulting in NaN grad norms.
+    """
+    for attr in _TE_WEIGHT_ATTRS:
+        if hasattr(src, attr):
+            try:
+                setattr(dst, attr, getattr(src, attr))
+            except (AttributeError, RuntimeError) as e:
+                logger.debug(f"[INT4 QAT] Failed to copy TE attr {attr!r}: {e}")
+
+    # Stash reference to the real parameter for writeback.
+    dst._qat_src_param = src
+
+    # Install a lightweight __setattr__ hook via dynamic subclass.
+    # When TE backward does  origin_weight.grad_added_to_main_grad = True,
+    # origin_weight is our fq tensor, and this hook syncs the write to src.
+    _make_writeback_tensor(dst)
+
+
+# Cache the subclass so we only create it once per base class.
+_writeback_cls_cache: dict[type, type] = {}
+
+
+def _make_writeback_tensor(t: torch.Tensor) -> None:
+    """Re-class *t* to a thin subclass with writeback __setattr__."""
+    base = type(t)
+    if base in _writeback_cls_cache:
+        t.__class__ = _writeback_cls_cache[base]
+        return
+    # Skip if already a writeback subclass.
+    if getattr(base, '_is_qat_writeback', False):
+        return
+
+    cls = type(
+        f'{base.__name__}_QATwb',
+        (base,),
+        {
+            '_is_qat_writeback': True,
+            '__setattr__': _qat_setattr,
+        },
+    )
+    _writeback_cls_cache[base] = cls
+    t.__class__ = cls
+
+
+def _qat_setattr(self, name: str, value) -> None:
+    """Intercept attr writes; sync ``grad_added_to_main_grad`` back."""
+    object.__setattr__(self, name, value)
+    if name == 'grad_added_to_main_grad':
+        src = getattr(self, '_qat_src_param', None)
+        if src is not None:
+            try:
+                object.__setattr__(src, name, value)
+            except (AttributeError, RuntimeError) as e:
+                logger.debug(
+                    f"[INT4 QAT] Writeback of {name!r} to src param failed: {e}"
+                )
+
+
+class _FakeQuantSTE(torch.autograd.Function):
+    """Combined FP8-dequant + INT4 fake-quant with Straight-Through Estimator.
+
+    Wrapping the entire dequant→fake-quant chain in a single autograd Function
+    avoids Float8Tensor arithmetic in the Python dispatch layer.
+    """
+
+    @staticmethod
+    def forward(ctx, weight, group_size, sym):
+        """Apply INT4 fake-quantization with STE to the input weight.
+
+        Args:
+            ctx: PyTorch autograd context.
+            weight: Input weight tensor, may be a Float8Tensor or plain Tensor.
+            group_size: Group size for per-group quantization.
+            sym: Whether to use symmetric quantization.
+
+        Returns:
+            torch.Tensor: Fake-quantized weight tensor in the same dtype as input.
+        """
+        w = weight
+        if hasattr(weight, 'dequantize'):
+            w = weight.dequantize()
+        if not w.is_contiguous():
+            w = w.contiguous()
+        return fake_int4_quantize_dequantize(w, group_size, sym=sym)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Straight-through estimator: pass gradients directly to weight.
+
+        Args:
+            ctx: PyTorch autograd context.
+            grad_output: Gradient tensor from downstream.
+
+        Returns:
+            tuple: (grad_output, None, None) — gradient for weight, None for group_size and sym.
+        """
+        return grad_output, None, None
+
+
+class FakeQuantWeightTransform:
+    """Fake-quantize a weight tensor with STE for QAT."""
+
+    def __init__(self, group_size: int = 32, sym: bool = True):
+        self.group_size = group_size
+        self.sym = sym
+        self.enabled = True
+        self._call_count = 0
+        self._logged_first = False
+
+    def __call__(self, weight: torch.Tensor) -> torch.Tensor:
+        if not self.enabled:
+            return weight
+
+        try:
+            fq = _FakeQuantSTE.apply(weight, self.group_size, self.sym)
+        except RuntimeError as e:
+            logger.warning(
+                f"[INT4 QAT] fake_quant failed, disabling transform for this module "
+                f"(weight shape={tuple(weight.shape)}, group_size={self.group_size}): {e}"
+            )
+            self.enabled = False
+            return weight
+
+        self._call_count += 1
+        if not self._logged_first:
+            is_quantized = hasattr(weight, 'dequantize')
+            logger.info(
+                f"[INT4 QAT] First fake_quant call — weight shape {tuple(weight.shape)}, "
+                f"dtype={weight.dtype}, device={weight.device}, "
+                f"fp8_param={is_quantized}"
+            )
+            self._logged_first = True
+
+        _copy_te_attrs(weight, fq)
+        return fq
+
+    def __repr__(self) -> str:
+        return (
+            f"FakeQuantWeightTransform(group_size={self.group_size}, "
+            f"sym={self.sym}, enabled={self.enabled})"
+        )
+
+
+def _patch_get_weight_tensors(
+    module: nn.Module,
+    transform: FakeQuantWeightTransform,
+) -> bool:
+    """Monkey-patch ``_get_weight_tensors`` on *module* for INT4 QAT."""
+    if not hasattr(module, '_get_weight_tensors'):
+        return False
+
+    original_fn = module._get_weight_tensors
+
+    def _patched_get_weights(
+        _orig=original_fn, _mod=module, _xform=transform,
+    ):
+        weights = _orig()
+        if _mod.training and _xform.enabled:
+            return [
+                _xform(w) if isinstance(w, torch.Tensor) else w
+                for w in weights
+            ]
+        return weights
+
+    module._get_weight_tensors = _patched_get_weights
+    object.__setattr__(module, '_int4_qat_transform', transform)
+    return True
+
+
+
+def apply_int4_qat(
+    model: nn.Module,
+    transform: Optional[FakeQuantWeightTransform] = None,
+    *,
+    group_size: int = 32,
+    sym: bool = True,
+    filter_regex: Optional[str] = _DEFAULT_QAT_REGEX,
+) -> tuple[FakeQuantWeightTransform, int]:
+    """Patch ``_get_weight_tensors`` on matching modules for INT4 QAT."""
+    if transform is None:
+        transform = FakeQuantWeightTransform(group_size=group_size, sym=sym)
+
+    compiled_re = re.compile(filter_regex) if filter_regex is not None else None
+
+    logger.info(
+        f"[INT4 QAT] apply_int4_qat — filter_regex={filter_regex!r}, "
+        f"group_size={transform.group_size}, sym={transform.sym}"
+    )
+
+    to_patch = [
+        (name, module)
+        for name, module in model.named_modules()
+        if compiled_re is None or compiled_re.search(name) is not None
+    ]
+
+    count = 0
+    for name, module in to_patch:
+        if _patch_get_weight_tensors(module, transform):
+            count += 1
+
+    logger.info(f"[INT4 QAT] Patched {count} modules (matched {len(to_patch)} candidates)")
+
+    return transform, count

--- a/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
+++ b/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
@@ -190,15 +190,63 @@ class FakeQuantWeightTransform:
         )
 
 
+def _check_group_alignment(
+    module_name: str,
+    weights: list,
+    group_size: int,
+) -> None:
+    """Reject TP shard layouts that would split a quantization group.
+
+    Zero-padding is only legitimate at the true tail of a tensor.  If a
+    weight is TP-sharded along its in-features dim (dim 1) and the local
+    shard is not a multiple of *group_size*, a quantization group would
+    straddle the TP boundary: each rank would pad the straddling group with
+    zeros that actually hold real values on another rank, producing wrong
+    scales (in both sym and asym modes).  Supporting that case requires a
+    cross-rank amax reduction (like Megatron's master-weight quantization
+    across DP ranks), which is not implemented — so fail loudly at setup.
+
+    TP sharding is detected via the attributes Megatron sets through
+    ``set_tensor_model_parallel_attributes`` (``tensor_model_parallel`` and
+    ``partition_dim``; ``partition_dim == 1`` means the weight is sharded
+    along in_features, e.g. row-parallel style).  Weights without these
+    attributes are treated as unsharded.
+    """
+    for w in weights:
+        if not isinstance(w, torch.Tensor) or w.dim() != 2:
+            continue
+        n = w.shape[1]
+        if n % group_size == 0:
+            continue
+        if getattr(w, 'tensor_model_parallel', False) and getattr(w, 'partition_dim', None) == 1:
+            raise ValueError(
+                f"[INT4 QAT] {module_name}: weight of shape {tuple(w.shape)} is "
+                f"TP-sharded along in_features (partition_dim=1), but the local "
+                f"shard size {n} is not a multiple of group_size={group_size}. "
+                f"A quantization group would straddle the TP boundary, which "
+                f"requires a cross-rank amax reduction (not implemented). "
+                f"Adjust the TP/ETP degree or --int4-qat-group-size so that "
+                f"shard_size % group_size == 0."
+            )
+        logger.info(
+            f"[INT4 QAT] {module_name}: in_features={n} is not a multiple of "
+            f"group_size={group_size}; the tail group will use zero-padded "
+            f"range estimation (tail of an unsharded tensor)."
+        )
+
+
 def _patch_get_weight_tensors(
     module: nn.Module,
     transform: FakeQuantWeightTransform,
+    name: str = '',
 ) -> bool:
     """Monkey-patch ``_get_weight_tensors`` on *module* for INT4 QAT."""
     if not hasattr(module, '_get_weight_tensors'):
         return False
 
     original_fn = module._get_weight_tensors
+
+    _check_group_alignment(name, original_fn(), transform.group_size)
 
     def _patched_get_weights(
         _orig=original_fn, _mod=module, _xform=transform,
@@ -244,7 +292,7 @@ def apply_int4_qat(
 
     count = 0
     for name, module in to_patch:
-        if _patch_get_weight_tensors(module, transform):
+        if _patch_get_weight_tensors(module, transform, name):
             count += 1
 
     logger.info(f"[INT4 QAT] Patched {count} modules (matched {len(to_patch)} candidates)")

--- a/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
+++ b/ops/cuda_source/int4_qat/int4_qat/weight_transform.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 Pluggable weight transforms for Quantization-Aware Training (QAT).
 

--- a/ops/cuda_source/int4_qat/setup.py
+++ b/ops/cuda_source/int4_qat/setup.py
@@ -1,0 +1,86 @@
+"""
+Setup for INT4 fake quantization CUDA kernels.
+
+Provides GPU-accelerated fake INT4 quantization (quantize → integer codes)
+and fused quantize-dequantize (3.4x faster) with symmetric and asymmetric modes,
+used for Quantization-Aware Training (QAT) of MoE expert weights.
+"""
+import os
+import subprocess
+from setuptools import setup, find_packages
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
+
+
+def get_arch_flags():
+    """Detect GPU architectures and generate NVCC gencode flags."""
+    import torch
+
+    arch_set = set()
+    if torch.cuda.is_available():
+        for i in range(torch.cuda.device_count()):
+            major, minor = torch.cuda.get_device_capability(i)
+            arch_set.add(f"{major}{minor}")
+
+    if not arch_set:
+        env_arch = os.environ.get("TORCH_CUDA_ARCH_LIST", "")
+        if env_arch:
+            for a in env_arch.replace(";", " ").split():
+                a = a.strip().replace("+PTX", "").replace(".", "")
+                if a:
+                    arch_set.add(a)
+        else:
+            arch_set = {"80", "86", "89", "90"}
+
+    flags = []
+    for arch in sorted(arch_set):
+        flags += [f"-gencode=arch=compute_{arch},code=sm_{arch}"]
+    # Always include sm_90a for Hopper/Blackwell
+    flags += ["-gencode=arch=compute_90a,code=sm_90a"]
+    return flags
+
+
+this_dir = os.path.dirname(os.path.abspath(__file__))
+
+nvcc_flags = [
+    "-O3",
+    "-std=c++17",
+    "--expt-relaxed-constexpr",
+    "-Xcompiler",
+    "-fPIC",
+    # NOTE: do NOT add --use_fast_math — it changes division rounding and
+    # breaks bit-exact match between the fused kernel and the original.
+] + get_arch_flags()
+
+ext_modules = [
+    CUDAExtension(
+        name="int4_qat.cuda",
+        sources=[os.path.join("csrc", "fake_int4_quant.cu")],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "nvcc": nvcc_flags,
+        },
+    ),
+    CUDAExtension(
+        name="int4_qat.cuda_fused",
+        sources=[os.path.join("csrc", "fake_int4_quant_dequant_fused.cu")],
+        extra_compile_args={
+            "cxx": ["-O3", "-std=c++17"],
+            "nvcc": nvcc_flags,
+        },
+    ),
+]
+
+try:
+    cmd = ["git", "rev-parse", "--short", "HEAD"]
+    rev = "+" + subprocess.check_output(cmd, cwd=this_dir).decode("ascii").rstrip()
+except Exception:
+    rev = ""
+
+setup(
+    name="int4_qat",
+    version="1.0.0" + rev,
+    description="INT4 fake quantization CUDA kernels for QAT",
+    packages=find_packages(include=["int4_qat"]),
+    ext_modules=ext_modules,
+    cmdclass={"build_ext": BuildExtension},
+)

--- a/ops/cuda_source/int4_qat/setup.py
+++ b/ops/cuda_source/int4_qat/setup.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
 """
 Setup for INT4 fake quantization CUDA kernels.
 
@@ -8,7 +10,7 @@ used for Quantization-Aware Training (QAT) of MoE expert weights.
 import os
 import subprocess
 from setuptools import setup, find_packages
-from torch.utils.cpp_extension import BuildExtension, CUDAExtension, CUDA_HOME
+from torch.utils.cpp_extension import BuildExtension, CUDAExtension
 
 
 def get_arch_flags():

--- a/ops/cuda_source/int4_qat/tests/test_int4_qat.py
+++ b/ops/cuda_source/int4_qat/tests/test_int4_qat.py
@@ -1,0 +1,389 @@
+"""Tests for int4_qat package."""
+import math
+import pytest
+import torch
+
+
+def _reference_fake_int4_quant(x, block_size, sym):
+    """Pure PyTorch per-block reference (loop-based, for correctness checking)."""
+    M, N = x.shape
+    block_m, block_n = block_size
+    scale_rows = math.ceil(M / block_m)
+    scale_cols = math.ceil(N / block_n)
+
+    q = torch.empty_like(x)
+    scale = torch.empty((scale_rows, scale_cols), device=x.device, dtype=x.dtype)
+    zero = torch.empty_like(scale)
+
+    for bi in range(scale_rows):
+        r0, r1 = bi * block_m, min((bi + 1) * block_m, M)
+        for bj in range(scale_cols):
+            c0, c1 = bj * block_n, min((bj + 1) * block_n, N)
+            block = x[r0:r1, c0:c1]
+
+            if sym:
+                s = torch.clamp(block.abs().max() / 7.0, min=1e-5)
+                z = torch.zeros((), device=x.device, dtype=x.dtype)
+                q_block = torch.round(block / s)
+            else:
+                block_min, block_max = block.min(), block.max()
+                s = torch.clamp((block_max - block_min) / 15.0, min=1e-5)
+                z = torch.clamp(-torch.round(block_min / s), min=0.0, max=15.0)
+                q_block = torch.round(block / s) + z
+
+            q[r0:r1, c0:c1] = q_block.to(x.dtype)
+            scale[bi, bj] = s.to(x.dtype)
+            zero[bi, bj] = z.to(x.dtype)
+
+    return q, scale, zero
+
+
+@pytest.fixture(scope="module")
+def cuda_device():
+    if not torch.cuda.is_available():
+        pytest.skip("CUDA required")
+    return torch.device("cuda")
+
+
+# ─── Low-level: fake_int4_quant ───
+
+
+@pytest.mark.parametrize(
+    "shape,block_size",
+    [
+        ((7, 65), [1, 32]),
+        ((65, 7), [32, 1]),
+        ((9, 257), [1, 128]),
+        ((33, 96), [8, 32]),
+    ],
+)
+def test_quant_symmetric(cuda_device, shape, block_size):
+    from int4_qat import fake_int4_quant
+
+    torch.manual_seed(0)
+    x = torch.randn(*shape, device=cuda_device, dtype=torch.float32) * 1.7 + 0.13
+    q, scale, zero = fake_int4_quant(x, block_size, sym=True)
+    ref_q, ref_scale, _ = _reference_fake_int4_quant(x, block_size, True)
+
+    assert q.shape == x.shape
+    assert q.dtype == x.dtype
+    torch.testing.assert_close(q, ref_q, rtol=0, atol=0)
+    torch.testing.assert_close(scale, ref_scale, rtol=1e-6, atol=1e-6)
+
+
+@pytest.mark.parametrize(
+    "shape,block_size",
+    [
+        ((7, 65), [1, 32]),
+        ((65, 7), [32, 1]),
+        ((9, 257), [1, 128]),
+        ((33, 96), [8, 32]),
+    ],
+)
+def test_quant_asymmetric(cuda_device, shape, block_size):
+    from int4_qat import fake_int4_quant
+
+    torch.manual_seed(1)
+    x = torch.randn(*shape, device=cuda_device, dtype=torch.float32)
+    x = x + torch.linspace(-0.5, 0.5, steps=shape[1], device=cuda_device).unsqueeze(0)
+
+    q, scale, zero = fake_int4_quant(x, block_size, sym=False)
+    ref_q, ref_scale, ref_zero = _reference_fake_int4_quant(x, block_size, False)
+
+    torch.testing.assert_close(q, ref_q, rtol=0, atol=0)
+    torch.testing.assert_close(scale, ref_scale, rtol=1e-6, atol=1e-6)
+    torch.testing.assert_close(zero, ref_zero, rtol=0, atol=0)
+
+
+def test_bfloat16(cuda_device):
+    from int4_qat import fake_int4_quant
+
+    torch.manual_seed(3)
+    x = torch.randn(17, 129, device=cuda_device, dtype=torch.bfloat16)
+    q, scale, zero = fake_int4_quant(x, [1, 128], sym=True)
+
+    assert q.shape == x.shape and q.dtype == x.dtype
+    assert scale.shape == (17, 2)
+    assert torch.isfinite(q.float()).all()
+
+
+# ─── Mid-level: fake_int4_quantize_dequantize ───
+
+
+def test_quantize_dequantize_shape_dtype(cuda_device):
+    from int4_qat import fake_int4_quantize_dequantize
+
+    torch.manual_seed(10)
+    w = torch.randn(64, 256, device=cuda_device, dtype=torch.bfloat16)
+    fq = fake_int4_quantize_dequantize(w, group_size=32, sym=True)
+
+    assert fq.shape == w.shape
+    assert fq.dtype == w.dtype
+    # Values should differ from original (quantization noise)
+    assert not torch.equal(fq, w)
+
+
+def test_quantize_dequantize_values_on_grid(cuda_device):
+    """Dequantized values should be exact multiples of scale."""
+    from int4_qat import fake_int4_quant, fake_int4_quantize_dequantize
+
+    torch.manual_seed(11)
+    w = torch.randn(8, 64, device=cuda_device, dtype=torch.float32)
+    fq = fake_int4_quantize_dequantize(w, group_size=32, sym=True)
+
+    # Verify: fq / scale should be integers (within tolerance)
+    _, scale, _ = fake_int4_quant(w, [1, 32], sym=True)
+    scale_full = scale.unsqueeze(-1).expand(8, 2, 32).reshape(8, 64)
+    codes = fq / scale_full
+    residual = (codes - codes.round()).abs()
+    assert residual.max() < 1e-4
+
+
+# ─── High-level: FakeInt4QuantSTE ───
+
+
+def test_ste_forward_matches_dequant(cuda_device):
+    from int4_qat import FakeQuantWeightTransform, fake_int4_quantize_dequantize
+
+    torch.manual_seed(20)
+    w = torch.randn(32, 128, device=cuda_device, dtype=torch.bfloat16, requires_grad=True)
+
+    transform = FakeQuantWeightTransform(group_size=32, sym=True)
+    fq_ste = transform(w)
+    with torch.no_grad():
+        fq_ref = fake_int4_quantize_dequantize(w, 32, True)
+
+    torch.testing.assert_close(fq_ste, fq_ref)
+
+
+def test_ste_gradient_passthrough(cuda_device):
+    """STE backward should pass gradient through unchanged."""
+    from int4_qat import FakeQuantWeightTransform
+
+    torch.manual_seed(21)
+    w = torch.randn(16, 64, device=cuda_device, dtype=torch.float32, requires_grad=True)
+
+    transform = FakeQuantWeightTransform(group_size=32, sym=True)
+    fq = transform(w)
+    fq.sum().backward()
+
+    assert w.grad is not None
+    # STE: grad should be all ones (from sum)
+    torch.testing.assert_close(w.grad, torch.ones_like(w))
+
+
+# ─── Fused kernel: fake_int4_quantize_dequantize via fused CUDA path ───
+
+
+def _has_fused_cuda():
+    try:
+        import int4_qat.cuda_fused  # noqa: F401
+        return True
+    except ImportError:
+        return False
+
+
+@pytest.mark.skipif(not _has_fused_cuda(), reason="Fused CUDA extension not built")
+class TestFusedKernel:
+    """Tests for the fused INT4 quant+dequant CUDA kernel."""
+
+    def test_fused_matches_two_pass_small(self, cuda_device):
+        """Bit-exact match on a small tensor."""
+        from int4_qat import fake_int4_quantize_dequantize
+        from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
+
+        torch.manual_seed(42)
+        w = torch.randn(64, 256, device=cuda_device, dtype=torch.bfloat16)
+
+        # Two-pass reference (force fallback by calling quant + dequant manually)
+        from int4_qat.interface import fake_int4_quant
+        q, scale, _ = fake_int4_quant(w, [1, 32], sym=True)
+        scale_exp = scale.unsqueeze(-1).expand(64, 8, 32).reshape(64, 256)
+        ref = (q * scale_exp).to(torch.bfloat16)
+
+        # Fused path
+        fused = fused_fake_int4_quantize_dequantize_cuda(w)
+
+        torch.testing.assert_close(fused, ref, rtol=0, atol=0)
+
+    @pytest.mark.parametrize("M,N", [
+        (128, 7168),       # partial fc1
+        (4096, 7168),      # single expert fc1
+        (4096, 2048),      # single expert fc2
+        (7, 65),           # non-aligned M and N
+        (1, 32),           # minimal: one row, one group
+        (1, 64),           # one row, two groups
+    ])
+    def test_fused_matches_two_pass_shapes(self, cuda_device, M, N):
+        """Bit-exact match across various shapes."""
+        from int4_qat.interface import fake_int4_quant
+        from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
+
+        torch.manual_seed(100 + M + N)
+        w = torch.randn(M, N, device=cuda_device, dtype=torch.bfloat16)
+
+        q, scale, _ = fake_int4_quant(w, [1, 32], sym=True)
+        scale_cols = (N + 31) // 32
+        scale_exp = scale.unsqueeze(-1).expand(M, scale_cols, 32)
+        scale_full = scale_exp.reshape(M, scale_cols * 32)[:, :N]
+        ref = (q * scale_full).to(torch.bfloat16)
+
+        fused = fused_fake_int4_quantize_dequantize_cuda(w)
+        torch.testing.assert_close(fused, ref, rtol=0, atol=0)
+
+    def test_fused_shape_dtype_preserved(self, cuda_device):
+        """Output shape and dtype must match input."""
+        from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
+
+        torch.manual_seed(50)
+        w = torch.randn(512, 1024, device=cuda_device, dtype=torch.bfloat16)
+        out = fused_fake_int4_quantize_dequantize_cuda(w)
+        assert out.shape == w.shape
+        assert out.dtype == w.dtype
+        assert not torch.equal(out, w)  # quantization should change values
+
+    def test_fused_transparent_dispatch(self, cuda_device):
+        """fake_int4_quantize_dequantize auto-dispatches to fused when eligible."""
+        from int4_qat import fake_int4_quantize_dequantize
+        from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
+
+        torch.manual_seed(60)
+        w = torch.randn(256, 1024, device=cuda_device, dtype=torch.bfloat16)
+
+        # Both paths should give identical results
+        via_api = fake_int4_quantize_dequantize(w, group_size=32, sym=True)
+        via_fused = fused_fake_int4_quantize_dequantize_cuda(w)
+        torch.testing.assert_close(via_api, via_fused, rtol=0, atol=0)
+
+    def test_fused_fallback_for_asymmetric(self, cuda_device):
+        """Asymmetric mode should fall back to two-pass (fused is sym-only)."""
+        from int4_qat import fake_int4_quantize_dequantize
+
+        torch.manual_seed(70)
+        w = torch.randn(64, 128, device=cuda_device, dtype=torch.bfloat16)
+        # Should not crash — falls back to two-pass
+        out = fake_int4_quantize_dequantize(w, group_size=32, sym=False)
+        assert out.shape == w.shape
+
+    def test_fused_fallback_for_group128(self, cuda_device):
+        """group_size=128 should fall back to two-pass."""
+        from int4_qat import fake_int4_quantize_dequantize
+
+        torch.manual_seed(80)
+        w = torch.randn(64, 256, device=cuda_device, dtype=torch.bfloat16)
+        out = fake_int4_quantize_dequantize(w, group_size=128, sym=True)
+        assert out.shape == w.shape
+
+    def test_fused_large_moe_shape(self, cuda_device):
+        """Full MoE expert fc1 shape — correctness at scale."""
+        from int4_qat.interface import fake_int4_quant
+        from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
+
+        M, N = 262144, 7168  # fc1: 64 experts × 4096 × 7168
+        torch.manual_seed(200)
+        w = torch.randn(M, N, device=cuda_device, dtype=torch.bfloat16)
+
+        q, scale, _ = fake_int4_quant(w, [1, 32], sym=True)
+        scale_cols = N // 32
+        scale_full = scale.unsqueeze(-1).expand(M, scale_cols, 32).reshape(M, N)
+        ref = (q * scale_full).to(torch.bfloat16)
+
+        fused = fused_fake_int4_quantize_dequantize_cuda(w)
+        torch.testing.assert_close(fused, ref, rtol=0, atol=0)
+
+
+# ─── FakeQuantWeightTransform ───
+
+
+class TestWeightTransform:
+    """Tests for the pluggable FakeQuantWeightTransform wrapper."""
+
+    def test_transform_matches_raw_api(self, cuda_device):
+        """Transform output must match fake_int4_quantize_dequantize."""
+        from int4_qat import FakeQuantWeightTransform, fake_int4_quantize_dequantize
+
+        torch.manual_seed(300)
+        w = torch.randn(64, 256, device=cuda_device, dtype=torch.bfloat16)
+
+        transform = FakeQuantWeightTransform(group_size=32, sym=True)
+        out = transform(w)
+
+        ref = fake_int4_quantize_dequantize(w, group_size=32, sym=True)
+        # STE: out = w + (ref - w).detach() == ref  (values equal, grad graph differs)
+        torch.testing.assert_close(out, ref, rtol=0, atol=0)
+
+    def test_transform_ste_gradient(self, cuda_device):
+        """Backward through the transform should pass gradient to original weight."""
+        from int4_qat import FakeQuantWeightTransform
+
+        torch.manual_seed(301)
+        w = torch.randn(16, 64, device=cuda_device, dtype=torch.float32,
+                         requires_grad=True)
+
+        transform = FakeQuantWeightTransform(group_size=32, sym=True)
+        out = transform(w)
+        loss = out.sum()
+        loss.backward()
+
+        assert w.grad is not None
+        torch.testing.assert_close(w.grad, torch.ones_like(w))
+
+    def test_transform_disabled(self, cuda_device):
+        """When enabled=False, transform is identity."""
+        from int4_qat import FakeQuantWeightTransform
+
+        torch.manual_seed(302)
+        w = torch.randn(32, 128, device=cuda_device, dtype=torch.bfloat16)
+
+        transform = FakeQuantWeightTransform(group_size=32, sym=True)
+        transform.enabled = False
+
+        out = transform(w)
+        assert out is w  # exact same object, not a copy
+
+    def test_transform_eval_mode(self, cuda_device):
+        """In eval mode, transform is identity regardless of .enabled."""
+        from int4_qat import FakeQuantWeightTransform
+
+        torch.manual_seed(303)
+        w = torch.randn(32, 128, device=cuda_device, dtype=torch.bfloat16)
+
+        transform = FakeQuantWeightTransform(group_size=32, sym=True)
+
+        # .enabled is True so transform will still quantize.
+        # The _get_weight_tensors gating handles training vs eval.
+        out = transform(w)
+        assert out.shape == w.shape
+
+    def test_apply_int4_qat_with_filter(self, cuda_device):
+        """apply_int4_qat with filter_regex attaches to matching modules only."""
+        from int4_qat import apply_int4_qat, FakeQuantWeightTransform
+
+        class FakeGroupedLinear(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+
+            def _get_weight_tensors(self):
+                return [torch.zeros(1)]
+
+        class FakeModel(torch.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.expert_fc1 = FakeGroupedLinear()
+                self.expert_fc2 = FakeGroupedLinear()
+                self.absorb = FakeGroupedLinear()
+
+        model = FakeModel()
+        # Use regex to match expert_fc1 / expert_fc2 but not absorb
+        transform, count = apply_int4_qat(
+            model,
+            filter_regex=r'expert_fc[12]$'
+        )
+
+        assert isinstance(transform, FakeQuantWeightTransform)
+        assert count == 2
+        assert hasattr(model.expert_fc1, '_int4_qat_transform')
+        assert hasattr(model.expert_fc2, '_int4_qat_transform')
+        assert not hasattr(model.absorb, '_int4_qat_transform')
+        # Same instance shared
+        assert model.expert_fc1._int4_qat_transform is model.expert_fc2._int4_qat_transform

--- a/ops/cuda_source/int4_qat/tests/test_int4_qat.py
+++ b/ops/cuda_source/int4_qat/tests/test_int4_qat.py
@@ -400,3 +400,52 @@ class TestWeightTransform:
         assert not hasattr(model.absorb, '_int4_qat_transform')
         # Same instance shared
         assert model.expert_fc1._int4_qat_transform is model.expert_fc2._int4_qat_transform
+
+
+def _make_module(weight):
+    class FakeGroupedLinear(torch.nn.Module):
+        def _get_weight_tensors(self):
+            return [weight]
+
+    return FakeGroupedLinear()
+
+
+def _tp_sharded(weight, partition_dim):
+    weight.tensor_model_parallel = True
+    weight.partition_dim = partition_dim
+    return weight
+
+
+class TestGroupAlignment:
+    """Guards against quantization groups straddling a TP shard boundary."""
+
+    def test_tail_group_allowed_when_unsharded(self):
+        """Unsharded weight with N % group_size != 0: tail padding is fine."""
+        from int4_qat import apply_int4_qat
+
+        _, count = apply_int4_qat(_make_module(torch.zeros(8, 65)), filter_regex=None)
+        assert count == 1
+
+    def test_tp_straddling_group_raises(self):
+        """TP shard along in_features with N % group_size != 0 must raise."""
+        from int4_qat import apply_int4_qat
+
+        w = _tp_sharded(torch.zeros(8, 65), partition_dim=1)
+        with pytest.raises(ValueError, match="straddle the TP boundary"):
+            apply_int4_qat(_make_module(w), filter_regex=None)
+
+    def test_tp_aligned_shard_allowed(self):
+        """TP shard along in_features that stays group-aligned is fine."""
+        from int4_qat import apply_int4_qat
+
+        w = _tp_sharded(torch.zeros(8, 64), partition_dim=1)
+        _, count = apply_int4_qat(_make_module(w), filter_regex=None)
+        assert count == 1
+
+    def test_tp_dim0_shard_does_not_affect_groups(self):
+        """Sharding along dim 0 (column-parallel) leaves groups intact."""
+        from int4_qat import apply_int4_qat
+
+        w = _tp_sharded(torch.zeros(8, 65), partition_dim=0)
+        _, count = apply_int4_qat(_make_module(w), filter_regex=None)
+        assert count == 1

--- a/ops/cuda_source/int4_qat/tests/test_int4_qat.py
+++ b/ops/cuda_source/int4_qat/tests/test_int4_qat.py
@@ -7,7 +7,14 @@ import torch
 
 
 def _reference_fake_int4_quant(x, block_size, sym):
-    """Pure PyTorch per-block reference (loop-based, for correctness checking)."""
+    """Pure PyTorch per-block reference (loop-based, for correctness checking).
+
+    Matches the CUDA kernels: partial blocks are zero-padded to the full block
+    size, and the padding participates in the min/max range estimation (this
+    mirrors slime upstream).  Symmetric mode is unaffected since |0| never
+    changes a block's abs-max, so partial blocks there are bit-identical to
+    reducing over the true elements only.
+    """
     M, N = x.shape
     block_m, block_n = block_size
     scale_rows = math.ceil(M / block_m)
@@ -22,6 +29,11 @@ def _reference_fake_int4_quant(x, block_size, sym):
         for bj in range(scale_cols):
             c0, c1 = bj * block_n, min((bj + 1) * block_n, N)
             block = x[r0:r1, c0:c1]
+            # Zero-pad partial blocks to the full block size (kernel semantics).
+            if (r1 - r0) < block_m or (c1 - c0) < block_n:
+                padded = torch.zeros(block_m, block_n, device=x.device, dtype=x.dtype)
+                padded[: r1 - r0, : c1 - c0] = block
+                block = padded
 
             if sym:
                 s = torch.clamp(block.abs().max() / 7.0, min=1e-5)
@@ -33,7 +45,7 @@ def _reference_fake_int4_quant(x, block_size, sym):
                 z = torch.clamp(-torch.round(block_min / s), min=0.0, max=15.0)
                 q_block = torch.round(block / s) + z
 
-            q[r0:r1, c0:c1] = q_block.to(x.dtype)
+            q[r0:r1, c0:c1] = q_block[: r1 - r0, : c1 - c0].to(x.dtype)
             scale[bi, bj] = s.to(x.dtype)
             zero[bi, bj] = z.to(x.dtype)
 

--- a/ops/cuda_source/int4_qat/tests/test_int4_qat.py
+++ b/ops/cuda_source/int4_qat/tests/test_int4_qat.py
@@ -1,3 +1,5 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
 """Tests for int4_qat package."""
 import math
 import pytest
@@ -189,7 +191,6 @@ class TestFusedKernel:
 
     def test_fused_matches_two_pass_small(self, cuda_device):
         """Bit-exact match on a small tensor."""
-        from int4_qat import fake_int4_quantize_dequantize
         from int4_qat.cuda_fused import fused_fake_int4_quantize_dequantize_cuda
 
         torch.manual_seed(42)


### PR DESCRIPTION
Add INT4 Quantization-Aware Training (QAT) support for MoE expert linear layers.

- Add int4_qat CUDA kernels (fake quantization/dequantization)
- Add CLI arguments: --enable-int4-qat, --int4-qat-group-size, --int4-qat-filter-regex
- Add QAT setup in training_utils.py pretrain loop
- Update Dockerfile to install int4_qat package
- Update .gitignore for int4_qat build artifacts

Resolves #12