### PR TITLE
[groot_n1.6] Support full-iteration / per-microbatch CUDA graph

### DIFF
--- a/examples/groot_n1.6/finetuning/sft_groot.sh
+++ b/examples/groot_n1.6/finetuning/sft_groot.sh
@@ -81,6 +81,12 @@ TRAINING_ARGS=(
     --no-load-rng
     --no-gradient-accumulation-fusion
     --deterministic-mode
+    # Optional: enable CUDA graph (per-microbatch)
+    #--cuda-graph-impl local
+    #--cuda-graph-scope per_microbatch
+    #--cuda-graph-warmup-steps 3
+    #--cuda-graph-pad-length 220          # required: pad seqs to fixed length for graph capture
+    #--no-check-for-nan-in-loss-and-grad  # required when CUDA graph enabled
 )
 
 MODEL_CONFIG_ARGS=(

--- a/loongforge/models/common/cuda_graph_base.py
+++ b/loongforge/models/common/cuda_graph_base.py
@@ -1,0 +1,430 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Common scaffolding for CUDA graph wrappers around forward_backward_func.
+
+Model-agnostic. Any model family can build a CUDA graph wrapper by subclassing
+``BaseCudaGraphWrapper`` and implementing the three phase hooks.
+
+Contains:
+- Tensor-struct utilities (deep copy / in-place clone / shape extract / shape compare)
+- ``StaticBufferLoader``: per-microbatch static buffer manager with stable addresses
+- ``BaseCudaGraphWrapper``: template-method ``torch.nn.Module`` orchestrating the
+  warmup / capture / replay phase machine. Subclasses override the three
+  phase implementations (``_run_capture``, ``_run_replay``, ``_invalidate_graph_state``)
+  while sharing data ingestion, warmup, shape tracking, loss allreduce, and
+  iteration accounting.
+"""
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager, nullcontext
+
+import torch
+from megatron.training.utils import average_losses_across_data_parallel_group
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Tensor-struct utilities
+# ---------------------------------------------------------------------------
+def copy_tensors_in_struct(src):
+    """Deep-copy a nested data structure, cloning all tensors to CUDA."""
+    if isinstance(src, tuple):
+        return tuple(copy_tensors_in_struct(i) for i in src)
+    elif isinstance(src, list):
+        return list(copy_tensors_in_struct(i) for i in src)
+    elif isinstance(src, dict):
+        return {k: copy_tensors_in_struct(v) for k, v in src.items()}
+    elif isinstance(src, torch.Tensor):
+        return src.clone().detach().cuda()
+    else:
+        return src
+
+
+def clone_tensors_in_struct(tgt, src):
+    """Clone tensors from src into pre-allocated tgt structure via copy_().
+
+    Raises KeyError with a descriptive message if src is missing a key that
+    exists in tgt (batch structure mismatch). The caller (StaticBufferLoader)
+    catches this and triggers graph re-capture.
+    """
+    if isinstance(tgt, dict) and isinstance(src, dict):
+        for k in tgt:
+            if k not in src:
+                raise KeyError(
+                    f"Batch structure mismatch: key '{k}' present in static "
+                    "buffer but absent in new batch. This typically means the "
+                    "data pipeline yields batches with inconsistent fields."
+                )
+            clone_tensors_in_struct(tgt[k], src[k])
+    elif isinstance(tgt, (tuple, list)) and isinstance(src, (tuple, list)):
+        for t, s in zip(tgt, src):
+            clone_tensors_in_struct(t, s)
+    elif isinstance(tgt, torch.Tensor) and isinstance(src, torch.Tensor):
+        tgt.copy_(src)
+
+
+def extract_tensor_shapes(data):
+    """Extract shape signatures for all tensors in a nested structure."""
+    if isinstance(data, tuple):
+        return tuple(extract_tensor_shapes(i) for i in data)
+    elif isinstance(data, list):
+        return list(extract_tensor_shapes(i) for i in data)
+    elif isinstance(data, dict):
+        return {k: extract_tensor_shapes(v) for k, v in data.items()}
+    elif isinstance(data, torch.Tensor):
+        return data.size()
+    else:
+        return type(data).__name__
+
+
+def shapes_match(shape_a, shape_b):
+    """Compare two shape signature structures for equality."""
+    if isinstance(shape_a, torch.Size) and isinstance(shape_b, torch.Size):
+        return shape_a == shape_b
+    elif isinstance(shape_a, dict) and isinstance(shape_b, dict):
+        return shape_a.keys() == shape_b.keys() and all(
+            shapes_match(shape_a[k], shape_b[k]) for k in shape_a
+        )
+    elif isinstance(shape_a, (tuple, list)) and isinstance(shape_b, (tuple, list)):
+        return len(shape_a) == len(shape_b) and all(
+            shapes_match(a, b) for a, b in zip(shape_a, shape_b)
+        )
+    return shape_a == shape_b
+
+
+# ---------------------------------------------------------------------------
+# StaticBufferLoader
+# ---------------------------------------------------------------------------
+class StaticBufferLoader:
+    """Manages static tensor buffers for pre-loading data before graph replay.
+
+    Maintains one independent static buffer per microbatch slot. Each slot has
+    a fixed memory address that persists across iterations — new data is copied
+    in via copy_() without reallocating.
+    """
+
+    def __init__(self):
+        self._buffers: list = None  # list of per-microbatch static buffers
+
+    def load(self, batch, slot_idx):
+        """Load a batch into the static buffer at slot_idx.
+
+        First call allocates the buffer; subsequent calls copy_() into it.
+        Returns the static buffer reference (same memory address every time).
+        """
+        if self._buffers is None:
+            self._buffers = []
+
+        # Extend buffer list if needed
+        while len(self._buffers) <= slot_idx:
+            self._buffers.append(None)
+
+        if self._buffers[slot_idx] is None:
+            self._buffers[slot_idx] = copy_tensors_in_struct(batch)
+        else:
+            try:
+                clone_tensors_in_struct(self._buffers[slot_idx], batch)
+            except Exception as e:
+                # Reallocating breaks CUDA graph's captured tensor addresses.
+                # Log a warning and raise so the graph wrapper can re-capture.
+                logger.warning(
+                    f"[StaticBufferLoader] clone failed at slot {slot_idx}: {e}. "
+                    "Reallocating buffer — CUDA graph will be invalidated."
+                )
+                self._buffers[slot_idx] = copy_tensors_in_struct(batch)
+                raise RuntimeError(
+                    f"Static buffer reallocated at slot {slot_idx} after CUDA graph capture; "
+                    "graph must be re-captured."
+                ) from e
+
+        return self._buffers[slot_idx]
+
+
+# ---------------------------------------------------------------------------
+# BaseCudaGraphWrapper
+# ---------------------------------------------------------------------------
+class BaseCudaGraphWrapper(torch.nn.Module):
+    """Template-method base class for CUDA graph wrappers around forward_backward_func.
+
+    Phase machine driven by ``__call__``:
+        warmup (eager, populates static buffers and shape signature)
+        ─► capture (record graph(s))
+        ─► replay (load new data, replay graph(s), post-process loss)
+
+    Subclasses MUST override:
+        - ``_run_capture(num_microbatches, kwargs)``  : record graph(s) + eager re-run
+        - ``_run_replay(num_microbatches, kwargs)``   : load → replay → post-process
+        - ``_invalidate_graph_state()``               : drop subclass-specific captured state
+
+    Subclasses MAY override (default no-op):
+        - ``_before_warmup_forward()``  : hook before eager forward in warmup
+        - ``_after_warmup_forward()``   : hook after eager forward in warmup
+        - ``_on_buffer_realloc(...)``   : kwargs builder for recursive __call__
+        - ``_suppress_loss_allreduce()``: ctxmgr to disable loss allreduce in graph
+        - ``LOG_TAG``                   : log tag
+        - ``_warmup_sentinel_attrs``    : submodule attrs to clear on invalidation
+    """
+
+    # Class name shown in log lines; subclasses override for clarity.
+    LOG_TAG = "BaseCudaGraphWrapper"
+    # Submodule attribute names that act as warmup-phase sentinels and must be
+    # cleared (set to False) on graph invalidation to prevent stale state from
+    # blocking re-capture. Subclasses extend.
+    _warmup_sentinel_attrs: tuple[str, ...] = ()
+
+    def __init__(self, forward_backward_func, cuda_graph_warmup_steps=3):
+        super().__init__()
+        self.forward_backward_func = forward_backward_func
+        self.static_loader = StaticBufferLoader()
+        self.captured: bool = False
+        self._call_count: int = 0
+        self._cuda_graph_warmup_steps: int = max(cuda_graph_warmup_steps, 1)
+        self._shape_signatures = None
+        self._needs_recapture: bool = False
+        # Persistent references to graph's static loss output tensors.
+        # These are the tensors the graph writes to on each replay — we must
+        # always read from THESE after replay, never from a replaced reference.
+        self._graph_loss_tensors: list[torch.Tensor] = []
+        self._model_ref: list | None = None
+        self._config = None
+
+    # ----------------------- shared utilities ---------------------------
+    def data_read(self, data_iterator, num_microbatches):
+        """Read num_microbatches from data_iterator into per-slot static buffers.
+
+        Each microbatch gets its own static buffer with a fixed memory address.
+        Returns a list of static buffer references (or None if iterator missing).
+        """
+        static_batches = []
+        iterator0 = data_iterator[0] if isinstance(data_iterator, list) else data_iterator
+        if iterator0 is None:
+            return None
+        for slot_idx in range(num_microbatches):
+            batch = next(iterator0)
+            static_buf = self.static_loader.load(batch, slot_idx)
+            static_batches.append(static_buf)
+        return static_batches
+
+    @staticmethod
+    def _set_warmup_flag(model, value: bool):
+        """Set ``_in_graph_warmup`` on every submodule. Required because checks
+        happen in nested modules that don't inherit attributes from parents."""
+        if model is None:
+            return
+        for _mc in model:
+            for _submod in _mc.modules():
+                _submod._in_graph_warmup = value
+
+    @staticmethod
+    def _zero_grad_buffers(model):
+        if model is None:
+            return
+        for mc in model:
+            if hasattr(mc, 'zero_grad_buffer'):
+                mc.zero_grad_buffer()
+            else:
+                mc.zero_grad()
+
+    def _cache_model_config(self, model):
+        if self._config is None and model is not None:
+            from megatron.core.pipeline_parallel.schedules import get_model_config
+            m = model[0] if isinstance(model, list) else model
+            self._config = get_model_config(m)
+
+    def _allreduce_and_update_losses(self, result_dicts):
+        """Allreduce ``self._graph_loss_tensors`` and write averaged values back
+        into the matching ``loss`` entries of ``result_dicts`` in-place."""
+        if not self._graph_loss_tensors:
+            return
+        _avg = average_losses_across_data_parallel_group(self._graph_loss_tensors)
+        _loss_idx = 0
+        for _r in result_dicts:
+            if isinstance(_r, dict) and "loss" in _r:
+                _r["loss"] = _avg[_loss_idx]
+                _loss_idx += 1
+
+    def _load_replay_data_or_recapture(self, num_microbatches, kwargs):
+        """Load replay data into static buffers and detect graph invalidation.
+
+        Handles two re-capture triggers:
+          1. ``StaticBufferLoader`` raised buffer-reallocation error.
+          2. Input shape changed since capture (``shapes_match`` False).
+
+        Returns ``(static_batches, recapture_kwargs)``:
+          - When ``recapture_kwargs is None``: caller proceeds to replay with
+            ``static_batches`` (may be ``None`` if data_iterator absent).
+          - When ``recapture_kwargs`` is set: caller MUST return
+            ``self.__call__(**recapture_kwargs)``; ``_invalidate_graph`` already
+            ran inside this method.
+        """
+        data_iter = kwargs.get("data_iterator")
+        if data_iter is None:
+            return None, None
+
+        try:
+            static_batches = self.data_read(data_iter, num_microbatches)
+        except RuntimeError as e:
+            if "Static buffer reallocated" in str(e):
+                logger.info(f"[{self.LOG_TAG}] Buffer reallocated, re-capturing graph")
+                new_kwargs = self._on_buffer_realloc(e, data_iter, num_microbatches, kwargs)
+                self._invalidate_graph()
+                return None, new_kwargs
+            raise
+
+        if static_batches and self._shape_signatures is not None:
+            new_shape = extract_tensor_shapes(static_batches[0])
+            if not shapes_match(self._shape_signatures, new_shape):
+                logger.info(f"[{self.LOG_TAG}] Shape change detected, recapturing")
+                self._invalidate_graph()
+                new_kwargs = dict(kwargs)
+                new_kwargs["data_iterator"] = [iter(static_batches)]
+                return None, new_kwargs
+
+        return static_batches, None
+
+    def _on_buffer_realloc(self, error, data_iter, num_microbatches, kwargs):
+        """Hook: build kwargs for recursive ``__call__`` after a buffer realloc.
+
+        Default: re-enter with original kwargs. Subclasses may override to
+        consume remaining slots from the iterator before recursing (avoids
+        stale data when only some microbatches were loaded before the error).
+        """
+        return dict(kwargs)
+
+    @staticmethod
+    def _with_static_data(kwargs, static_batches):
+        """Return a fresh kwargs dict with ``data_iterator`` replaced by an
+        iterator over ``static_batches``. Returns ``kwargs`` unchanged when
+        ``static_batches`` is ``None``."""
+        if static_batches is None:
+            return kwargs
+        new_kwargs = dict(kwargs)
+        new_kwargs["data_iterator"] = [iter(static_batches)]
+        return new_kwargs
+
+    @contextmanager
+    def _preserve_rng_state(self):
+        """Context manager: snapshot CUDA RNG state on enter, restore on exit.
+
+        Use around code that consumes the default generator (e.g. graph capture
+        with TE RNG tracker, or eager RNG buffer pre-allocation) so the
+        externally observable RNG sequence is unaffected.
+        """
+        state = torch.cuda.get_rng_state()
+        try:
+            yield
+        finally:
+            torch.cuda.set_rng_state(state)
+
+    def _suppress_loss_allreduce(self):
+        """Context manager: disable cross-DP loss allreduce within the block.
+
+        Default: no-op (``nullcontext``). Subclasses override to plug into a
+        model-specific suppression mechanism (e.g. a module-level flag read by
+        the loss reduction code path).
+        """
+        return nullcontext()
+
+    def _clear_warmup_sentinels(self):
+        """Walk every submodule in the captured model and reset any attribute
+        listed in ``_warmup_sentinel_attrs`` to False. Subclasses extend the
+        attribute list to plug in additional sentinels."""
+        if self._model_ref is None or not self._warmup_sentinel_attrs:
+            return
+        for _mc in self._model_ref:
+            for _submod in _mc.modules():
+                for attr in self._warmup_sentinel_attrs:
+                    if hasattr(_submod, attr):
+                        setattr(_submod, attr, False)
+
+    # ----------------------- template method ----------------------------
+    def __call__(self, *args, **kwargs):
+        num_microbatches = kwargs.get("num_microbatches", 1)
+        self._call_count += 1
+        curr_iter = self._call_count - 1
+
+        if curr_iter < self._cuda_graph_warmup_steps:
+            return self._run_warmup(curr_iter, num_microbatches, kwargs)
+
+        if not self.captured:
+            return self._run_capture(num_microbatches, kwargs)
+
+        if self._needs_recapture:
+            self._invalidate_graph()
+            return self.__call__(*args, **kwargs)
+
+        return self._run_replay(num_microbatches, kwargs)
+
+    # ----------------------- warmup (shared) ----------------------------
+    def _run_warmup(self, curr_iter, num_microbatches, kwargs):
+        data_iter = kwargs.get("data_iterator")
+        if data_iter is not None:
+            static_batches = self.data_read(data_iter, num_microbatches)
+            if static_batches is not None:
+                if curr_iter == 0:
+                    self._shape_signatures = extract_tensor_shapes(static_batches[0])
+                    logger.info(f"[{self.LOG_TAG}] Recorded shape signature from warmup step 0")
+                kwargs = dict(kwargs)
+                kwargs["data_iterator"] = [iter(static_batches)]
+
+        model = kwargs.get("model")
+        if model is not None:
+            self._model_ref = model
+        self._set_warmup_flag(model, True)
+
+        self._before_warmup_forward()
+        result = self.forward_backward_func(**kwargs)
+        self._after_warmup_forward()
+
+        self._set_warmup_flag(model, False)
+        self._cache_model_config(model)
+
+        return result
+
+    # ----------------------- subclass hooks -----------------------------
+    def _before_warmup_forward(self):
+        """Hook called before eager forward in warmup. Default no-op."""
+
+    def _after_warmup_forward(self):
+        """Hook called after eager forward in warmup. Default no-op."""
+
+    def _run_capture(self, num_microbatches, kwargs):
+        raise NotImplementedError
+
+    def _run_replay(self, num_microbatches, kwargs):
+        raise NotImplementedError
+
+    def _invalidate_graph(self):
+        """Invalidate captured graph state. Calls subclass
+        ``_invalidate_graph_state`` for graph-specific cleanup, then resets
+        common state and clears submodule warmup sentinels.
+
+        Subclasses should NOT override this directly — override
+        ``_invalidate_graph_state`` instead.
+        """
+        self._invalidate_graph_state()
+        self.captured = False
+        self._call_count = 0
+        self._needs_recapture = True
+        self._graph_loss_tensors = []
+        self._shape_signatures = None
+        self._clear_warmup_sentinels()
+
+    def _invalidate_graph_state(self):
+        """Subclass hook: drop subclass-specific captured graph state
+        (e.g. CUDAGraph handles, sub-graph buffers). Common state reset is
+        handled by ``_invalidate_graph`` after this returns."""
+        raise NotImplementedError
+
+    # ----------------------- iteration accounting ----------------------
+    @property
+    def curr_iter(self):
+        """Return the current iteration index."""
+        return self._call_count - 1
+
+    def next_iter(self):
+        """Increment the call count for the next iteration."""
+        self._call_count += 1

--- a/loongforge/models/common/cuda_graph_config.py
+++ b/loongforge/models/common/cuda_graph_config.py
@@ -1,0 +1,67 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""CUDA Graph mode query interface (model-agnostic).
+
+Provides a unified interface for querying which CUDA graph mode is active.
+Reads training args ``--cuda-graph-impl`` and ``--cuda-graph-scope`` and
+exposes typed predicates that any model layer can call to fork its behavior
+between eager and graph-captured paths.
+
+Configuration is read from training args:
+    --cuda-graph-impl local              : Required for graph to activate.
+    --cuda-graph-scope full_iteration    : Single-graph capture of the entire
+                                           forward+backward iteration.
+    --cuda-graph-scope per_microbatch    : Per-microbatch sub-graph capture
+                                           with eager RNG between sub-graphs
+                                           (bit-exact loss alignment).
+"""
+from __future__ import annotations
+
+
+def _get_args():
+    """Import and return training args."""
+    from loongforge.utils import get_args
+    return get_args()
+
+
+def _is_local_impl() -> bool:
+    """Check whether cuda_graph_impl is 'local'."""
+    args = _get_args()
+    if args is None:
+        return False
+    return getattr(args, "cuda_graph_impl", "none") == "local"
+
+
+def is_full_iteration_graph() -> bool:
+    """Check whether full-iteration CUDA graph is active.
+
+    When --cuda-graph-impl=local and --cuda-graph-scope=full_iteration,
+    the entire forward+backward is captured as a single CUDA graph.
+    """
+    args = _get_args()
+    if args is None:
+        return False
+    scope = getattr(args, "cuda_graph_scope", "full")
+    return _is_local_impl() and scope == "full_iteration"
+
+
+def is_per_microbatch_graph() -> bool:
+    """Check whether per-microbatch CUDA graph mode is active.
+
+    When --cuda-graph-impl=local and --cuda-graph-scope=per_microbatch, each
+    microbatch is captured as its own sub-graph and any non-deterministic RNG
+    operations are externalized to run eagerly between sub-graph replays. This
+    achieves bit-exact loss alignment with pure eager at near full-iteration
+    performance.
+    """
+    args = _get_args()
+    if args is None:
+        return False
+    scope = getattr(args, "cuda_graph_scope", "full")
+    return _is_local_impl() and scope == "per_microbatch"
+
+
+def is_any_graph_mode() -> bool:
+    """Check whether any CUDA graph mode is active."""
+    return is_full_iteration_graph() or is_per_microbatch_graph()

--- a/loongforge/models/embodied/groot_n1_6/eagle3_model/modeling_eagle3_vl.py
+++ b/loongforge/models/embodied/groot_n1_6/eagle3_model/modeling_eagle3_vl.py
@@ -24,6 +24,7 @@ from transformers.models.llama.modeling_llama import LlamaForCausalLM
 from transformers.models.qwen2.modeling_qwen2 import Qwen2ForCausalLM
 from transformers.models.qwen3.modeling_qwen3 import Qwen3ForCausalLM
 from transformers.models.siglip.modeling_siglip import SiglipVisionModel
+from transformers.masking_utils import ALL_MASK_ATTENTION_FUNCTIONS
 from transformers.utils import logging
 
 from .configuration_eagle3_vl import (
@@ -33,6 +34,284 @@ from .configuration_eagle3_vl import (
 from .modeling_siglip2 import Siglip2VisionModel
 
 logger = logging.get_logger(__name__)
+
+
+# =============================================================================
+# CUDA-graph-safe Flash Attention patches
+# =============================================================================
+
+
+def _flash_attention_mask_no_sync(
+    batch_size, cache_position, kv_length, kv_offset=0, mask_function=None, attention_mask=None, **kwargs
+):
+    """Patched flash_attention_mask that skips .all() GPU→CPU sync for CUDA graph compatibility.
+
+    The original transformers flash_attention_mask calls attention_mask.all() to decide
+    whether to return None (for is_causal optimization). This .all() triggers a GPU→CPU
+    sync which is forbidden during CUDA graph capture. We simply skip that optimization
+    and always return the sliced mask (FA2 handles the mask correctly either way).
+    """
+    if attention_mask is not None:
+        attention_mask = attention_mask[:, kv_offset:kv_offset + kv_length]
+    return attention_mask
+
+
+# Prevents GPU→CPU sync in create_causal_mask → flash_attention_mask
+# Deferred: applied only when GRooT model is instantiated (see Eagle3VlForConditionalGeneration.__init__)
+_FA2_PATCHES_INSTALLED = False
+
+
+# Buffer cache for graph-safe FA2 operations.
+# Pre-allocated during warmup, reused during graph capture to avoid cudaMalloc and CPU→GPU sync.
+_FA2_GRAPH_BUFFERS: dict = {}
+
+
+def _get_fa2_buffers(batch_size, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, device):
+    """Get or create pre-allocated buffers for graph-safe FA2.
+
+    Includes a single zero-token buffer for each of q/k/v that is concatenated
+    after packing to prevent FA2 OOB reads when all tokens are valid.
+    """
+    key = (batch_size, seq_len, num_q_heads, num_kv_heads, head_dim, dtype, device)
+    if key not in _FA2_GRAPH_BUFFERS:
+        total = batch_size * seq_len
+        # Pre-compute the constant "total" value as a 1-element tensor for concat
+        total_tensor = torch.tensor([total], dtype=torch.int32, device=device)
+        _FA2_GRAPH_BUFFERS[key] = {
+            "seq_ids": torch.arange(batch_size, device=device).unsqueeze(1).expand(-1, seq_len).reshape(-1),
+            "pos_in_seq": torch.arange(seq_len, device=device).unsqueeze(0).expand(batch_size, -1).reshape(-1),
+            "sort_key": torch.zeros(total, dtype=torch.int64, device=device),
+            "total_tensor": total_tensor,
+            "zero_tensor": torch.zeros(1, dtype=torch.int32, device=device),
+            # Pre-allocated zero tokens for OOB prevention (avoids cudaMalloc during graph capture)
+            "zero_q": torch.zeros(1, num_q_heads, head_dim, device=device, dtype=dtype),
+            "zero_kv": torch.zeros(1, num_kv_heads, head_dim, device=device, dtype=dtype),
+        }
+    return _FA2_GRAPH_BUFFERS[key]
+
+
+def _graph_safe_unpad_and_attend(
+    query_states,
+    key_states,
+    value_states,
+    attention_mask,
+    flash_attn_varlen_func,
+    softmax_scale,
+    causal,
+    flash_kwargs,
+):
+    """Graph-safe FA2 attention with argsort-based packing.
+
+    Replaces the original nonzero-based unpad path. All operations produce fixed-size
+    outputs and use pre-allocated buffers, making them fully CUDA-graph-capturable.
+    """
+    batch_size, kv_seq_len, num_kv_heads, head_dim = key_states.shape
+    total = batch_size * kv_seq_len
+    device = attention_mask.device
+    num_q_heads = query_states.shape[2]
+
+    # Get pre-allocated buffers (created during warmup, reused during capture)
+    bufs = _get_fa2_buffers(batch_size, kv_seq_len, num_q_heads, num_kv_heads, head_dim,
+                            query_states.dtype, device)
+    seq_ids = bufs["seq_ids"]
+    pos_in_seq = bufs["pos_in_seq"]
+    sort_key = bufs["sort_key"]
+    total_tensor = bufs["total_tensor"]
+    zero_tensor = bufs["zero_tensor"]
+    zero_q = bufs["zero_q"]
+    zero_kv = bufs["zero_kv"]
+
+    flat_mask = attention_mask.reshape(-1).int()  # (B*S,)
+
+    # Compute sort key: valid tokens first (per-sequence, in position order), padding at end
+    sort_key.copy_(seq_ids * kv_seq_len + pos_in_seq + (1 - flat_mask).long() * total)
+    sorted_indices = torch.argsort(sort_key, stable=True)  # (B*S,) fixed
+    reverse_indices = torch.argsort(sorted_indices)  # (B*S,) fixed
+
+    # Build cu_seqlens WITHOUT in-place scalar assignment (which causes CPU→GPU sync).
+    # cu_seqlens = [0, cumsum(seqlens), safe_total]
+    # Each call creates a NEW tensor to avoid version-counter conflicts in autograd.
+    seqlens = attention_mask.sum(dim=-1, dtype=torch.int32)  # (B,)
+    cumulative = torch.cumsum(seqlens, dim=0, dtype=torch.int32)  # (B,)
+    # When all tokens are valid (no padding), cumulative[-1] == total, which creates a
+    # zero-length virtual sequence that crashes FA2 (cu_seqlens[i]==cu_seqlens[i+1]).
+    # Use max(total_tensor, cumulative[-1:] + 1) to guarantee the dummy sequence has length >= 1.
+    safe_total = torch.max(total_tensor, cumulative[-1:] + 1)
+    cu_seqlens = torch.cat([zero_tensor, cumulative, safe_total])  # (B+2,)
+    # max_seqlen must cover the virtual padding sequence (safe_total[0] - cumulative[-1])
+    # Use `total` as a safe upper bound — it's always >= actual max seqlen.
+    max_seqlen = total  # safe upper bound for FA2 tiling
+
+    # Pack q, k, v using sorted_indices, then unconditionally append a zero dummy token.
+    # This prevents FA2 OOB reads when safe_total == total+1 (all tokens valid).
+    # torch.cat produces a NEW tensor each call, so autograd version tracking is correct.
+    # The zero_q/zero_kv buffers are pre-allocated (no cudaMalloc during graph capture).
+    packed_q = torch.cat([query_states.reshape(total, num_q_heads, head_dim)[sorted_indices], zero_q], dim=0)
+    packed_k = torch.cat([key_states.reshape(total, num_kv_heads, head_dim)[sorted_indices], zero_kv], dim=0)
+    packed_v = torch.cat([value_states.reshape(total, num_kv_heads, head_dim)[sorted_indices], zero_kv], dim=0)
+
+    # Flash attention on packed sequences (B real + 1 dummy for padding)
+    attn_output_packed = flash_attn_varlen_func(
+        packed_q,
+        packed_k,
+        packed_v,
+        cu_seqlens_q=cu_seqlens,
+        cu_seqlens_k=cu_seqlens,
+        max_seqlen_q=max_seqlen,
+        max_seqlen_k=max_seqlen,
+        softmax_scale=softmax_scale,
+        causal=causal,
+        **flash_kwargs,
+    )
+
+    # Unpack: take only the first `total` tokens, then reverse sort to restore original positions
+    attn_output_flat = attn_output_packed[:total][reverse_indices]  # (B*S, H, D)
+
+    # Zero out padding positions
+    attn_output_flat = attn_output_flat * flat_mask.unsqueeze(-1).unsqueeze(-1).to(attn_output_flat.dtype)
+
+    # Reshape back to (B, S, H, D)
+    return attn_output_flat.reshape(batch_size, kv_seq_len, num_q_heads, head_dim)
+
+
+def _is_graph_mode_active() -> bool:
+    """Check if we should use graph-safe FA2 path.
+
+    Returns True when:
+    - Full-iteration or per-microbatch CUDA graph is configured (covers warmup + capture + replay phases)
+    - OR we're currently in a CUDA graph capture stream
+    """
+    try:
+        from loongforge.models.common.cuda_graph_config import (
+            is_full_iteration_graph, is_per_microbatch_graph,
+        )
+        if is_full_iteration_graph() or is_per_microbatch_graph():
+            return True
+    except (ImportError, RuntimeError):
+        pass
+    return torch.cuda.is_available() and torch.cuda.is_current_stream_capturing()
+
+
+def _install_graph_safe_fa2_patch():
+    """Monkey-patch transformers' _flash_attention_forward.
+
+    In graph mode: uses argsort-based packing (fixed output shapes, graph-capturable).
+    In eager mode: uses original nonzero-based path (better performance).
+    """
+    import transformers.modeling_flash_attention_utils as fa_utils
+
+    _original_flash_attention_forward = fa_utils._flash_attention_forward
+
+    def _patched_flash_attention_forward(
+        query_states,
+        key_states,
+        value_states,
+        attention_mask,
+        query_length,
+        is_causal,
+        dropout=0.0,
+        softmax_scale=None,
+        sliding_window=None,
+        use_top_left_mask=False,
+        softcap=None,
+        deterministic=None,
+        cu_seq_lens_q=None,
+        cu_seq_lens_k=None,
+        max_length_q=None,
+        max_length_k=None,
+        target_dtype=None,
+        attn_implementation=None,
+        **kwargs,
+    ):
+        # Use graph-safe argsort path only when:
+        # 1. attention_mask is not None (the problematic branch)
+        # 2. We're in training mode with query_length == kv_seq_len
+        # 3. No pre-computed varlen kwargs
+        # 4. Graph mode is active (full_iteration_graph configured or stream capturing)
+        if (
+            attention_mask is not None
+            and query_length == key_states.shape[1]
+            and cu_seq_lens_q is None
+            and _is_graph_mode_active()
+        ):
+            # Resolve flash_attn varlen function
+            if attn_implementation == "flash_attention_3":
+                from flash_attn_interface import flash_attn_varlen_func as _varlen_func
+            else:
+                from flash_attn import flash_attn_varlen_func as _varlen_func
+
+            # Build flash_kwargs
+            fa_kwargs = {}
+            if dropout > 0.0:
+                fa_kwargs["dropout_p"] = dropout
+            if sliding_window is not None:
+                fa_kwargs["window_size"] = (sliding_window, sliding_window)
+            if deterministic is None:
+                det_flag = os.environ.get("FLASH_ATTENTION_DETERMINISTIC", "0") == "1"
+            else:
+                det_flag = deterministic
+            if attn_implementation != "flash_attention_3":
+                fa_kwargs["deterministic"] = det_flag
+            if softcap is not None:
+                fa_kwargs["softcap"] = softcap
+
+            # PEFT dtype handling
+            if target_dtype is not None:
+                query_states = query_states.to(target_dtype)
+                key_states = key_states.to(target_dtype)
+                value_states = value_states.to(target_dtype)
+
+            causal = is_causal or (query_length > 1 and not use_top_left_mask)
+
+            return _graph_safe_unpad_and_attend(
+                query_states,
+                key_states,
+                value_states,
+                attention_mask,
+                _varlen_func,
+                softmax_scale,
+                causal,
+                fa_kwargs,
+            )
+
+        # Eager mode or non-matching cases: use original implementation (nonzero-based)
+        return _original_flash_attention_forward(
+            query_states,
+            key_states,
+            value_states,
+            attention_mask,
+            query_length,
+            is_causal,
+            dropout=dropout,
+            softmax_scale=softmax_scale,
+            sliding_window=sliding_window,
+            use_top_left_mask=use_top_left_mask,
+            softcap=softcap,
+            deterministic=deterministic,
+            cu_seq_lens_q=cu_seq_lens_q,
+            cu_seq_lens_k=cu_seq_lens_k,
+            max_length_q=max_length_q,
+            max_length_k=max_length_k,
+            target_dtype=target_dtype,
+            attn_implementation=attn_implementation,
+            **kwargs,
+        )
+
+    # Apply the patch to ALL references
+    fa_utils._flash_attention_forward = _patched_flash_attention_forward
+    # Also patch the local reference in flash_attention.py (imported at module load time)
+    import transformers.integrations.flash_attention as flash_attn_integration
+    flash_attn_integration._flash_attention_forward = _patched_flash_attention_forward
+
+
+# Install the patch lazily (called from model __init__, not at import time)
+def _maybe_install_fa2_patches():
+    global _FA2_PATCHES_INSTALLED
+    if _FA2_PATCHES_INSTALLED:
+        return
+    ALL_MASK_ATTENTION_FUNCTIONS._global_mapping["flash_attention_2"] = _flash_attention_mask_no_sync
+    _install_graph_safe_fa2_patch()
+    _FA2_PATCHES_INSTALLED = True
 
 
 # =============================================================================
@@ -83,6 +362,8 @@ class Eagle3VlForConditionalGeneration(Eagle3VlPreTrainedModel, GenerationMixin)
 
     def __init__(self, config: Eagle3VLConfig, vision_model=None, language_model=None):
         super().__init__(config)
+        # Install FA2 patches on first model instantiation (not at import time)
+        _maybe_install_fa2_patches()
 
         self.select_layer = config.select_layer
         self.template = getattr(config, "template", None)
@@ -147,6 +428,8 @@ class Eagle3VlForConditionalGeneration(Eagle3VlPreTrainedModel, GenerationMixin)
         )
         self.image_token_index = config.image_token_index
         self.neftune_alpha = None
+        # Cached spatial shapes for CUDA graph capture (fixed in training)
+        self._cached_pixel_shuffle_shapes = None
 
         self.use_backbone_lora = getattr(config, "use_backbone_lora", 0) != 0
         self.use_llm_lora = getattr(config, "use_llm_lora", 0) != 0
@@ -226,17 +509,19 @@ class Eagle3VlForConditionalGeneration(Eagle3VlPreTrainedModel, GenerationMixin)
 
         input_ids = input_ids.reshape(B * N)
         selected = input_ids == self.image_token_index
-        try:
-            input_embeds[selected] = input_embeds[selected] * 0.0 + vit_embeds
-        except Exception as e:
-            print(
-                f"warning: {e}, input_embeds[selected].shape={input_embeds[selected].shape}, "
-                f"vit_embeds.shape={vit_embeds.shape}"
-            )
-            n_token = selected.sum()
-            input_embeds[selected] = (
-                input_embeds[selected] * 0.0 + vit_embeds[:n_token]
-            )
+        # Defensive: if token count mismatch (data preprocessing anomaly), truncate vit_embeds.
+        # Only check in eager mode — int(sum()) triggers CPU sync forbidden during capture.
+        # During capture/replay, shapes are fixed by warmup so mismatch cannot occur.
+        if not torch.cuda.is_current_stream_capturing():
+            num_img_tokens = int(selected.sum())
+            if num_img_tokens != vit_embeds.shape[0]:
+                vit_embeds = vit_embeds[:num_img_tokens]
+        # Use masked_scatter_ uniformly (graph-capturable AND numerically identical
+        # to boolean indexing). This eliminates any code-path difference between
+        # graph capture/replay and eager.
+        input_embeds.masked_scatter_(
+            selected.unsqueeze(-1).expand_as(input_embeds), vit_embeds
+        )
 
         input_embeds = input_embeds.reshape(B, N, C)
 
@@ -279,7 +564,20 @@ class Eagle3VlForConditionalGeneration(Eagle3VlPreTrainedModel, GenerationMixin)
     def pixel_shuffle_back(self, vit_embeds, spatial_shapes):
         """Apply pixel shuffle to vision embeddings."""
         B, N, C = vit_embeds.shape
-        shapes = spatial_shapes.tolist()
+        # spatial_shapes.tolist() triggers GPU→CPU sync — not capturable in CUDA graph.
+        # Cache the result from the first eager call and reuse during graph capture,
+        # since shapes are fixed across iterations in training.
+        if torch.cuda.is_current_stream_capturing():
+            shapes = self._cached_pixel_shuffle_shapes
+            if shapes is None:
+                raise RuntimeError(
+                    "pixel_shuffle_back: CUDA graph capture started before warmup. "
+                    "_cached_pixel_shuffle_shapes is None. "
+                    "Ensure at least one eager forward pass runs before graph capture."
+                )
+        else:
+            shapes = spatial_shapes.tolist()
+            self._cached_pixel_shuffle_shapes = shapes
 
         # Split at once
         lengths = [h * w for (h, w) in shapes]
@@ -367,8 +665,26 @@ class Eagle3VlForConditionalGeneration(Eagle3VlPreTrainedModel, GenerationMixin)
         B, N, C = vit_embeds.shape
         vit_embeds = vit_embeds.reshape(B * N, C)
 
-        if image_flags is not None and any(image_flags == 0):
-            vit_embeds = self.mask_valid_tokens(vit_embeds, spatial_shapes, image_flags)
+        # any(image_flags == 0) triggers GPU→CPU sync via Python's any() iterating
+        # over a tensor — not capturable in CUDA graph. In fixed-batch training all
+        # images are valid (flags all 1), so skip masking during graph capture.
+        if image_flags is not None:
+            if torch.cuda.is_current_stream_capturing():
+                # During capture, rely on warmup-phase validation: if warmup detected
+                # invalid images, capture must not proceed (would bake in wrong path).
+                if getattr(self, '_capture_has_invalid_images', False):
+                    raise RuntimeError(
+                        "CUDA graph capture: image_flags contained zeros during warmup. "
+                        "Ensure all batches have valid images when using full-iteration "
+                        "CUDA graph, or disable CUDA graph for this dataset."
+                    )
+            elif any(image_flags == 0):
+                # Only record the flag during graph warmup phase, not during
+                # unrelated eager calls (eval, inference) which should not block
+                # subsequent graph capture.
+                if getattr(self, '_in_graph_warmup', False):
+                    self._capture_has_invalid_images = True
+                vit_embeds = self.mask_valid_tokens(vit_embeds, spatial_shapes, image_flags)
 
         return vit_embeds
 

--- a/loongforge/models/embodied/groot_n1_6/eagle3_model/modeling_siglip2.py
+++ b/loongforge/models/embodied/groot_n1_6/eagle3_model/modeling_siglip2.py
@@ -190,11 +190,20 @@ def flash_attention_forward_for_packing(
     # FA2 always relies on the value set in the module, so remove it if present in kwargs to avoid passing it twice
     kwargs.pop("is_causal", None)
 
-    cu_seqlens = F.pad(
-        torch.cumsum(torch.tensor(seq_len_list, device=query.device, dtype=torch.int32), dim=0), (1, 0)
-    )
-    cu_seqlens = cu_seqlens.to(torch.int32)
-    max_seq_len = max(seq_len_list)
+    # Cache cu_seqlens on the module so its tensor address stays stable across iterations.
+    # torch.tensor(list) during CUDA graph capture triggers a host-device sync (not capturable).
+    if (
+        not hasattr(module, "_cu_seqlens_cache")
+        or module._cu_seqlens_cache.shape[0] != len(seq_len_list) + 1
+        or module._cu_seqlens_cache.device != query.device
+        or getattr(module, "_seq_len_list_cache", None) != seq_len_list
+    ):
+        seq_len_t = torch.tensor(seq_len_list, device=query.device, dtype=torch.int32)
+        module._cu_seqlens_cache = F.pad(torch.cumsum(seq_len_t, dim=0), (1, 0)).to(torch.int32)
+        module._max_seq_len_cache = max(seq_len_list)
+        module._seq_len_list_cache = list(seq_len_list)
+    cu_seqlens = module._cu_seqlens_cache
+    max_seq_len = module._max_seq_len_cache
     attn_output = _flash_attention_forward(
         query,
         key,
@@ -424,6 +433,16 @@ class Siglip2VisionEmbeddings(nn.Module):
         self.num_patches = config.num_patches
         self.position_embedding_size = int(self.num_patches**0.5)
         self.position_embedding = nn.Embedding(self.num_patches, self.embed_dim)
+        # Cached index permutation for graph-safe window reordering (fixed for constant batch config)
+        self.register_buffer("_window_sort_idx", None, persistent=False)
+        # Cached reverse mapping for graph-safe token reordering (fixed for constant batch config)
+        self.register_buffer("_reverse_mapping_cache", None, persistent=False)
+        # Cached batch_hw list from .tolist() for graph capture (shapes are fixed in training)
+        self._cached_batch_hw_list = None
+        # Cached spatial shapes GPU tensor for graph capture
+        self._cached_spatial_shapes = None
+        # Cached resized positional embeddings for graph capture (F.interpolate not capturable)
+        self._cached_resized_pos_emb = None
 
     def split_patch_embeddings_to_windows_with_meta(self, patch_embeds, batch_hw, window_size):
         """
@@ -442,7 +461,20 @@ class Siglip2VisionEmbeddings(nn.Module):
         """
 
         # 1. Compute start position of each image in the flat tensor
-        batch_hw = batch_hw.tolist()
+        # batch_hw.tolist() triggers GPU→CPU sync — not capturable in CUDA graph.
+        # Cache the result from the first eager call and reuse during graph capture,
+        # since shapes are fixed across iterations in training.
+        if torch.cuda.is_current_stream_capturing():
+            batch_hw = self._cached_batch_hw_list
+            if batch_hw is None:
+                raise RuntimeError(
+                    "split_patch_embeddings_to_windows_with_meta: CUDA graph capture "
+                    "started before warmup. _cached_batch_hw_list is None."
+                )
+        else:
+            batch_hw_list = batch_hw.tolist()
+            self._cached_batch_hw_list = batch_hw_list
+            batch_hw = batch_hw_list
         counts = [H * W for (H, W) in batch_hw]
         starts = [0] + list(accumulate(counts))[:-1]
 
@@ -515,7 +547,19 @@ class Siglip2VisionEmbeddings(nn.Module):
             key=lambda k: (all_meta[k]["img_idx"], all_meta[k]["win_xy"][0], all_meta[k]["win_xy"][1]),
         )
         all_windows = torch.cat(all_windows, dim=0)
-        all_windows = all_windows[sorted_idx]
+        # Use a persistent CUDA tensor for the index permutation so that the address is
+        # stable across iterations — required for CUDA graph capture/replay.
+        # Invalidate cache when content changes (not just length), since different
+        # image size combinations can produce the same window count but different orderings.
+        _new_sort_key = tuple(sorted_idx)
+        if (self._window_sort_idx is None or
+                self._window_sort_idx.shape[0] != len(sorted_idx) or
+                getattr(self, '_window_sort_key_cache', None) != _new_sort_key):
+            self._window_sort_idx = torch.tensor(
+                sorted_idx, dtype=torch.long, device=patch_embeds.device
+            )
+            self._window_sort_key_cache = _new_sort_key
+        all_windows = all_windows[self._window_sort_idx]
         win_meta_list = [all_meta[i] for i in sorted_idx]
 
         windows_list = []
@@ -559,7 +603,19 @@ class Siglip2VisionEmbeddings(nn.Module):
 
                 # After this window, advance offset by the number of effective tokens in the window
             offset += h_eff * w_eff
-        reverse_mapping = torch.tensor(mapping, dtype=torch.long)
+        # Cache on self for CUDA-graph-safe stable tensor address; also keeps the index on GPU
+        # to avoid CPU→GPU sync inside the graph (torch.tensor(list) from CPU is not capturable).
+        # Invalidate when content changes — same total_patches but different image sizes
+        # produces a different mapping.
+        _new_mapping_key = tuple(mapping)
+        if (self._reverse_mapping_cache is None or
+                self._reverse_mapping_cache.shape[0] != len(mapping) or
+                getattr(self, '_reverse_mapping_key_cache', None) != _new_mapping_key):
+            self._reverse_mapping_cache = torch.tensor(
+                mapping, dtype=torch.long, device=patch_embeds.device
+            )
+            self._reverse_mapping_key_cache = _new_mapping_key
+        reverse_mapping = self._reverse_mapping_cache
 
         return all_tokens, win_meta_list, reverse_mapping
 
@@ -598,12 +654,16 @@ class Siglip2VisionEmbeddings(nn.Module):
         for i in range(batch_size):
             # (1, dim, height, width) -> (1, dim, target_height, target_width)
             height, width = spatial_shapes[i]
+            # F.interpolate with antialias=True uses a kernel that is not
+            # CUDA-graph-capturable. Disable antialias during graph capture;
+            # the quality difference is negligible for positional embeddings.
+            antialias = not torch.cuda.is_current_stream_capturing()
             resized_embeddings = F.interpolate(
                 positional_embeddings,
                 size=(height, width),
                 mode="bilinear",
                 align_corners=False,
-                antialias=True,
+                antialias=antialias,
             )
 
             # (1, dim, target_height, target_width) -> (target_height * target_width, dim)
@@ -622,8 +682,24 @@ class Siglip2VisionEmbeddings(nn.Module):
         for shape in bchw_list:
             b, _, h, w = shape
             hw_list.extend([(h // self.patch_size, w // self.patch_size)] * b)
-        hw_tensor = torch.tensor(hw_list)
-        return hw_tensor
+        # Use cached GPU tensor during graph capture; torch.tensor() on CPU
+        # creates a CPU tensor whose implicit GPU transfer breaks CUDA graph.
+        if torch.cuda.is_current_stream_capturing():
+            if self._cached_spatial_shapes is None:
+                raise RuntimeError(
+                    "get_spatial_shapes: CUDA graph capture started before warmup. "
+                    "_cached_spatial_shapes is None."
+                )
+            return self._cached_spatial_shapes
+        target_device = self.position_embedding.weight.device
+        hw_tensor = torch.tensor(hw_list, device=target_device)
+        if (hasattr(self, '_cached_spatial_shapes') and
+                self._cached_spatial_shapes is not None and
+                self._cached_spatial_shapes.shape == hw_tensor.shape):
+            self._cached_spatial_shapes.copy_(hw_tensor)
+        else:
+            self._cached_spatial_shapes = hw_tensor
+        return self._cached_spatial_shapes
 
     def forward(self, pixel_values: torch.FloatTensor) -> torch.Tensor:
         """
@@ -648,9 +724,26 @@ class Siglip2VisionEmbeddings(nn.Module):
         )
         spatial_shapes = self.get_spatial_shapes(bchw_list)
 
