### PR TITLE
[ci, docs] feat: add initial GitHub Actions CI surface

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,34 @@
+# GitHub Actions Workflows
+
+This directory contains the CI/CD workflows for LoongForge.
+
+## Workflows
+
+| Workflow | Trigger | Purpose |
+|---|---|---|
+| `pr-title.yml` | PR open/edit | Validate PR title format: `[<modules>] <type>: <description>` |
+| `license.yml` | PR | Check SPDX Apache-2.0 header on newly added source files |
+| `secrets.yml` | PR + push to master | Scan for leaked secrets via gitleaks |
+| `build.yml` | PR + push to master | Build sdist + wheel on Python 3.10 / 3.12 |
+| `auto-label.yml` | Issue/PR open/edit | Auto-label issues and PRs by keyword matching |
+
+All workflows support `workflow_dispatch` for manual re-runs from the Actions UI (except `auto-label.yml`).
+
+## PR Title Convention
+
+```
+[<modules>] <type>: <description>
+```
+
+**Modules:** `llm, vlm, vla, diffusion, train, data, ops, ckpt, peft, docker, xpu, ci, docs, tests, scripts, release`
+
+**Types:** `feat, fix, refactor, perf, docs, test, chore, ci`
+
+**Example:** `[llm, ckpt] feat: support Qwen3-Next checkpoint conversion`
+
+## Adding a New Workflow
+
+1. Create a `.yml` file in this directory.
+2. Set `permissions` to least-privilege (default: `contents: read`).
+3. Add a `concurrency` block to cancel stale runs on PR branches.
+4. Test locally where possible before pushing.

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -38,7 +38,7 @@ All workflows support `workflow_dispatch` for manual re-runs from the Actions UI
 
 `submodule-sync.yml` updates `third_party/Loong-Megatron` to the branch configured in `.gitmodules` and commits the submodule pointer when it changes.
 
-Fork validation defaults to `ci/initial-workflows`. It can also receive `submodule_repository` from workflow inputs or `repository_dispatch` payloads to test against a forked Loong-Megatron without changing `.gitmodules`. When this workflow is adopted upstream, change the default `target_branch` input and fallback value in `.github/workflows/submodule-sync.yml` to `master`.
+The workflow defaults to `master`. It can also receive `submodule_repository` from workflow inputs or `repository_dispatch` payloads to test against a forked Loong-Megatron without changing `.gitmodules`.
 
 Required secrets:
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -10,6 +10,7 @@ This directory contains the CI/CD workflows for LoongForge.
 | `license.yml` | PR | Check SPDX Apache-2.0 header on newly added source files |
 | `secrets.yml` | PR + push to master | Scan for leaked secrets via gitleaks |
 | `build.yml` | PR + push to master | Build sdist + wheel on Python 3.10 / 3.12 |
+| `submodule-sync.yml` | repository dispatch / workflow dispatch + manual | Sync `third_party/Loong-Megatron` to its tracked branch and push the submodule pointer update |
 | `auto-label.yml` | Issue/PR open/edit | Auto-label issues and PRs by keyword matching |
 
 All workflows support `workflow_dispatch` for manual re-runs from the Actions UI (except `auto-label.yml`).
@@ -32,3 +33,16 @@ All workflows support `workflow_dispatch` for manual re-runs from the Actions UI
 2. Set `permissions` to least-privilege (default: `contents: read`).
 3. Add a `concurrency` block to cancel stale runs on PR branches.
 4. Test locally where possible before pushing.
+
+## Submodule Sync
+
+`submodule-sync.yml` updates `third_party/Loong-Megatron` to the branch configured in `.gitmodules` and commits the submodule pointer when it changes.
+
+Fork validation defaults to `ci/initial-workflows`. It can also receive `submodule_repository` from workflow inputs or `repository_dispatch` payloads to test against a forked Loong-Megatron without changing `.gitmodules`. When this workflow is adopted upstream, change the default `target_branch` input and fallback value in `.github/workflows/submodule-sync.yml` to `master`.
+
+Required secrets:
+
+- `SUBMODULE_SYNC_APP_ID`
+- `SUBMODULE_SYNC_APP_PRIVATE_KEY`
+
+The GitHub App behind those secrets must be able to push to the configured target branch.

