### PR TITLE
fix(pi05): use torch checkpoint format for DDP SFT

### DIFF
--- a/examples/pi05/finetuning/sft_pi05.sh
+++ b/examples/pi05/finetuning/sft_pi05.sh
@@ -49,7 +49,7 @@ TRAINING_ARGS=(
     --tensor-model-parallel-size 1
     --pipeline-model-parallel-size 1
     --no-masked-softmax-fusion
-    --ckpt-format fsdp_dtensor
+    --ckpt-format torch
     --load $CHECKPOINT_PATH
     --no-load-optim
     --no-load-rng


### PR DESCRIPTION
## Is your feature request related to a problem? Please describe.
The PI0.5 SFT script needs to use the `torch` checkpoint format for DDP-based SFT runs.

## Describe the solution you'd like
Update the PI0.5 SFT script to use the `torch` checkpoint format.

## Describe alternatives you've considered
N/A

## Additional context
N/A