-        resized_positional_embeddings = self.resize_positional_embeddings(
-            positional_embeddings, spatial_shapes
-        )
+        # F.interpolate is not CUDA-graph-capturable (uses torch.arange internally).
+        # Cache the result from the first eager call; it's constant for fixed batch shapes.
+        if torch.cuda.is_current_stream_capturing():
+            resized_positional_embeddings = self._cached_resized_pos_emb
+            if resized_positional_embeddings is None:
+                raise RuntimeError(
+                    "Siglip2VisionEmbeddings.forward: CUDA graph capture started before "
+                    "warmup. _cached_resized_pos_emb is None."
+                )
+        else:
+            resized_positional_embeddings = self.resize_positional_embeddings(
+                positional_embeddings, spatial_shapes
+            )
+            if (hasattr(self, '_cached_resized_pos_emb') and
+                    self._cached_resized_pos_emb is not None and
+                    self._cached_resized_pos_emb.shape == resized_positional_embeddings.shape):
+                self._cached_resized_pos_emb.copy_(resized_positional_embeddings)
+            else:
+                self._cached_resized_pos_emb = resized_positional_embeddings
+            resized_positional_embeddings = self._cached_resized_pos_emb
         # Add positional embeddings to patch embeddings
         embeddings = patch_embeds + resized_positional_embeddings
 