--- a/.github/workflows/auto-label.yml
+++ b/.github/workflows/auto-label.yml
@@ -1,0 +1,75 @@
+name: Auto Label
+
+on:
+  issues:
+    types: [opened, edited]
+  pull_request_target:
+    types: [opened, edited, ready_for_review, synchronize]
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  auto-label:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const payload = context.payload;
+            const eventName = context.eventName;
+
+            if (payload.sender && payload.sender.type === 'Bot') {
+              console.log('Triggered by bot, skipping.');
+              return;
+            }
+
+            let text = "";
+            let targetNumber = null;
+
+            if (eventName === 'pull_request_target') {
+              text = (payload.pull_request.title + " " + (payload.pull_request.body || "")).toLowerCase();
+              targetNumber = payload.pull_request.number;
+            } else {
+              const issue = payload.issue;
+              text = (issue.title + " " + (issue.body || "")).toLowerCase();
+              targetNumber = issue.number;
+            }
+
+            const rules = [
+              ['bug', ['bug', 'error', 'fail', 'crash', 'broken']],
+              ['enhancement', ['feature', 'request', 'enhance', 'add support']],
+              ['documentation', ['doc', 'docs', 'readme', 'documentation']],
+              ['question', ['question', 'how to', 'help', 'why does']],
+              ['ci', ['ci', 'workflow', 'github actions', 'pre-commit']],
+              ['docker', ['docker', 'dockerfile', 'container', 'image']],
+              ['xpu', ['xpu', 'kunlun', 'p800']],
+              ['model', ['model', 'qwen', 'llama', 'deepseek', 'internvl', 'minimax', 'glm']],
+              ['training', ['train', 'pretrain', 'sft', 'fine-tun']],
+              ['checkpoint', ['checkpoint', 'ckpt', 'convert']],
+            ];
+
+            const labelsToAdd = new Set();
+
+            for (const [label, keywords] of rules) {
+              const matched = keywords.some(kw => {
+                const escaped = kw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+                const regex = new RegExp(`(^|[^a-zA-Z0-9_])${escaped}(?=[^a-zA-Z0-9_]|$)`, 'i');
+                return regex.test(text);
+              });
+              if (matched) labelsToAdd.add(label);
+            }
+
+            if (labelsToAdd.size > 0) {
+              const labels = Array.from(labelsToAdd);
+              console.log(`Adding labels: ${labels.join(', ')}`);
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: targetNumber,
+                labels: labels,
+              });
+            } else {
+              console.log('No matching keywords found.');
+            }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: build-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10', '3.12']
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - run: python -m pip install --upgrade pip build twine
+
+      - run: python -m build --sdist --wheel --outdir dist/
+
+      - run: twine check dist/*
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: dist-py${{ matrix.python-version }}
+          path: dist/
+          retention-days: 7

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,12 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ['3.10', '3.12']
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-python@v5
         with:
-          python-version: ${{ matrix.python-version }}
+          python-version: '3.12'
           cache: pip
 
       - run: python -m pip install --upgrade pip build twine
@@ -36,6 +32,6 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: dist-py${{ matrix.python-version }}
+          name: dist
           path: dist/
           retention-days: 7

--- a/.github/workflows/license.yml
+++ b/.github/workflows/license.yml
@@ -1,0 +1,56 @@
+name: License Header
+
+on:
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: license-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  spdx:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+          cache: pip
+
+      - run: pip install pre-commit
+
+      - name: Compute newly added files
+        id: new
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="${{ github.event.pull_request.base.sha }}"
+            HEAD="${{ github.event.pull_request.head.sha }}"
+          else
+            BASE="HEAD~1"
+            HEAD="HEAD"
+          fi
+          git diff --name-only --diff-filter=A "$BASE" "$HEAD" \
+              -- '*.py' '*.sh' '*.cu' '*.cpp' '*.h' \
+            | grep -vE '^(third_party|patches)/' > new_files.txt || true
+          if [ -s new_files.txt ]; then
+            echo "has_files=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_files=false" >> "$GITHUB_OUTPUT"
+          fi
+          echo "--- newly added files ---"
+          cat new_files.txt || true
+
+      - name: Run SPDX check
+        if: steps.new.outputs.has_files == 'true'
+        shell: bash
+        run: |
+          xargs -a new_files.txt pre-commit run spdx-check --files

--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -1,0 +1,60 @@
+name: PR Title Check
+
+on:
+  pull_request:
+    types: [opened, edited, reopened, synchronize]
+  workflow_dispatch:
+
+permissions:
+  pull-requests: read
+
+concurrency:
+  group: pr-title-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const title = context.payload.pull_request?.title || "";
+            const TYPES = ["feat","fix","refactor","perf","docs","test","chore","ci"];
+            const MODULES = new Set([
+              "llm","vlm","vla","diffusion",
+              "train","data","ops","ckpt","peft",
+              "docker","xpu","ci","docs","tests","scripts","release",
+            ]);
+            const re = /^(?<breaking>\[BREAKING\])?\[(?<mods>[a-zA-Z0-9,\s\-]+)\]\s+(?<type>[a-zA-Z]+):\s+.+$/;
+            const m = title.match(re);
+            const fail = (msg) => core.setFailed(msg);
+            if (!m) {
+              fail([
+                `PR title "${title}" does not match required format.`,
+                ``,
+                `Expected: [<modules>] <type>: <description>`,
+                `      or: [BREAKING][<modules>] <type>: <description>`,
+                ``,
+                `Valid types:   ${TYPES.join(", ")}`,
+                `Valid modules: ${[...MODULES].join(", ")}`,
+                ``,
+                `Example: [llm, ckpt] feat: support Qwen3-Next checkpoint conversion`,
+              ].join("\n"));
+              return;
+            }
+            const typ = m.groups.type.toLowerCase();
+            if (!TYPES.includes(typ)) {
+              fail(`Invalid type "${typ}". Valid types: ${TYPES.join(", ")}`);
+              return;
+            }
+            const mods = m.groups.mods.split(",").map(s => s.trim().toLowerCase()).filter(Boolean);
+            const bad = mods.filter(x => !MODULES.has(x));
+            if (bad.length) {
+              fail([
+                `Invalid modules: ${bad.join(", ")}`,
+                `Valid modules: ${[...MODULES].join(", ")}`,
+              ].join("\n"));
+              return;
+            }
+            core.info(`OK: type=${typ}, modules=[${mods.join(", ")}]`);

--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -1,0 +1,25 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: secrets-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/master' }}
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -55,8 +55,8 @@ jobs:
 
       - name: Configure git identity
         run: |
-          git config user.name "loongforge-submodule-sync[bot]"
-          git config user.email "loongforge-submodule-sync[bot]@users.noreply.github.com"
+          git config user.name "loongforge-submodule-sync-test[bot]"
+          git config user.email "286252304+loongforge-submodule-sync-test[bot]@users.noreply.github.com"
 
       - name: Update submodule pointer
         id: update

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -23,7 +23,7 @@ on:
         default: ''
 
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: submodule-sync-${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'master' }}
@@ -38,25 +38,18 @@ jobs:
       SUBMODULE_BRANCH: ${{ github.event.inputs.submodule_branch || github.event.client_payload.submodule_branch || 'loong-main/core_v0.15.0' }}
       SUBMODULE_REPOSITORY: ${{ github.event.inputs.submodule_repository || github.event.client_payload.submodule_repository || '' }}
     steps:
-      - name: Create GitHub App token
-        id: app-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.SUBMODULE_SYNC_APP_ID }}
-          private-key: ${{ secrets.SUBMODULE_SYNC_APP_PRIVATE_KEY }}
-
       - name: Checkout target branch
         uses: actions/checkout@v4
         with:
           ref: ${{ env.TARGET_BRANCH }}
-          token: ${{ steps.app-token.outputs.token }}
+          token: ${{ github.token }}
           fetch-depth: 0
           submodules: false
 
       - name: Configure git identity
         run: |
-          git config user.name "loongforge-submodule-sync-test[bot]"
-          git config user.email "286252304+loongforge-submodule-sync-test[bot]@users.noreply.github.com"
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
       - name: Update submodule pointer
         id: update

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -8,7 +8,7 @@ on:
       target_branch:
         description: Branch to update in this repository
         required: true
-        default: ci/initial-workflows
+        default: master
       submodule_path:
         description: Submodule path to update
         required: true
@@ -26,14 +26,14 @@ permissions:
   contents: read
 
 concurrency:
-  group: submodule-sync-${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'ci/initial-workflows' }}
+  group: submodule-sync-${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'master' }}
   cancel-in-progress: false
 
 jobs:
   sync:
     runs-on: ubuntu-latest
     env:
-      TARGET_BRANCH: ${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'ci/initial-workflows' }}
+      TARGET_BRANCH: ${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'master' }}
       SUBMODULE_PATH: ${{ github.event.inputs.submodule_path || github.event.client_payload.submodule_path || 'third_party/Loong-Megatron' }}
       SUBMODULE_BRANCH: ${{ github.event.inputs.submodule_branch || github.event.client_payload.submodule_branch || 'loong-main/core_v0.15.0' }}
       SUBMODULE_REPOSITORY: ${{ github.event.inputs.submodule_repository || github.event.client_payload.submodule_repository || '' }}

--- a/.github/workflows/submodule-sync.yml
+++ b/.github/workflows/submodule-sync.yml
@@ -1,0 +1,92 @@
+name: Submodule Sync
+
+on:
+  repository_dispatch:
+    types: [loong-megatron-submodule-updated]
+  workflow_dispatch:
+    inputs:
+      target_branch:
+        description: Branch to update in this repository
+        required: true
+        default: ci/initial-workflows
+      submodule_path:
+        description: Submodule path to update
+        required: true
+        default: third_party/Loong-Megatron
+      submodule_branch:
+        description: Submodule branch to track
+        required: true
+        default: loong-main/core_v0.15.0
+      submodule_repository:
+        description: Optional owner/repo override for fork validation
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: submodule-sync-${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'ci/initial-workflows' }}
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_BRANCH: ${{ github.event.inputs.target_branch || github.event.client_payload.target_branch || 'ci/initial-workflows' }}
+      SUBMODULE_PATH: ${{ github.event.inputs.submodule_path || github.event.client_payload.submodule_path || 'third_party/Loong-Megatron' }}
+      SUBMODULE_BRANCH: ${{ github.event.inputs.submodule_branch || github.event.client_payload.submodule_branch || 'loong-main/core_v0.15.0' }}
+      SUBMODULE_REPOSITORY: ${{ github.event.inputs.submodule_repository || github.event.client_payload.submodule_repository || '' }}
+    steps:
+      - name: Create GitHub App token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.SUBMODULE_SYNC_APP_ID }}
+          private-key: ${{ secrets.SUBMODULE_SYNC_APP_PRIVATE_KEY }}
+
+      - name: Checkout target branch
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.TARGET_BRANCH }}
+          token: ${{ steps.app-token.outputs.token }}
+          fetch-depth: 0
+          submodules: false
+
+      - name: Configure git identity
+        run: |
+          git config user.name "loongforge-submodule-sync[bot]"
+          git config user.email "loongforge-submodule-sync[bot]@users.noreply.github.com"
+
+      - name: Update submodule pointer
+        id: update
+        shell: bash
+        run: |
+          set -euo pipefail
+          git submodule sync -- "$SUBMODULE_PATH"
+          if [ -n "$SUBMODULE_REPOSITORY" ]; then
+            git config "submodule.$SUBMODULE_PATH.url" "https://github.com/$SUBMODULE_REPOSITORY.git"
+          fi
+          git submodule update --init -- "$SUBMODULE_PATH"
+          git -C "$SUBMODULE_PATH" fetch origin "$SUBMODULE_BRANCH"
+          git submodule update --remote -- "$SUBMODULE_PATH"
+
+          if git diff --quiet -- "$SUBMODULE_PATH"; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "Submodule $SUBMODULE_PATH is already current on $SUBMODULE_BRANCH."
+            exit 0
+          fi
+
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+          echo "New submodule pointer:"
+          git diff --submodule=log -- "$SUBMODULE_PATH"
+
+      - name: Commit submodule update
+        if: steps.update.outputs.changed == 'true'
+        run: |
+          git add "$SUBMODULE_PATH"
+          git commit -m "[ci] chore: sync Loong-Megatron submodule"
+
+      - name: Push submodule update
+        if: steps.update.outputs.changed == 'true'
+        run: git push origin "HEAD:$TARGET_BRANCH"

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -1,0 +1,8 @@
+# LoongForge gitleaks configuration.
+#
+# Start from gitleaks' default ruleset. Project-specific allowlists
+# or custom rules should be added below with a comment citing the PR
+# or incident that justified the exemption.
+
+[extend]
+useDefault = true

--- a/.license-header.txt
+++ b/.license-header.txt
@@ -1,0 +1,2 @@
+Copyright 2026 The LoongForge Authors.
+SPDX-License-Identifier: Apache-2.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,32 @@
+# Shared by local developer hooks and the license.yml workflow.
+# Run locally:  pre-commit run --all-files
+# Install hook: pre-commit install
+
+exclude: '^(third_party|patches)/'
+
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v5.0.0
+    hooks:
+      - id: trailing-whitespace
+      - id: end-of-file-fixer
+      - id: check-yaml
+        args: ['--unsafe']   # allow Hydra _target_ and custom tags
+      - id: check-added-large-files
+        args: ['--maxkb=1024']
+      - id: check-merge-conflict
+      - id: check-case-conflict
+
+  - repo: https://github.com/Lucas-C/pre-commit-hooks
+    rev: v1.5.5
+    hooks:
+      - id: insert-license
+        alias: spdx-check
+        name: SPDX header check
+        files: '\.(py|sh|cu|cpp|h)$'
+        exclude: '^(third_party|patches|tests/datasets)/'
+        args:
+          - --license-filepath=.license-header.txt
+          - --use-current-year
+          - --detect-license-in-X-top-lines=10
+          - --no-extra-eol

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,6 +135,39 @@ Before submitting a pull request, please make sure that:
 6. Your changes are fully tested.
 7. You submit the pull request against the correct development branch as required.
 
+## Continuous Integration
+
+Every PR runs the following GitHub Actions workflows on CPU runners (no GPU/XPU).
+
+| Workflow | What it checks | Reproduce locally |
+|---|---|---|
+| PR Title Check | Title matches `[<modules>] <type>: <description>` | n/a — edit the PR title |
+| License Header | Newly added `.py/.sh/.cu/.cpp/.h` files have the SPDX Apache-2.0 header | `pre-commit run spdx-check --files <path>` |
+| Secret Scan | gitleaks finds no leaked secrets in new commits | `gitleaks detect --config .gitleaks.toml` |
+| Build | `python -m build` succeeds on Python 3.10 and 3.12 | `python -m build --sdist --wheel --outdir dist/` |
+
+### Valid PR title modules
+
+`llm, vlm, vla, diffusion, train, data, ops, ckpt, peft, docker, xpu, ci, docs, tests, scripts, release`
+
+### Valid PR title types
+
+`feat, fix, refactor, perf, docs, test, chore, ci`
+
+### Example
+
+`[llm, ckpt] feat: support Qwen3-Next checkpoint conversion`
+
+### Setting up pre-commit locally
+
+```bash
+pip install pre-commit
+pre-commit install
+pre-commit run --all-files   # optional
+```
+
+Once installed, the SPDX header check and other hygiene hooks run automatically on `git commit`.
+
 ## License
 By contributing to LoongForge, you agree that your original contributions will be licensed under the [Apache License 2.0](https://github.com/baidu-baige/LoongForge/blob/master/LICENSE).
 


### PR DESCRIPTION
# Summary

- PR title format validator (`pr-title.yml`)
- SPDX license header check on newly added files (`license.yml`)
- gitleaks incremental secret scan (`secrets.yml`)
- sdist + wheel build sanity check on Python 3.12 (`build.yml`)
- Auto-label issues and PRs by keyword (`auto-label.yml`)
- Loong-Megatron submodule sync workflow (`submodule-sync.yml`)
- pre-commit config with hygiene hooks + SPDX check
- Document CI checks in `CONTRIBUTING.md` and `.github/workflows/README.md`

## Details

- No ruff lint in this phase (960 existing violations; adoption strategy pending)
- No GPU/XPU tests (GitHub-hosted runners are CPU-only)
- License header enforcement only applies to newly added `.py/.sh/.cu/.cpp/.h` files
- Header template follows `docs/source/HEADER_GUIDELINES.md` convention
- `submodule-sync.yml` updates `third_party/Loong-Megatron` to `loong-main/core_v0.15.0` and pushes the submodule pointer when it changes
- Submodule sync defaults to `master` for upstream usage and can be triggered manually or by the Loong-Megatron dispatch workflow
- Submodule sync uses the repository `GITHUB_TOKEN` with `contents: write`; ensure LoongForge Actions workflow permissions allow read/write
- Submodule sync commits are authored as `github-actions[bot]`