--- a/loongforge/models/embodied/groot_n1_6/modeling_groot.py
+++ b/loongforge/models/embodied/groot_n1_6/modeling_groot.py
@@ -167,6 +167,14 @@ class Gr00tN1d6ActionHead(nn.Module):
         """
         Sample time steps from beta distribution.
 
+        When running inside a CUDA graph capture (full-iteration graph), uses
+        the inverse CDF method which is graph-capturable.  For Beta(alpha, 1),
+        the inverse CDF is u^(1/alpha), which only requires torch.rand (CUDA RNG).
+
+        For general Beta(alpha, beta) with beta != 1, falls back to
+        torch.distributions.Beta.sample() which is NOT graph-capturable and
+        will raise a RuntimeError if called during graph capture.
+
         Args:
             batch_size: Number of samples to generate
             device: Device to place tensors on
@@ -175,7 +183,26 @@ class Gr00tN1d6ActionHead(nn.Module):
         Returns:
             Sampled time steps
         """
-        sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        # Use inverse CDF for Beta(alpha, 1) — always, not just during graph capture.
+        # This ensures identical RNG consumption in both eager and CUDA graph modes.
+        # For Beta(alpha, 1), the CDF is x^alpha, so the inverse CDF is u^(1/alpha).
+        # When --cuda-graph-scope=per_microbatch: use Beta.sample() to achieve
+        # bit-exact alignment with pure eager (sample_time runs outside the graph).
+        from loongforge.models.common.cuda_graph_config import is_per_microbatch_graph
+
+        if is_per_microbatch_graph():
+            sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        elif self.config.noise_beta_beta != 1.0:
+            if torch.cuda.is_current_stream_capturing():
+                raise RuntimeError(
+                    "sample_time() during CUDA graph capture requires noise_beta_beta=1.0, "
+                    f"got beta={self.config.noise_beta_beta}."
+                )
+            # Fallback to Beta.sample (beta != 1)
+            sample = self.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+        else:
+            u = torch.rand(batch_size, device=device, dtype=dtype)
+            sample = u.pow(1.0 / self.config.noise_beta_alpha)
         sample = (1 - sample) * self.config.noise_s
         return sample
 
@@ -293,9 +320,25 @@ class Gr00tN1d6ActionHead(nn.Module):
             state_features = state_features + noise
 
         # Embed noised action trajectory (flow matching)
-        noise = torch.randn(actions.shape, device=actions.device, dtype=actions.dtype)
-        t = self.sample_time(actions.shape[0], device=actions.device, dtype=actions.dtype)
-        t = t[:, None, None]  # shape (B, 1, 1) for broadcast
+        # In per-microbatch graph mode: use external static buffers for noise/time
+        # so that graph captures reads from fixed addresses, and we can
+        # overwrite them with fresh Beta.sample() values before each replay.
+        _noise_buf = getattr(self, '_split_noise_buf', None)
+        if _noise_buf is not None:
+            # Split graph mode: read from pre-allocated static buffers.
+            # Buffers are allocated before capture with correct shape.
+            noise = self._split_noise_buf
+            t_1d = self._split_time_buf
+            t = t_1d[:, None, None]
+        else:
+            # Record action shape during warmup for later buffer allocation
+            if getattr(self, '_split_record_shape', False):
+                self._split_actions_shape = actions.shape
+                self._split_actions_device = actions.device
+                self._split_actions_dtype = actions.dtype
+            noise = torch.randn(actions.shape, device=actions.device, dtype=actions.dtype)
+            t = self.sample_time(actions.shape[0], device=actions.device, dtype=actions.dtype)
+            t = t[:, None, None]  # shape (B, 1, 1) for broadcast
 
         # Interpolate between noise and actions
         noisy_trajectory = (1 - t) * noise + t * actions
@@ -616,7 +659,9 @@ class Gr00tN1d6(nn.Module):
         self._checkpoint_max_state_dim = self._detect_checkpoint_state_dim()
         self._checkpoint_max_action_dim = self._detect_checkpoint_action_dim()
         self._checkpoint_action_horizon = self._detect_checkpoint_action_horizon()
-
+        # Pre-allocated padding buffers (lazily initialised on first forward call to
+        # avoid repeated torch.zeros/torch.full kernel launches inside CUDA Graph).
+        self._pad_bufs: dict | None = None
         # Collator is imported here to avoid circular dependency
         try:
             from .processor_groot import Gr00tN1d6DataCollator
@@ -699,6 +744,53 @@ class Gr00tN1d6(nn.Module):
             return 50  # N1.6 default
         return int(checkpoint_horizon)
 
+    def _init_pad_bufs(self, inputs: dict) -> None:
+        """Pre-allocate zero/one-filled buffers for checkpoint-dim padding.
+
+        Called lazily on the first forward pass so that batch size, device, and
+        dtypes are all known.  Each buffer covers the *full* expected shape so that
+        only a copy_ (no kernel for the zero tail) is needed on every subsequent
+        forward pass, eliminating repeated FillFunctor kernel launches.
+        """
+        bufs: dict = {}
+        max_S = self._checkpoint_max_state_dim
+        max_D = self._checkpoint_max_action_dim
+        exp_T = self._checkpoint_action_horizon
+
+        state = inputs.get("state")
+        if state is not None and torch.is_tensor(state):
+            dev, dt = state.device, state.dtype
+            if state.ndim == 2:
+                B = state.shape[0]
+                bufs["state_2d"] = torch.zeros(B, max_S, device=dev, dtype=dt)
+            elif state.ndim == 3:
+                B, T = state.shape[0], state.shape[1]
+                bufs["state_3d"] = torch.zeros(B, T, max_S, device=dev, dtype=dt)
+
+        action = inputs.get("action")
+        if action is not None and torch.is_tensor(action):
+            dev, dt = action.device, action.dtype
+            a = action if action.ndim == 3 else action.unsqueeze(1)
+            B = a.shape[0]
+            bufs["action"] = torch.zeros(B, exp_T, max_D, device=dev, dtype=dt)
+
+        for mask_key in ("action_mask", "action_is_pad"):
+            mask = inputs.get(mask_key)
+            if mask is None or not torch.is_tensor(mask):
+                continue
+            dev, dt = mask.device, mask.dtype
+            pad_val = 1 if mask_key == "action_is_pad" else 0
+            if mask.ndim == 2:
+                B = mask.shape[0]
+                buf = torch.full((B, exp_T), pad_val, device=dev, dtype=dt)
+                bufs[f"{mask_key}_2d"] = buf
+            elif mask.ndim == 3:
+                B = mask.shape[0]
+                buf = torch.full((B, exp_T, max_D), pad_val, device=dev, dtype=dt)
+                bufs[f"{mask_key}_3d"] = buf
+
+        self._pad_bufs = bufs
+
     def _pad_inputs_to_checkpoint_dims(self, inputs: dict) -> dict:
         """Pad / truncate state and action tensors to the dimensions expected by
         the checkpoint weights.
@@ -716,142 +808,121 @@ class Gr00tN1d6(nn.Module):
         """
         inputs = dict(inputs)  # shallow copy so we don't mutate the original
 
+        # Lazily initialise pre-allocated padding buffers on the first call
+        # (batch size / device / dtype are only known at runtime).
+        # Re-initialise if batch size changes (e.g. last micro-batch or eval).
+        _first_tensor = next((v for v in inputs.values() if torch.is_tensor(v)), None)
+        if _first_tensor is not None:
+            _B = _first_tensor.shape[0]
+            # Also check that existing buffers match current state ndim to avoid
+            # KeyError when state switches between 2D and 3D across iterations.
+            _state = inputs.get("state")
+            _state_buf_key = None
+            if _state is not None and torch.is_tensor(_state) and _state.ndim in (2, 3):
+                _state_buf_key = f"state_{_state.ndim}d"
+            # Also check mask ndim to avoid KeyError when mask switches between 2D/3D.
+            _mask_buf_missing = False
+            for _mk in ("action_mask", "action_is_pad"):
+                _m = inputs.get(_mk)
+                if _m is not None and torch.is_tensor(_m) and _m.ndim in (2, 3):
+                    _mk_key = f"{_mk}_{_m.ndim}d"
+                    if self._pad_bufs and _mk_key not in self._pad_bufs:
+                        _mask_buf_missing = True
+                        break
+            _need_reinit = (
+                self._pad_bufs is None
+                or not self._pad_bufs
+                or next(iter(self._pad_bufs.values())).shape[0] != _B
+                or (_state_buf_key is not None and _state_buf_key not in self._pad_bufs)
+                or _mask_buf_missing
+            )
+            if _need_reinit:
+                self._init_pad_bufs(inputs)
+
+        bufs = self._pad_bufs
+        max_state_dim = self._checkpoint_max_state_dim
+        max_action_dim = self._checkpoint_max_action_dim
+        expected_T = self._checkpoint_action_horizon
+
         # ---- state ----
         state = inputs.get("state")
         if state is not None and torch.is_tensor(state):
-            device = state.device
-            max_state_dim = self._checkpoint_max_state_dim
             if state.ndim == 2:
                 B, D = state.shape
                 if D < max_state_dim:
-                    inputs["state"] = torch.cat(
-                        [state, torch.zeros(
-                            B, max_state_dim - D, 
-                            device=device, 
-                            dtype=state.dtype
-                        )], 
-                        dim=1
-                    )
+                    buf = bufs["state_2d"]
+                    buf.zero_()
+                    buf[:, :D].copy_(state)
+                    inputs["state"] = buf
                 elif D > max_state_dim:
                     inputs["state"] = state[:, :max_state_dim]
             elif state.ndim == 3:
                 B, T, D = state.shape
                 if D < max_state_dim:
-                    inputs["state"] = torch.cat(
-                        [state, torch.zeros(
-                            B, T, max_state_dim - D, 
-                            device=device, 
-                            dtype=state.dtype
-                        )], 
-                        dim=2
-                    )
+                    buf = bufs["state_3d"]
+                    buf.zero_()
+                    buf[:, :, :D].copy_(state)
+                    inputs["state"] = buf
                 elif D > max_state_dim:
                     inputs["state"] = state[:, :, :max_state_dim]
 
         # ---- action ----
         action = inputs.get("action")
         if action is not None and torch.is_tensor(action):
-            device = action.device
-            max_action_dim = self._checkpoint_max_action_dim
-            expected_T = self._checkpoint_action_horizon
-
             # Ensure 3-D: [B, T, D]
             if action.ndim == 2:
                 action = action.unsqueeze(1)  # [B, D] -> [B, 1, D]
 
             B, T, D = action.shape
+            need_T_pad = T < expected_T
+            need_D_pad = D < max_action_dim
 
-            # Pad / truncate time dimension
-            if T < expected_T:
-                action = torch.cat(
-                    [action, torch.zeros(
-                        B, expected_T - T, D, 
-                        device=device, 
-                        dtype=action.dtype
-                    )], 
-                    dim=1
-                )
+            if need_T_pad or need_D_pad:
+                buf = bufs["action"]
+                t_copy = min(T, expected_T)
+                d_copy = min(D, max_action_dim)
+                buf.zero_()
+                buf[:, :t_copy, :d_copy].copy_(action[:, :t_copy, :d_copy])
+                action = buf
             elif T > expected_T:
                 action = action[:, :expected_T, :]
-
-            # Pad / truncate action dim
-            if D < max_action_dim:
-                action = torch.cat(
-                    [action, torch.zeros(
-                        B, expected_T, max_action_dim - D, 
-                        device=device, 
-                        dtype=action.dtype
-                    )],
-                    dim=2,
-                )
-            elif D > max_action_dim:
+            if D > max_action_dim:
                 action = action[:, :, :max_action_dim]
 
             inputs["action"] = action
 
         # ---- action_mask / action_is_pad ----
-        # Align time dimension to expected_T.
-        # action_mask is 3-D [B, T, D] and must also have its action_dim padded to
-        # max_action_dim so it can broadcast against pred_actions [B, T, max_action_dim].
-        # action_is_pad is 2-D [B, T] and only needs the time dimension aligned.
-        expected_T = self._checkpoint_action_horizon
-        max_action_dim = self._checkpoint_max_action_dim
+        # action_mask is 3-D [B, T, D]; action_is_pad is 2-D [B, T].
+        # Pad tail with 0 (mask) or 1 (is_pad); truncate if too long.
         for mask_key in ("action_mask", "action_is_pad"):
             mask = inputs.get(mask_key)
             if mask is None or not torch.is_tensor(mask):
                 continue
             if mask.ndim == 2:
-                # [B, T] — only align time dimension
                 B, T = mask.shape
                 if T < expected_T:
-                    pad_val = 1 if mask_key == "action_is_pad" else 0
-                    inputs[mask_key] = torch.cat(
-                        [mask,
-                         torch.full(
-                             (B, expected_T - T), 
-                             pad_val, 
-                             device=mask.device, 
-                             dtype=mask.dtype
-                         )],
-                        dim=1,
-                    )
+                    buf = bufs[f"{mask_key}_2d"]
+                    buf.fill_(1 if mask_key == "action_is_pad" else 0)
+                    buf[:, :T].copy_(mask)
+                    inputs[mask_key] = buf
                 elif T > expected_T:
                     inputs[mask_key] = mask[:, :expected_T]
             elif mask.ndim == 3:
-                # [B, T, D] — align both time and action_dim dimensions
                 B, T, D = mask.shape
-                # pad / truncate time
-                if T < expected_T:
-                    pad_val = 1 if mask_key == "action_is_pad" else 0
-                    mask = torch.cat(
-                        [mask,
-                         torch.full(
-                             (B, expected_T - T, D), 
-                             pad_val, 
-                             device=mask.device, 
-                             dtype=mask.dtype
-                         )],
-                        dim=1,
-                    )
-                elif T > expected_T:
-                    mask = mask[:, :expected_T, :]
-                # pad / truncate action_dim
-                T_now = mask.shape[1]
-                D_now = mask.shape[2]
-                if D_now < max_action_dim:
-                    # Pad with zeros — padded action dims carry no real signal,
-                    # so masking them out (0) prevents spurious loss contribution.
-                    mask = torch.cat(
-                        [mask,
-                         torch.zeros(
-                             B, T_now, max_action_dim - D_now, 
-                             device=mask.device, 
-                             dtype=mask.dtype
-                         )],
-                        dim=2,
-                    )
-                elif D_now > max_action_dim:
-                    mask = mask[:, :, :max_action_dim]
+                need_T_pad = T < expected_T
+                need_D_pad = D < max_action_dim
+                if need_T_pad or need_D_pad:
+                    buf = bufs[f"{mask_key}_3d"]
+                    t_copy = min(T, expected_T)
+                    d_copy = min(D, max_action_dim)
+                    buf.fill_(1 if mask_key == "action_is_pad" else 0)
+                    buf[:, :t_copy, :d_copy].copy_(mask[:, :t_copy, :d_copy])
+                    mask = buf
+                else:
+                    if T > expected_T:
+                        mask = mask[:, :expected_T, :]
+                    if mask.shape[2] > max_action_dim:
+                        mask = mask[:, :, :max_action_dim]
                 inputs[mask_key] = mask
 
         return inputs

--- a/loongforge/models/embodied/groot_n1_6/modules/groot_full_iteration_graph.py
+++ b/loongforge/models/embodied/groot_n1_6/modules/groot_full_iteration_graph.py
@@ -1,0 +1,141 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GrootFullIterationGraph: Full-iteration CUDA graph for GRooT training.
+
+Captures the entire forward_backward_func (all micro-batches of forward +
+backward + gradient sync) into a single CUDA graph, eliminating kernel launch
+overhead and Python interpreter overhead between layers.
+
+Controlled by training args: --cuda-graph-impl=local --cuda-graph-scope=full_iteration
+"""
+from __future__ import annotations
+
+import logging
+
+import torch
+
+from loongforge.models.common.cuda_graph_base import (
+    BaseCudaGraphWrapper,
+    copy_tensors_in_struct,
+)
+
+from .groot_graph_mixin import GrootGraphMixin
+
+logger = logging.getLogger(__name__)
+
+
+class GrootFullIterationGraph(GrootGraphMixin, BaseCudaGraphWrapper):
+    """Full-iteration CUDA Graph wrapper for GRooT VLA training."""
+
+    LOG_TAG = "GrootFullIterationGraph"
+    # Submodules (e.g. ViT) flip this on during warmup when they see padding;
+    # must be cleared on graph invalidation to allow re-capture.
+    _warmup_sentinel_attrs = ("_capture_has_invalid_images",)
+
+    def __init__(self, forward_backward_func, cuda_graph_warmup_steps=3):
+        super().__init__(forward_backward_func, cuda_graph_warmup_steps)
+        self.cuda_graph: dict[str, torch.cuda.CUDAGraph] = {}
+        # Instance-level result storage (NOT class-level) to avoid cross-instance pollution.
+        self._graph_result: list = []
+
+    def _invalidate_graph_state(self):
+        self.cuda_graph.clear()
+
+    def _run_capture(self, num_microbatches, kwargs):
+        training_str = kwargs.get("training_str", "train")
+        training_str_key = training_str + "_capture"
+
+        # Load data into static buffers
+        data_iter = kwargs.get("data_iterator")
+        static_batches = None
+        if data_iter is not None:
+            static_batches = self.data_read(data_iter, num_microbatches)
+            kwargs = self._with_static_data(kwargs, static_batches)
+
+        if training_str_key not in self.cuda_graph:
+            self.cuda_graph[training_str_key] = torch.cuda.CUDAGraph()
+        cg = self.cuda_graph[training_str_key]
+
+        # Suppress allreduce + isolate RNG consumption inside graph capture.
+        with self._suppress_loss_allreduce(), self._preserve_rng_state():
+            torch.cuda.synchronize()
+            with torch.cuda.graph(cg):
+                # Re-wrap static buffers as fresh iterator for capture
+                if static_batches is not None:
+                    kwargs["data_iterator"] = [iter(static_batches)]
+                captured_result = self.forward_backward_func(**kwargs)
+
+            # Save the captured result reference — graph replay updates THESE tensors
+            if isinstance(captured_result, list):
+                self._graph_result = captured_result
+                # Save persistent references to graph's loss output tensors.
+                # These addresses are fixed — graph replay writes new values here.
+                self._graph_loss_tensors = []
+                for _cr in captured_result:
+                    if isinstance(_cr, dict) and "loss" in _cr:
+                        self._graph_loss_tensors.append(_cr["loss"])
+
+        # Defensive zero-grad between capture and eager re-run.
+        # In practice, CUDA graph capture leaves param.grad at zero and DDP's
+        # backward hook is skipped during capture (is_graph_capturing() -> return),
+        # so main_grad is not polluted. This zero_grad is kept as a safety net
+        # in case future PyTorch/Megatron changes alter that behavior.
+        self._zero_grad_buffers(kwargs.get("model"))
+
+        # Run one eager step with same data to produce correct output for this iter
+        if static_batches is not None:
+            kwargs["data_iterator"] = [iter(static_batches)]
+        result = self.forward_backward_func(**kwargs)
+
+        self.captured = True
+        self._needs_recapture = False
+        logger.info(f"[GrootFullIterationGraph] CUDA graph captured for {training_str}")
+
+        return result
+
+    def _on_buffer_realloc(self, error, data_iter, num_microbatches, kwargs):
+        """After a buffer realloc, consume remaining slots from the original
+        iterator so they don't go stale, then re-enter using the static
+        buffers as the new iterator source."""
+        import re as _re
+        # Parse the slot index from the error to know how many batches
+        # were already consumed from the iterator (slots 0..slot_idx).
+        _m = _re.search(r"at slot (\d+)", str(error))
+        consumed_count = int(_m.group(1)) + 1 if _m else num_microbatches
+        # Continue consuming remaining slots from original iterator to avoid stale data
+        iterator0 = data_iter[0] if isinstance(data_iter, list) else data_iter
+        if iterator0 is not None:
+            for remaining_slot in range(consumed_count, num_microbatches):
+                try:
+                    batch = next(iterator0)
+                    self.static_loader._buffers[remaining_slot] = copy_tensors_in_struct(batch)
+                except StopIteration:
+                    break
+        new_kwargs = dict(kwargs)
+        if self.static_loader._buffers:
+            new_kwargs["data_iterator"] = [iter(self.static_loader._buffers)]
+        return new_kwargs
+
+    def _run_replay(self, num_microbatches, kwargs):
+        training_str = kwargs.get("training_str", "train")
+        training_str_key = training_str + "_capture"
+
+        # Load new data into the SAME static buffers (preserves captured memory addresses)
+        # and detect any graph-invalidation trigger.
+        _, recapture_kwargs = self._load_replay_data_or_recapture(num_microbatches, kwargs)
+        if recapture_kwargs is not None:
+            return self.__call__(**recapture_kwargs)
+
+        # Replay the captured graph (reads from static buffers which now contain new data).
+        with self._suppress_loss_allreduce():
+            self.cuda_graph[training_str_key].replay()
+            torch.cuda.synchronize()
+
+        # Read loss from the graph's STATIC output tensors (fixed addresses),
+        # NOT from a stale dict reference (which may have been overwritten by
+        # previous allreduce results).
+        if self._graph_loss_tensors:
+            self._allreduce_and_update_losses(self._graph_result)
+
+        return self._graph_result if self._graph_result else []

--- a/loongforge/models/embodied/groot_n1_6/modules/groot_graph_mixin.py
+++ b/loongforge/models/embodied/groot_n1_6/modules/groot_graph_mixin.py
@@ -1,0 +1,33 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared mixin for GRooT CUDA graph wrappers.
+
+Plugs GRooT-specific behavior into the model-agnostic
+``BaseCudaGraphWrapper`` template via the documented hook API.
+"""
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+
+class GrootGraphMixin:
+    """Suppress GRooT's per-step loss allreduce while a CUDA graph is being
+    captured or replayed.
+
+    Loss allreduce performs NCCL ops, which are not capturable. The flag
+    ``loongforge.train.embodied.sft_groot._SKIP_LOSS_ALLREDUCE`` is read by
+    the loss reduction path; we set it inside the ctxmgr and restore the
+    prior value (in ``finally``, so an in-graph error cannot leave the flag
+    permanently corrupted)."""
+
+    @contextmanager
+    def _suppress_loss_allreduce(self):
+        import loongforge.train.embodied.sft_groot as _sft_groot_mod
+
+        _saved = getattr(_sft_groot_mod, "_SKIP_LOSS_ALLREDUCE", False)
+        _sft_groot_mod._SKIP_LOSS_ALLREDUCE = True
+        try:
+            yield
+        finally:
+            _sft_groot_mod._SKIP_LOSS_ALLREDUCE = _saved

--- a/loongforge/models/embodied/groot_n1_6/modules/groot_per_microbatch_graph.py
+++ b/loongforge/models/embodied/groot_n1_6/modules/groot_per_microbatch_graph.py
@@ -1,0 +1,365 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GrootPerMicrobatchGraph: Per-microbatch CUDA graph with externalized RNG.
+
+Captures each microbatch's forward+backward as an independent CUDA graph.
+Before each sub-graph replay, noise and time are generated eagerly using
+Beta.sample(), achieving bit-exact RNG alignment with pure eager mode.
+
+Architecture per iteration replay:
+  for each microbatch i:
+    1. Generate noise_i + time_i EAGERLY (torch.randn + Beta.sample)
+    2. copy_() into static buffers
+    3. sub_graph_i.replay()  (forward + backward for microbatch i)
+  4. finalize_model_grads (gradient allreduce)
+  5. allreduce loss
+
+This preserves the eager RNG consumption order:
+  noise0 -> time0 -> [fwd0+bwd0] -> noise1 -> time1 -> [fwd1+bwd1] -> ...
+
+Controlled by: --cuda-graph-impl=local --cuda-graph-scope=per_microbatch
+"""
+from __future__ import annotations
+
+import contextlib
+import logging
+
+import torch
+from megatron.training.utils import unwrap_model
+
+from loongforge.models.common.cuda_graph_base import (
+    BaseCudaGraphWrapper,
+    StaticBufferLoader,
+)
+
+from .groot_graph_mixin import GrootGraphMixin
+
+logger = logging.getLogger(__name__)
+
+
+class GrootPerMicrobatchGraph(GrootGraphMixin, BaseCudaGraphWrapper):
+    """Per-microbatch CUDA graph with externalized RNG for bit-exact training.
+
+    Each microbatch gets its own CUDA graph. Before each sub-graph replay,
+    noise/time are generated eagerly so the RNG sequence matches pure eager
+    exactly (noise_i -> time_i -> dropout_i -> backward_i -> ...).
+    """
+
+    LOG_TAG = "GrootPerMicrobatchGraph"
+    # Submodules (e.g. ViT) flip this on during warmup when they see padding;
+    # must be cleared on graph invalidation to allow re-capture.
+    _warmup_sentinel_attrs = ("_capture_has_invalid_images",)
+
+    def __init__(self, forward_backward_func, cuda_graph_warmup_steps=3):
+        super().__init__(forward_backward_func, cuda_graph_warmup_steps)
+
+        # Per-microbatch CUDA graphs
+        self._sub_graphs: list[torch.cuda.CUDAGraph] = []
+
+        # Static RNG buffers per microbatch
+        self._noise_bufs: list[torch.Tensor] = []
+        self._time_bufs: list[torch.Tensor] = []
+
+        # Per-microbatch loss output references
+        self._sub_graph_results: list[list] = []
+
+        # Cached action_head reference
+        self._action_head = None
+
+    # ------------------- action_head plumbing -------------------------
+    def _find_action_head(self):
+        """Find the action_head module in the model."""
+        if self._action_head is not None:
+            return self._action_head
+        if self._model_ref is None:
+            return None
+        for _mc in self._model_ref:
+            model = unwrap_model(_mc)
+            for _name, mod in model.named_modules():
+                if hasattr(mod, 'action_encoder') and hasattr(mod, 'sample_time'):
+                    self._action_head = mod
+                    return mod
+        return None
+
+    def _enable_shape_recording(self):
+        ah = self._find_action_head()
+        if ah is not None:
+            ah._split_record_shape = True
+
+    def _disable_shape_recording(self):
+        ah = self._find_action_head()
+        if ah is not None:
+            ah._split_record_shape = False
+
+    # ------------------- RNG buffer management ------------------------
+    def _allocate_rng_bufs(self, num_microbatches):
+        """Allocate static noise/time buffers using shape recorded during warmup."""
+        ah = self._find_action_head()
+        if ah is None:
+            raise RuntimeError("[GrootPerMicrobatchGraph] Cannot find action_head")
+
+        actions_shape = getattr(ah, '_split_actions_shape', None)
+        if actions_shape is None:
+            raise RuntimeError(
+                "[GrootPerMicrobatchGraph] Action shape not recorded during warmup."
+            )
+        device = ah._split_actions_device
+        dtype = ah._split_actions_dtype
+
+        self._noise_bufs = []
+        self._time_bufs = []
+
+        for mb_idx in range(num_microbatches):
+            noise_buf = torch.randn(actions_shape, device=device, dtype=dtype)
+            batch_size = actions_shape[0]
+            t = ah.beta_dist.sample([batch_size]).to(device, dtype=dtype)
+            time_buf = (1 - t) * ah.config.noise_s
+            self._noise_bufs.append(noise_buf)
+            self._time_bufs.append(time_buf)
+
+    def _set_rng_buf_on_model(self, mb_idx):
+        """Set the static buffer for a specific microbatch on the action_head."""
+        ah = self._find_action_head()
+        if ah is not None:
+            ah._split_noise_buf = self._noise_bufs[mb_idx]
+            ah._split_time_buf = self._time_bufs[mb_idx]
+
+    def _clear_rng_bufs_on_model(self):
+        ah = self._find_action_head()
+        if ah is not None:
+            ah._split_noise_buf = None
+            ah._split_time_buf = None
+
+    def _eager_rng_single(self, mb_idx):
+        """Generate fresh noise/time for a single microbatch and copy into buffer."""
+        ah = self._find_action_head()
+        if ah is None:
+            return
+
+        noise_buf = self._noise_bufs[mb_idx]
+        time_buf = self._time_bufs[mb_idx]
+
+        # Fresh noise (consumes default generator offset)
+        noise = torch.randn_like(noise_buf)
+        noise_buf.copy_(noise)
+
+        # Fresh time via Beta.sample (consumes default generator offset)
+        batch_size = time_buf.shape[0]
+        t = ah.beta_dist.sample([batch_size]).to(
+            time_buf.device, dtype=time_buf.dtype
+        )
+        t = (1 - t) * ah.config.noise_s
+        time_buf.copy_(t)
+
+    # ------------------- BaseCudaGraphWrapper hooks -------------------
+    def _before_warmup_forward(self):
+        self._enable_shape_recording()
+
+    def _after_warmup_forward(self):
+        self._disable_shape_recording()
+
+    @staticmethod
+    def _issue_grad_sync(model_list):
+        """Manually dispatch grad reduce after replay.
+
+        Graph replay only re-executes recorded kernels — Python autograd hooks
+        do not fire — so DDP's overlap path never gets a chance to call
+        ``start_grad_sync()`` on its own. We do it here so the subsequent
+        ``finalize_model_grads_func`` can ``finish_grad_sync()`` (wait on the
+        handle).
+        """
+        if model_list is None:
+            return
+        for mc in model_list:
+            if hasattr(mc, "start_grad_sync"):
+                mc.start_grad_sync()
+
+    @staticmethod
+    def _is_overlap_grad_reduce(model_list):
+        if not model_list:
+            return False
+        cfg = getattr(model_list[0], "ddp_config", None)
+        return bool(cfg is not None and getattr(cfg, "overlap_grad_reduce", False))
+
+    @staticmethod
+    def _collect_bucket_groups(model_list):
+        bgs = []
+        if not model_list:
+            return bgs
+        for mc in model_list:
+            bgs.extend(getattr(mc, "bucket_groups", []))
+            bgs.extend(getattr(mc, "expert_parallel_bucket_groups", []))
+        return bgs
+
+    @contextlib.contextmanager
+    def _suppress_grad_sync(self, model_list):
+        """Pin DDP and schedule state so capture-time backwards don't fire
+        ``start_grad_sync()`` and the schedule's ``no_sync`` toggling is a
+        no-op. Restored on exit.
+        """
+        saved_finalize = self._config.finalize_model_grads_func
+        saved_no_sync = self._config.no_sync_func
+        bgs = self._collect_bucket_groups(model_list)
+        saved_flags = [getattr(bg, "is_last_microbatch", True) for bg in bgs]
+        self._config.finalize_model_grads_func = None
+        self._config.no_sync_func = contextlib.nullcontext
+        for bg in bgs:
+            bg.is_last_microbatch = False
+        try:
+            yield
+        finally:
+            self._config.finalize_model_grads_func = saved_finalize
+            self._config.no_sync_func = saved_no_sync
+            for bg, prev in zip(bgs, saved_flags):
+                bg.is_last_microbatch = prev
+
+    def _capture_one_microbatch(self, mb_idx, kwargs, static_batches):
+        """Capture a single microbatch's forward+backward into a CUDAGraph."""
+        self._set_rng_buf_on_model(mb_idx)
+
+        mb_kwargs = dict(kwargs)
+        mb_kwargs["num_microbatches"] = 1
+        if static_batches is not None:
+            mb_kwargs["data_iterator"] = [iter([static_batches[mb_idx]])]
+
+        cg = torch.cuda.CUDAGraph()
+        torch.cuda.synchronize()
+
+        with torch.cuda.graph(cg):
+            if static_batches is not None:
+                mb_kwargs["data_iterator"] = [iter([static_batches[mb_idx]])]
+            captured_result = self.forward_backward_func(**mb_kwargs)
+
+        self._sub_graphs.append(cg)
+
+        if isinstance(captured_result, list):
+            self._sub_graph_results.append(captured_result)
+            for _cr in captured_result:
+                if isinstance(_cr, dict) and "loss" in _cr:
+                    self._graph_loss_tensors.append(_cr["loss"])
+
+    def _invalidate_graph_state(self):
+        """Drop sub-graph handles, RNG buffers, and reset static loader.
+        Common state (captured/_call_count/etc.) is reset by base class."""
+        self._sub_graphs.clear()
+        self._sub_graph_results = []
+        self._noise_bufs = []
+        self._time_bufs = []
+        self.static_loader = StaticBufferLoader()
+        self._clear_rng_bufs_on_model()
+
+    def _run_capture(self, num_microbatches, kwargs):
+        data_iter = kwargs.get("data_iterator")
+        static_batches = None
+        if data_iter is not None:
+            static_batches = self.data_read(data_iter, num_microbatches)
+
+        _model = kwargs.get("model")
+        self._sub_graphs = []
+        self._sub_graph_results = []
+        self._graph_loss_tensors = []
+
+        # Detect overlap_grad_reduce mode. When enabled, we let the schedule
+        # run normally for the LAST sub-graph so that DDP's backward hooks
+        # fire, ``start_grad_sync()`` records its NCCL kernels into the
+        # graph, and ``finalize_model_grads_func`` records ``cm.wait()`` —
+        # giving us the same overlap window full_iteration enjoys.
+        _model_list = _model if isinstance(_model, list) else (
+            [_model] if _model is not None else None
+        )
+        bake_grad_sync = (
+            self._is_overlap_grad_reduce(_model_list) and num_microbatches > 0
+        )
+
+        try:
+            with self._preserve_rng_state(), self._suppress_loss_allreduce():
+                self._allocate_rng_bufs(num_microbatches)
+
+                # Suppressed range: [0, last) when baking; otherwise all.
+                last_idx = num_microbatches - 1
+                n_suppressed = last_idx if bake_grad_sync else num_microbatches
+
+                with self._suppress_grad_sync(_model_list):
+                    for mb_idx in range(n_suppressed):
+                        self._capture_one_microbatch(mb_idx, kwargs, static_batches)
+
+                # Capture last sub-graph OUTSIDE the suppression context so
+                # the schedule's own no_sync/finalize flow runs inside
+                # torch.cuda.graph — recording NCCL kernels.
+                if bake_grad_sync:
+                    self._capture_one_microbatch(last_idx, kwargs, static_batches)
+        finally:
+            self._clear_rng_bufs_on_model()
+
+        # Remember whether grad sync is baked into the last sub-graph so
+        # _run_replay knows to skip the eager grad-sync dispatch.
+        self._grad_sync_in_graph = bake_grad_sync
+
+        # Zero grad and run eager for correct output this iteration
+        self._zero_grad_buffers(_model)
+
+        kwargs = self._with_static_data(kwargs, static_batches)
+        result = self.forward_backward_func(**kwargs)
+
+        self.captured = True
+        self._needs_recapture = False
+        logger.info(
+            f"[GrootPerMicrobatchGraph] Captured {num_microbatches} per-microbatch "
+            f"sub-graphs for bit-exact RNG alignment"
+        )
+        return result
+
+    def _run_replay(self, num_microbatches, kwargs):
+        # Load new data into static buffers and detect any graph-invalidation trigger.
+        _, recapture_kwargs = self._load_replay_data_or_recapture(num_microbatches, kwargs)
+        if recapture_kwargs is not None:
+            return self.__call__(**recapture_kwargs)
+
+        # Per-microbatch replay with interleaved RNG.
+        # The trailing ``torch.cuda.synchronize()`` is intentional: the
+        # subsequent optimizer.step must read reduced grads, so the host
+        # has to wait for the captured NCCL allreduce regardless. Letting
+        # the host run ahead just shifts the wait into the next iter's
+        # timer (and we measured it as a small regression).
+        try:
+            with self._suppress_loss_allreduce():
+                for mb_idx in range(num_microbatches):
+                    # Generate noise/time eagerly (same RNG order as eager)
+                    self._eager_rng_single(mb_idx)
+                    # Set buffer on model for this sub-graph
+                    self._set_rng_buf_on_model(mb_idx)
+                    # Replay this microbatch's graph
+                    self._sub_graphs[mb_idx].replay()
+                torch.cuda.synchronize()
+        finally:
+            self._clear_rng_bufs_on_model()
+
+        # Finalize model grads (gradient allreduce across DP).
+        # Three paths:
+        # (a) overlap + grad sync baked into last sub-graph: replay already
+        #     re-launches the NCCL kernels and the captured cm.wait().
+        # (b) overlap, grad sync NOT in graph: manually start_grad_sync,
+        #     then finalize finishes it (waits on the handle).
+        # (c) no overlap: finalize runs the synchronous reduce.
+        if self._config is not None and self._config.finalize_model_grads_func is not None:
+            _model = kwargs.get("model")
+            if _model is not None:
+                model_list = _model if isinstance(_model, list) else [_model]
+                _overlap = self._is_overlap_grad_reduce(model_list)
+                _baked = getattr(self, "_grad_sync_in_graph", False)
+                if not (_overlap and _baked):
+                    if _overlap:
+                        self._issue_grad_sync(model_list)
+                    self._config.finalize_model_grads_func(model_list, None)
+
+        # Post-replay: allreduce loss across flattened sub-graph results
+        if self._graph_loss_tensors:
+            flat_results = [_r for mb_results in self._sub_graph_results for _r in mb_results]
+            self._allreduce_and_update_losses(flat_results)
+
+        # Return flattened results
+        all_results = []
+        for mb_results in self._sub_graph_results:
+            all_results.extend(mb_results)
+        return all_results if all_results else []

--- a/loongforge/models/embodied/groot_n1_6/processor_groot.py
+++ b/loongforge/models/embodied/groot_n1_6/processor_groot.py
@@ -260,8 +260,14 @@ def build_processor(
     return processor
 
 
-def make_gr00t_n1d6_pre_post_processors(policy_cfg=None, dataset_stats=None, dataset=None):
-    """Build preprocessors aligned with `lerobot` GR00T-N1.6 baseline."""
+def make_gr00t_n1d6_pre_post_processors(policy_cfg=None, dataset_stats=None, dataset=None, max_length=None):
+    """Build preprocessors aligned with `lerobot` GR00T-N1.6 baseline.
+
+    Args:
+        max_length: If set, pad token sequences to this fixed length. Required
+            for full-iteration CUDA graph where all batches must have identical
+            tensor shapes. When None, uses dynamic padding.
+    """
 
     if policy_cfg is None:
         raise ValueError("policy_cfg (Gr00tN1d6Config) is required to build processors")
@@ -339,6 +345,7 @@ def make_gr00t_n1d6_pre_post_processors(policy_cfg=None, dataset_stats=None, dat
         random_rotation_angle=getattr(policy_cfg, "random_rotation_angle", None),
         color_jitter_params=getattr(policy_cfg, "color_jitter_params", None),
         use_processor_image_size=False,
+        max_length=max_length,
     )
     baseline_processor.train()
 
@@ -866,14 +873,26 @@ class Gr00tN1d6DataCollator:
         tokenizer_assets_repo: str = "lerobot/eagle3-processor-groot-n1d6",
         model_type: Literal["eagle"] = "eagle",
         transformers_loading_kwargs: dict | None = None,
+        max_length: int | None = None,
     ):
-        """Initialize data collator."""
+        """Initialize data collator.
+
+        Args:
+            max_length: If set, pad all sequences to this fixed length using
+                ``padding="max_length"`` and ``truncation=True``. This ensures
+                all batches have identical tensor shapes, which is required for
+                full-iteration CUDA graph (``--cuda-graph-scope=full_iteration``).
+                When ``None`` (default), uses dynamic padding (pad to longest
+                sequence in the batch).
+        """
         if transformers_loading_kwargs is None:
             transformers_loading_kwargs = {}
         self.processor = build_processor(model_name, tokenizer_assets_repo, transformers_loading_kwargs)
         self.processor.tokenizer.padding_side = "left"
         self.model_type = model_type
         self.model_name = model_name
+        self.max_length = max_length
+        self._truncation_warned = False
 
     def __call__(self, features: list[dict[str, Any]]) -> BatchFeature:
         """Process features into batch."""
@@ -891,7 +910,28 @@ class Gr00tN1d6DataCollator:
 
                 if self.model_type == "eagle":
                     image_inputs, _ = self.processor.process_vision_info([v["conversation"] for v in values])
-                vlm_inputs = self.processor(text=text_list, images=image_inputs, return_tensors="pt", padding=True)
+                vlm_inputs = self.processor(
+                    text=text_list, images=image_inputs, return_tensors="pt",
+                    padding="max_length" if self.max_length else True,
+                    max_length=self.max_length,
+                    truncation=self.max_length is not None,
+                )
+                # Detect truncation: if any sample has attention_mask all-1 with
+                # max_length set, it was truncated (no pad tokens added).
+                if (self.max_length is not None and not self._truncation_warned
+                        and "attention_mask" in vlm_inputs):
+                    attn_mask = vlm_inputs["attention_mask"]
+                    num_truncated = int((attn_mask.sum(dim=-1) == attn_mask.shape[-1]).sum())
+                    if num_truncated > 0:
+                        self._truncation_warned = True
+                        warnings.warn(
+                            f"{num_truncated}/{attn_mask.shape[0]} samples in this batch "
+                            f"have no padding tokens (sequence length == max_length="
+                            f"{self.max_length}), which likely means they were truncated. "
+                            "Consider increasing --cuda-graph-pad-length if this is unexpected.",
+                            UserWarning,
+                            stacklevel=2,
+                        )
                 for k, v in vlm_inputs.items():
                     batch[k] = v
             elif key in ("pixel_values", "image_grid_thw", "attention_mask", "input_ids"):
@@ -946,6 +986,7 @@ class Gr00tN1d6Processor:
         embodiment_id_mapping: dict[str, int] | None = None,
         transformers_loading_kwargs: dict | None = None,
         use_processor_image_size: bool = False,
+        max_length: int | None = None,
     ):
         """Initialize Gr00tN1d6 processor."""
         if transformers_loading_kwargs is None:
@@ -988,6 +1029,7 @@ class Gr00tN1d6Processor:
         self.shortest_image_edge = shortest_image_edge
         self.crop_fraction = crop_fraction
         self.use_processor_image_size = use_processor_image_size
+        self.max_length = max_length
 
         if use_albumentations and not ALBUMENTATIONS_AVAILABLE:
             warnings.warn(
@@ -1023,6 +1065,7 @@ class Gr00tN1d6Processor:
             tokenizer_assets_repo=tokenizer_assets_repo,
             model_type=model_type,
             transformers_loading_kwargs=transformers_loading_kwargs,
+            max_length=max_length,
         )
         self.training = True
         self._cached_raw_state = None

--- a/loongforge/train/arguments.py
+++ b/loongforge/train/arguments.py
@@ -11,8 +11,13 @@ video processing, multimodal training, and parallel execution.
 import argparse
 
 from loongforge.data import get_support_templates
-from loongforge.models import get_support_model_archs
 from loongforge.utils import constants
+
+
+def get_support_model_archs(*args, **kwargs):
+    """Lazy import wrapper to avoid circular import with loongforge.models."""
+    from loongforge.models import get_support_model_archs as _fn
+    return _fn(*args, **kwargs)
 
 
 def loongforge_extra_train_args_provider(parser: argparse.ArgumentParser):
@@ -865,6 +870,30 @@ def _add_extra_video_args(parser):
 # Training Arguments
 # =============================================================================
 
+def _extend_cuda_graph_scope_choices(parser: argparse.ArgumentParser):
+    """Add ``'per_microbatch'`` to the choices of Megatron's ``--cuda-graph-scope``.
+
+    Avoids patching the upstream Megatron parser. Looks up the action by its
+    option string and mutates its ``choices``/``help`` in place. Silently
+    no-ops if the upstream definition has changed and the action can't be
+    found, so we never break parsing.
+    """
+    extra_help = (
+        ' "per_microbatch" scope (LoongForge extension) captures one CUDA graph per '
+        'micro-batch with eager RNG between sub-graphs for bit-exact '
+        'alignment with pure eager. Only supported with --cuda-graph-impl=local.'
+    )
+    for action in parser._actions:
+        if "--cuda-graph-scope" in getattr(action, "option_strings", ()):
+            choices = list(action.choices or [])
+            if "per_microbatch" not in choices:
+                choices.append("per_microbatch")
+                action.choices = choices
+            if action.help and "per_microbatch" not in action.help:
+                action.help = action.help.rstrip() + extra_help
+            return
+
+
 def _add_extra_training_args(parser: argparse.ArgumentParser):
     """Add arguments for training configuration.
     
@@ -933,6 +962,27 @@ def _add_extra_training_args(parser: argparse.ArgumentParser):
         help="[DEPRECATED] This flag is ignored. Variable sequence length support "
              "is now automatic. Default: False"
     )
+
+    group.add_argument(
+        "--cuda-graph-pad-length",
+        type=int,
+        default=None,
+        dest="cuda_graph_pad_length",
+        help="Fixed sequence length for CUDA graph mode. "
+             "When set (e.g. --cuda-graph-pad-length 220), the data collator pads "
+             "all token sequences to this length (padding='max_length', truncation=True) "
+             "so all batches have identical tensor shapes — a prerequisite for CUDA graph "
+             "capture. When None (default), dynamic padding is used. "
+             "Should be set to a value slightly larger than the maximum actual token "
+             "length in the dataset to minimize wasted computation. "
+             "NOTE: currently only consumed by the groot SFT pipeline "
+             "(Gr00tN1d6DataCollator); other model pipelines ignore this flag.",
+    )
+
+    # Extend Megatron's --cuda-graph-scope to accept "per_microbatch" without patching
+    # the upstream parser. Mutates the already-registered action's choices/help
+    # in place (this provider runs after add_megatron_arguments).
+    _extend_cuda_graph_scope_choices(parser)
 
     # EMA (Exponential Moving Average) arguments
     group.add_argument(

--- a/loongforge/train/embodied/sft_groot.py
+++ b/loongforge/train/embodied/sft_groot.py
@@ -332,11 +332,22 @@ def get_batch(data_iterator):
     return tree_map(lambda x: x.to(device, non_blocking=True) if torch.is_tensor(x) else x, batch)
 
 
+# Module-level flag: when True, loss_func skips NCCL all_reduce (used during
+# CUDA graph capture/replay where NCCL ops are unreliable).
+_SKIP_LOSS_ALLREDUCE = False
+
+
 def loss_func(local_loss_dict: dict, output_tensor: torch.Tensor):
     """Reduce loss across data-parallel ranks and surface useful metrics."""
     loss = output_tensor.float()
-    averaged_loss = average_losses_across_data_parallel_group([loss])
-    loss_reduced = {"loss": averaged_loss[0]}
+
+    if _SKIP_LOSS_ALLREDUCE:
+        # During graph capture/replay, store raw per-GPU loss without NCCL.
+        # The graph wrapper will all_reduce after replay.
+        loss_reduced = {"loss": loss.clone().detach()}
+    else:
+        averaged_loss = average_losses_across_data_parallel_group([loss])
+        loss_reduced = {"loss": averaged_loss[0]}
 
     if local_loss_dict and "loss_per_dim" in local_loss_dict:
         # Megatron's reduction expects scalar or 2-element tensors. Collapse per-dim losses to a scalar mean.
@@ -402,9 +413,10 @@ def forward_step(data_iterator, model):
         # The model returns a dict with 'loss' key
         output_loss = output["loss"]
 
-    # Scale by data parallel size so total_inputs reflects global batch tokens
+    # Scale by data parallel size so total_inputs reflects global batch tokens.
+    # Use CPU tensor to avoid CUDA allocation during CUDA graph capture.
     dp_world_size = mpu.get_data_parallel_world_size(with_context_parallel=False)
-    output["total_inputs"] = torch.tensor(total_tokens * dp_world_size, dtype=torch.float, device=output_loss.device)
+    output["total_inputs"] = torch.tensor(total_tokens * dp_world_size, dtype=torch.float)
     return output_loss, partial(loss_func, output)
 
 
@@ -544,6 +556,7 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
         policy_cfg=preprocessor_cfg,
         dataset_stats=dataset_stats,
         dataset=base_dataset,
+        max_length=getattr(args, "cuda_graph_pad_length", None),
     )
 
     # Optional debug hook: force the first sample index to match a reference run (e.g., lerobot).
@@ -575,6 +588,17 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
         )
         shuffle = False
 
+    # Seed for reproducible dataloader ordering.
+    run_seed = args.seed if args.seed is not None else 42
+    data_loader_generator = torch.Generator().manual_seed(run_seed)
+
+    def worker_init_fn(worker_id):
+        """Set per-worker seed derived from the run seed."""
+        worker_seed = run_seed + worker_id
+        np.random.seed(worker_seed)
+        random.seed(worker_seed)
+        torch.manual_seed(worker_seed)
+
     dataloader = torch.utils.data.DataLoader(
         base_dataset,
         num_workers=args.num_workers,
@@ -584,6 +608,8 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
         pin_memory=config.device == "cuda",
         drop_last=False,
         prefetch_factor=2 if args.num_workers > 0 else None,
+        worker_init_fn=worker_init_fn if args.num_workers > 0 else None,
+        generator=data_loader_generator,
     )
 
     def _prefetch_preprocess_iter(dl_iter, prefetch_count=2):
@@ -618,6 +644,32 @@ def train_valid_test_datasets_provider(train_val_test_num_samples):
 def default_sft_trainer(train_args):
     """Megatron-FSDP trainer for groot SFT."""
     _ensure_megatron_defaults(train_args)
+
+    # Validate that --cuda-graph-pad-length is set when using full_iteration scope.
+    # Without padding, _graph_safe_unpad_and_attend may access packed tensors OOB during capture.
+    if (getattr(train_args, 'cuda_graph_impl', 'none') == 'local' and
+            getattr(train_args, 'cuda_graph_scope', 'full') == 'full_iteration'):
+        if getattr(train_args, 'cuda_graph_pad_length', None) is None:
+            raise ValueError(
+                "--cuda-graph-pad-length must be set when using "
+                "--cuda-graph-scope=full_iteration. Without padding tokens, "
+                "_graph_safe_unpad_and_attend may access packed tensors out of "
+                "bounds during CUDA graph capture."
+            )
+
+    # Register full-iteration CUDA graph wrapper for this model family.
+    from loongforge.train.training_utils import (
+        register_full_iteration_graph_wrapper,
+        register_per_microbatch_graph_wrapper,
+    )
+    from loongforge.models.embodied.groot_n1_6.modules.groot_full_iteration_graph import (
+        GrootFullIterationGraph,
+    )
+    from loongforge.models.embodied.groot_n1_6.modules.groot_per_microbatch_graph import (
+        GrootPerMicrobatchGraph,
+    )
+    register_full_iteration_graph_wrapper("groot_n1_6", GrootFullIterationGraph)
+    register_per_microbatch_graph_wrapper("groot_n1_6", GrootPerMicrobatchGraph)
 
     trainer = MegatronTrainer(
         train_args=train_args,

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -55,7 +55,6 @@ from megatron.core.distributed import (
     DistributedDataParallelConfig,
     TorchFullyShardedDataParallelConfig,
 )
-from megatron.core.full_cuda_graph import FullCudaGraphWrapper
 from megatron.core.transformer.cuda_graphs import TECudaGraphHelper
 
 try:
@@ -161,6 +160,42 @@ except ImportError:
     HAS_INSPECTOR = False
 
 stimer = StragglerDetector()
+
+
+# ---------------------------------------------------------------------------
+# Full-iteration CUDA graph wrapper registry.
+# Models register their wrapper class via register_full_iteration_graph_wrapper()
+# during trainer construction; training_utils.train() looks up the wrapper here.
+# ---------------------------------------------------------------------------
+_FULL_ITER_GRAPH_REGISTRY: dict[str, type] = {}
+
+
+def register_full_iteration_graph_wrapper(model_name: str, wrapper_cls: type):
+    """Register a full-iteration CUDA graph wrapper for a given model."""
+    _FULL_ITER_GRAPH_REGISTRY[model_name] = wrapper_cls
+
+
+def get_full_iteration_graph_wrapper(model_name: str):
+    """Look up a registered full-iteration graph wrapper, or None."""
+    return _FULL_ITER_GRAPH_REGISTRY.get(model_name)
+
+
+# ---------------------------------------------------------------------------
+# Per-microbatch CUDA graph wrapper registry.
+# Models register their wrapper class via register_per_microbatch_graph_wrapper()
+# during trainer construction; training_utils.train() looks up the wrapper here.
+# ---------------------------------------------------------------------------
+_PER_MICROBATCH_GRAPH_REGISTRY: dict[str, type] = {}
+
+
+def register_per_microbatch_graph_wrapper(model_name: str, wrapper_cls: type):
+    """Register a per-microbatch CUDA graph wrapper for a given model."""
+    _PER_MICROBATCH_GRAPH_REGISTRY[model_name] = wrapper_cls
+
+
+def get_per_microbatch_graph_wrapper(model_name: str):
+    """Look up a registered per-microbatch CUDA graph wrapper, or None."""
+    return _PER_MICROBATCH_GRAPH_REGISTRY.get(model_name)
 
 
 def is_hf_checkpoint(load_path):
@@ -2435,12 +2470,43 @@ def train(
     num_microbatches = get_num_microbatches()
     eval_duration = 0.0
     eval_iterations = 0
-    # Wrap forward_backward_func for Full iteration CUDA graph
     forward_backward_func = get_forward_backward_func()
-    if args.cuda_graph_impl == "local" and args.cuda_graph_scope == "full_iteration":
-        forward_backward_func = FullCudaGraphWrapper(
-            forward_backward_func, cuda_graph_warmup_steps=args.cuda_graph_warmup_steps
+
+    # Full-iteration CUDA graph: wraps forward_backward_func when enabled.
+    # Wrapper class is registered by model-specific trainer (e.g. sft_groot.py).
+    # If no model-specific wrapper is registered, fall back to Megatron's
+    # FullCudaGraphWrapper (simpler, no loss-allreduce suppression or self-heal).
+    if (getattr(args, "cuda_graph_impl", "none") == "local" and
+            getattr(args, "cuda_graph_scope", "full") == "full_iteration"):
+        wrapper_cls = get_full_iteration_graph_wrapper(
+            getattr(args, "model_family", ""))
+        if wrapper_cls is None:
+            from megatron.core.full_cuda_graph import FullCudaGraphWrapper
+            wrapper_cls = FullCudaGraphWrapper
+        forward_backward_func = wrapper_cls(
+            forward_backward_func,
+            cuda_graph_warmup_steps=getattr(args, "cuda_graph_warmup_steps", 3),
         )
+        print_rank_0(f"[{wrapper_cls.__name__}] Enabled full-iteration CUDA graph")
+
+    # Per-microbatch CUDA graph mode: one sub-graph per microbatch with
+    # externalized RNG. Beta.sample + torch.randn run eagerly before each
+    # replay, achieving bit-exact loss alignment with pure eager at
+    # full_iteration performance.
+    # Wrapper class is registered by model-specific trainer (e.g. sft_groot.py).
+    if (getattr(args, "cuda_graph_impl", "none") == "local" and
+            getattr(args, "cuda_graph_scope", "full") == "per_microbatch"):
+        wrapper_cls = get_per_microbatch_graph_wrapper(
+            getattr(args, "model_family", ""))
+        if wrapper_cls is not None:
+            forward_backward_func = wrapper_cls(
+                forward_backward_func,
+                cuda_graph_warmup_steps=getattr(args, "cuda_graph_warmup_steps", 3),
+            )
+            print_rank_0(
+                f"[{wrapper_cls.__name__}] Per-microbatch CUDA graph mode enabled. "
+                "RNG externalized for bit-exact alignment with pure eager."
+            )
 
     prof = None
     if (


### PR DESCRIPTION
- Add common CUDA graph base (`cuda_graph_base.py`, `cuda_graph_config.py`)
- Add full-iteration and per-microbatch graph wrappers under `groot_n1_6/modules/`
- Wire CUDA graph support into `modeling_groot`, eagle3 VL / siglip2 modules
- Update `sft_groot` training entry, `arguments`, `training_utils` and `processor`
- Add `--cuda-graph-pad-length` and extend `--cuda-graph-scope` with
  `per_microbatch` choice (LoongForge extension; opt-in, no example default)

Resolves https://github.com/baidu-baige/LoongForge/issues/49