### PR TITLE
[Task] Wan2.2 data packing training support

### DIFF
--- a/docs/source/wan_tutorial/index.rst
+++ b/docs/source/wan_tutorial/index.rst
@@ -1,0 +1,8 @@
+Diffusion Training Tutorial
+============================
+
+.. toctree::
+   :maxdepth: 2
+
+   quick_start_wan_training
+   wan_packing

--- a/docs/source/wan_tutorial/quick_start_wan_training.md
+++ b/docs/source/wan_tutorial/quick_start_wan_training.md
@@ -99,7 +99,7 @@ Each `.pth` file contains the following three keys:
 Edit `examples/wan/convert_wan2.2.sh` (section `hg2mcore`):
 - `--checkpoint_path` → source HF folder (`high_noise_model` / `low_noise_model`)
 - `--save_path` → target Megatron checkpoint folder
-- `--tp`, `--pp`, `--num_layers`, `--num_checkpoints` → match your conversion setup
+- `--num_layers`, `--num_checkpoints` → match your conversion setup
 
 Run from `examples/wan` because the script invokes conversion utilities with relative paths:
 ```bash
@@ -137,6 +137,7 @@ CP_RING_DEGREE = CP_SIZE / CP_ULYSSES_DEGREE
 - `DATASET_PATH` → output path from Section 1 (e.g. `./data/preprocessed`)
 - `--context-parallel-size 4`
 - `--context-parallel-ulysses-degree 2`
+- Optional packing: add `--packing-sft-data` to enable WAN sample packing, and tune `--packing-buffer-size` for the packing buffer size.
 
 **Step-2** Start  
 - Single-node:  

--- a/docs/source/wan_tutorial/wan_packing.md
+++ b/docs/source/wan_tutorial/wan_packing.md
@@ -1,0 +1,52 @@
+# Wan2.2 Packing Training
+
+Wan2.2 packing concatenates multiple variable-length video samples into one packed training sequence. It keeps per-sample attention and loss boundaries through THD `PackedSeqParams`, so packed samples do not attend to each other and padding tokens do not contribute to loss.
+
+## When to Use
+
+Enable packing when your Wan2.2 training set contains videos or text prompts with noticeably different lengths. Packing reduces wasted computation from padding and is compatible with context parallel training.
+
+Supported context-parallel modes:
+- No CP: `CP_SIZE=1`
+- Ring CP: `CP_SIZE>1`, `CP_ULYSSES_DEGREE=1`
+- Ulysses CP: `CP_SIZE=CP_ULYSSES_DEGREE`
+- Hybrid Ring + Ulysses: `CP_SIZE>CP_ULYSSES_DEGREE>1`
+
+## Data Requirements
+
+Use the same preprocessed Wan dataset format as normal training. Each sample should provide:
+- `input_latents`: video latent tensor
+- `y`: optional image-conditioning latent
+- `context`: text embedding
+- `seed`: sample seed used for deterministic noise and timestep generation
+- `grid_sizes`: optional latent patch grid; when missing, LoongForge derives it from `input_latents`
+
+Packing supports variable-length samples. For CP training, each sample in a packed bin is padded to the per-sample CP split boundary before the bin is concatenated.
+
+## How to Enable
+
+Add the packing flags to the Wan pretrain script:
+
+```bash
+--packing-sft-data
+--packing-buffer-size 512
+```
+
+Example launch:
+
+```bash
+cd examples/wan
+CUDA_VISIBLE_DEVICES=0,1,2,3 \
+CP_SIZE=4 \
+CP_ULYSSES_DEGREE=2 \
+bash pretrain_wan2.2_i2v_a14b.sh
+```
+
+`--packing-buffer-size` controls how many samples are buffered before forming packed bins. Larger buffers can improve packing density but use more host memory.
+
+## Notes and Limitations
+
+- Packing currently uses `micro_batch_size=1`; the validator enforces this when packing is enabled.
+- The packed attention path uses THD metadata and may not be bitwise identical to non-packed dense attention, but loss should stay numerically close.
+- Keep `seq_length` large enough for one packed bin. In CP mode, LoongForge aligns the effective sequence length to the required CP split boundary.
+- For accuracy checks, compare the first several training iterations against a packing-off run with the same data order and do not change `train-iters` between the two runs.

--- a/examples/wan/pretrain_wan2.2_i2v_a14b.sh
+++ b/examples/wan/pretrain_wan2.2_i2v_a14b.sh
@@ -102,6 +102,8 @@ TRAINING_ARGS=(
     --no-load-rng
     --no-strict-fsdp-dtensor-load
     --finetune
+    # --packing-sft-data
+    # --packing-buffer-size ${PACKING_BUFFER_SIZE:-512}
     ${RECOMPUTE_ARGS[@]}
 )
 

--- a/loongforge/data/video/packed_dataset.py
+++ b/loongforge/data/video/packed_dataset.py
@@ -1,0 +1,336 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packed dataset for sequence packing in diffusion model training.
+
+Patchify variable-length latents, pad text to fixed
+max length, apply CP padding, then concatenate across samples in each bin.
+"""
+
+from typing import List, Dict, Any
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+from torch.utils.data import IterableDataset
+from megatron.core import parallel_state
+
+from loongforge.utils import get_args, print_rank_0
+from loongforge.data.video.latent_dataset import TensorDataset
+from loongforge.data.video.sequence_packing_utils import first_fit
+
+
+
+def _get_cp_sample_alignment(cp_world_size: int) -> int:
+    """Return per-sample sequence alignment required by CP split."""
+    return cp_world_size * 2 if cp_world_size > 1 else 1
+
+
+# ---------------------------------------------------------------------------
+# Patchify utilities (Wan: patch_size=(1,2,2))
+# ---------------------------------------------------------------------------
+
+def _patchify_latent(latent: torch.Tensor, patch_size=(1, 2, 2)):
+    """Convert [C, T, H, W] → [num_patches, pT * pH * pW * C].
+
+    Output is in **(pT, pH, pW, C)** order within each patch.
+    This matches the ``unpatchify`` / ``Head`` output layout used for
+    training-target comparison in the loss function.
+    """
+    c, t, h, w = latent.shape
+    pT, pH, pW = patch_size
+    assert t % pT == 0 and h % pH == 0 and w % pW == 0, (
+        f"Spatial dims ({t},{h},{w}) must be divisible by patch_size {patch_size}"
+    )
+    fP, hP, wP = t // pT, h // pH, w // pW
+    # (c, fP, pT, hP, pH, wP, pW) → (fP, hP, wP, pT, pH, pW, c)
+    x = latent.reshape(c, fP, pT, hP, pH, wP, pW)
+    x = x.permute(1, 3, 5, 2, 4, 6, 0).contiguous()
+    num_patches = fP * hP * wP
+    return x.reshape(num_patches, c * pT * pH * pW)
+
+
+def _patchify_for_conv3d(latent: torch.Tensor, patch_size=(1, 2, 2)):
+    """Convert [C, T, H, W] → [num_patches, C * pT * pH * pW].
+
+    Output is in **(C, pT, pH, pW)** order within each patch — the same
+    layout as ``nn.Conv3d(weight).view(out_channels, -1)``.  Use this for
+    model-input patchification so that ``F.linear(x, conv_weight, conv_bias)``
+    is numerically identical to the Conv3d forward pass.
+    """
+    c, t, h, w = latent.shape
+    pT, pH, pW = patch_size
+    assert t % pT == 0 and h % pH == 0 and w % pW == 0, (
+        f"Spatial dims ({t},{h},{w}) must be divisible by patch_size {patch_size}"
+    )
+    fP, hP, wP = t // pT, h // pH, w // pW
+    # (c, fP, pT, hP, pH, wP, pW) → (fP, hP, wP, c, pT, pH, pW)
+    x = latent.reshape(c, fP, pT, hP, pH, wP, pW)
+    x = x.permute(1, 3, 5, 0, 2, 4, 6).contiguous()
+    num_patches = fP * hP * wP
+    return x.reshape(num_patches, c * pT * pH * pW)
+
+
+class PackedDataset(IterableDataset):
+    """A dataset that packs variable-length diffusion samples.
+
+    Each sample's latent is patchified into a 2-D token sequence, text is
+    padded to ``context_max_len``, and optional CP padding is applied.
+    Samples in each bin are concatenated along the sequence dimension.
+    """
+
+    # Wan patch size
+    PATCH_SIZE = (1, 2, 2)
+
+    def __init__(
+        self,
+        data_path: str,
+        steps_per_epoch: int,
+        args,
+        scheduler=None,
+        packing_buffer_size: int = 512,
+        seq_length: int = 8192,
+        dp_rank: int = 0,
+        dp_world_size: int = 1,
+    ):
+        super().__init__()
+        self.data_path = data_path
+        self.steps_per_epoch = steps_per_epoch
+        self.args = args
+        self.scheduler = scheduler
+        self.packing_buffer_size = packing_buffer_size
+        self.seq_length = seq_length
+        self.dp_rank = dp_rank
+        self.dp_world_size = dp_world_size
+
+        self.context_max_len = getattr(args, "context_max_len", 512)
+
+        cp_world_size = parallel_state.get_context_parallel_world_size()
+        self.cp_world_size = cp_world_size
+        self.cp_chunk_factor = _get_cp_sample_alignment(cp_world_size)
+        self.sharding_factor = self.cp_chunk_factor if cp_world_size > 1 else 0
+
+        # Initialize the base dataset
+        self.base_dataset = TensorDataset(data_path, steps_per_epoch)
+
+        # Validate timestep boundaries
+        max_ts = args.max_timestep_boundary
+        min_ts = args.min_timestep_boundary
+        assert 0 <= max_ts <= 1, "max_timestep should range from 0 to 1"
+        assert 0 <= min_ts <= 1, "min_timestep should range from 0 to 1"
+        assert min_ts <= max_ts, f"min_timestep: {min_ts} should <= max_timestep: {max_ts}"
+
+    # ------------------------------------------------------------------
+    # Sequence length helpers
+    # ------------------------------------------------------------------
+
+    def _compute_seq_length(self, sample: Dict[str, Any]) -> int:
+        """Compute video sequence length (num_patches) from input_latents."""
+        input_latents = sample["input_latents"]
+        _, _, latent_frames, latent_height, latent_width = input_latents.shape
+        patch_frames, patch_height, patch_width = self.PATCH_SIZE
+        return (
+            (latent_frames // patch_frames)
+            * (latent_height // patch_height)
+            * (latent_width // patch_width)
+        )
+
+    @staticmethod
+    def _ceil_to_multiple(n: int, m: int) -> int:
+        return ((n + m - 1) // m) * m
+
+    # ------------------------------------------------------------------
+    # Bin packing
+    # ------------------------------------------------------------------
+
+    def _pack_samples(self, samples: List[Dict[str, Any]]) -> List[List[Dict[str, Any]]]:
+        """Pack samples into bins using First-Fit while preserving sample order."""
+        seq_lengths = [self._compute_seq_length(s) for s in samples]
+        if self.sharding_factor > 0:
+            seq_lengths = [self._ceil_to_multiple(length, self.sharding_factor) for length in seq_lengths]
+
+        packed_indices = first_fit(seq_lengths, self.seq_length)
+
+        bins = [[samples[i] for i in idxs] for idxs in packed_indices]
+        return bins
+
+    # ------------------------------------------------------------------
+    # Main iteration
+    # ------------------------------------------------------------------
+
+    def __iter__(self):
+        from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
+
+        scheduler = self.scheduler
+        if scheduler is None:
+            scheduler = FlowMatchScheduler(shift=5, sigma_min=0.0, extra_one_step=True)
+            scheduler.set_timesteps(1000, training=True)
+
+        required_bins = self.steps_per_epoch
+        buffer = []
+        sample_idx = self.dp_rank
+        batch_count = 0
+
+        while batch_count < required_bins:
+            # Fill buffer
+            while len(buffer) < self.packing_buffer_size:
+                wrapped_idx = sample_idx % len(self.base_dataset)
+                buffer.append(self.base_dataset[wrapped_idx])
+                sample_idx += self.dp_world_size
+
+            bins = self._pack_samples(buffer)
+
+            for bin_samples in bins:
+                if batch_count >= required_bins:
+                    return
+                processed = self._process_bin(bin_samples, scheduler)
+                merged = self._merge_samples(processed)
+                batch_count += 1
+                yield merged
+
+            buffer = []
+
+        return
+
+    # ------------------------------------------------------------------
+    # Per-bin processing
+    # ------------------------------------------------------------------
+
+    def _process_bin(self, bin_samples, scheduler):
+        """Process all samples in a bin: patchify, pad, gen noise."""
+        processed = []
+        max_ts = self.args.max_timestep_boundary
+        min_ts = self.args.min_timestep_boundary
+        max_ts_boundary = int(max_ts * scheduler.num_train_timesteps)
+        min_ts_boundary = int(min_ts * scheduler.num_train_timesteps)
+
+        for sample in bin_samples:
+            out = self._process_sample(sample, scheduler, min_ts_boundary, max_ts_boundary)
+            processed.append(out)
+        return processed
+
+    def _process_sample(self, sample, scheduler, min_ts_boundary, max_ts_boundary):
+        """Process a single sample: patchify, pad text, CP pad, gen noise."""
+        result = {}
+
+        # --- 1. Extract latents and y ---
+        input_latents = sample["input_latents"]
+        if input_latents.size(0) == 1:
+            input_latents = input_latents.squeeze(0)
+
+        y = sample.get("y")
+        if y is not None:
+            if y.dim() == 5 and y.size(0) == 1:
+                y = y.squeeze(0)
+
+        # grid_sizes from .pth or computed from latent shape (without y)
+        if "grid_sizes" in sample:
+            grid_sizes = sample["grid_sizes"]
+        else:
+            _, latent_frames, latent_height, latent_width = input_latents.shape
+            patch_frames, patch_height, patch_width = self.PATCH_SIZE
+            grid_sizes = torch.tensor(
+                [
+                    latent_frames // patch_frames,
+                    latent_height // patch_height,
+                    latent_width // patch_width,
+                ],
+                dtype=torch.int32,
+            )
+
+        seq_len_q = int(torch.prod(torch.tensor(grid_sizes.tolist())).item())
+
+        # --- 2. Text padding ---
+        context = sample["context"]  # [1, actual_len, dim]
+        if context.dim() == 3:
+            context = context.squeeze(0)  # [actual_len, dim]
+        actual_text_len = context.shape[0]
+        if actual_text_len < self.context_max_len:
+            context = F.pad(context, (0, 0, 0, self.context_max_len - actual_text_len))
+        elif actual_text_len > self.context_max_len:
+            context = context[:self.context_max_len]
+        seq_len_kv = self.context_max_len
+
+        # --- 3. CP padding ---
+        # Compute padded lengths for CP split planning. Padding is deferred
+        if self.sharding_factor > 0:
+            seq_len_q_padded = self._ceil_to_multiple(seq_len_q, self.sharding_factor)
+            seq_len_kv_padded = self._ceil_to_multiple(seq_len_kv, self.sharding_factor)
+        else:
+            seq_len_q_padded = seq_len_q
+            seq_len_kv_padded = seq_len_kv
+
+        loss_mask = torch.ones(seq_len_q, dtype=torch.float32)
+
+        seed = sample["seed"]
+        rng = np.random.RandomState(seed=seed)
+        noise_np = rng.randn(*input_latents.shape)
+        noise = torch.tensor(noise_np, dtype=input_latents.dtype, device=input_latents.device)
+        rand_int = rng.randint(min_ts_boundary, max_ts_boundary)
+        timestep_id = torch.tensor([rand_int], dtype=torch.long)
+
+        timestep_for_scale = scheduler.timesteps[timestep_id].to(dtype=input_latents.dtype)
+        scale = scheduler.training_weight(timestep_for_scale)
+
+        result["input_latents_raw"] = input_latents
+        result["y_raw"] = y.to(dtype=input_latents.dtype) if y is not None else None
+        result["noise_raw"] = noise
+        result["loss_mask"] = loss_mask.unsqueeze(1)
+        result["context"] = context.unsqueeze(1)
+        result["grid_sizes"] = grid_sizes
+        result["seq_len_q"] = torch.tensor([seq_len_q], dtype=torch.int32)
+        result["seq_len_q_padded"] = torch.tensor([seq_len_q_padded], dtype=torch.int32)
+        result["seq_len_kv"] = torch.tensor([seq_len_kv], dtype=torch.int32)
+        result["seq_len_kv_padded"] = torch.tensor([seq_len_kv_padded], dtype=torch.int32)
+        result["timestep_id"] = timestep_id
+        result["scale"] = scale.reshape(-1)
+        result["seed"] = torch.tensor([seed], dtype=torch.long)
+
+        return result
+
+    def _pad_packed_sequence(self, chunks: List[torch.Tensor], padded_lengths: List[int]) -> torch.Tensor:
+        padded_chunks = []
+        for chunk, padded_length in zip(chunks, padded_lengths):
+            pad_len = padded_length - chunk.shape[0]
+            if pad_len > 0:
+                pad_shape = (pad_len, *chunk.shape[1:])
+                pad = torch.zeros(pad_shape, dtype=chunk.dtype, device=chunk.device)
+                chunk = torch.cat([chunk, pad], dim=0)
+            padded_chunks.append(chunk)
+        return torch.cat(padded_chunks, dim=0)
+
+    # ------------------------------------------------------------------
+    # Merge samples within a bin
+    # ------------------------------------------------------------------
+
+    def _merge_samples(self, bin_samples: List[Dict[str, Any]]) -> Dict[str, Any]:
+        """Merge processed samples into one packed bin."""
+        merged = {}
+
+        merged["input_latents_raw"] = [s["input_latents_raw"] for s in bin_samples]
+        merged["y_raw"] = [s["y_raw"] for s in bin_samples]
+        merged["noise_raw"] = [s["noise_raw"] for s in bin_samples]
+
+        if self.sharding_factor > 0:
+            merged["loss_mask"] = self._pad_packed_sequence(
+                [s["loss_mask"] for s in bin_samples],
+                [s["seq_len_q_padded"].item() for s in bin_samples],
+            )
+            merged["context"] = self._pad_packed_sequence(
+                [s["context"] for s in bin_samples],
+                [s["seq_len_kv_padded"].item() for s in bin_samples],
+            )
+        else:
+            merged["loss_mask"] = torch.cat([s["loss_mask"] for s in bin_samples], dim=0)
+            merged["context"] = torch.cat([s["context"] for s in bin_samples], dim=0)
+
+        merged["grid_sizes"] = torch.stack([s["grid_sizes"] for s in bin_samples], dim=0)
+        merged["seq_len_q"] = torch.cat([s["seq_len_q"] for s in bin_samples])
+        merged["seq_len_q_padded"] = torch.cat([s["seq_len_q_padded"] for s in bin_samples])
+        merged["seq_len_kv"] = torch.cat([s["seq_len_kv"] for s in bin_samples])
+        merged["seq_len_kv_padded"] = torch.cat([s["seq_len_kv_padded"] for s in bin_samples])
+        merged["timestep_id"] = torch.cat([s["timestep_id"] for s in bin_samples])
+        merged["scale"] = torch.cat([s["scale"] for s in bin_samples])
+        merged["seed"] = torch.stack([s["seed"] for s in bin_samples])
+
+        return merged

--- a/loongforge/data/video/sequence_packing_utils.py
+++ b/loongforge/data/video/sequence_packing_utils.py
@@ -1,0 +1,34 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sequence packing utilities for diffusion models"""
+
+from typing import List
+
+
+def first_fit(seqlens: List[int], pack_size: int) -> List[List[int]]:
+    """
+    Packs sequences of varying lengths into bins using the First-Fit algorithm.
+
+    Args:
+      seqlens: A list of integers, representing the lengths of the sequences to be packed.
+      pack_size: The maximum capacity of each bin.
+
+    Returns:
+      A list of lists, where each inner list represents a bin and contains the indices
+        of the sequences assigned to that bin.
+    """
+    bins = []  # each bin: {"indices": [...], "used": total_size}
+    for i, s in enumerate(seqlens):
+        # Find first bin that fits
+        found = False
+        for bin_info in bins:
+            if bin_info["used"] + s <= pack_size:
+                bin_info["indices"].append(i)
+                bin_info["used"] += s
+                found = True
+                break
+        if not found:  # open a new bin
+            bins.append({"indices": [i], "used": s})
+    # Return only the indices
+    return [bin_info["indices"] for bin_info in bins]

--- a/loongforge/models/diffusion/wan/wan_attention.py
+++ b/loongforge/models/diffusion/wan/wan_attention.py
@@ -4,6 +4,7 @@
 """attention module"""
 
 import torch
+import torch.distributed as dist
 
 from copy import deepcopy
 from megatron.core.transformer.attention import (
@@ -17,6 +18,7 @@ from megatron.core.transformer.transformer_config import TransformerConfig
 from megatron.core.transformer.spec_utils import ModuleSpec, build_module
 from megatron.core.transformer.enums import AttnMaskType
 from megatron.core import InferenceParams, parallel_state, tensor_parallel
+from megatron.core.packed_seq_params import PackedSeqParams
 import torch.nn as nn
 
 try:
@@ -27,6 +29,55 @@ try:
 except ImportError:
     HAVE_TE = False
     SplitAlongDim = None
+
+
+# [Packing][CP][Ulysses] All-to-all for THD format: scatter one tensor
+# dimension and gather another while preserving autograd through the inverse op.
+def _thd_all_to_all(input_: torch.Tensor, scatter_dim: int, gather_dim: int, group: dist.ProcessGroup):
+    world_size = dist.get_world_size(group)
+    if world_size == 1:
+        return input_
+    input_list = [t.contiguous() for t in torch.tensor_split(input_, world_size, scatter_dim)]
+    output_list = [torch.empty_like(input_list[0]) for _ in range(world_size)]
+    dist.all_to_all(output_list, input_list, group=group)
+    return torch.cat(output_list, dim=gather_dim).contiguous()
+
+
+class _THDSeqAllToAll(torch.autograd.Function):
+    @staticmethod
+    def forward(ctx, input_, scatter_dim, gather_dim, group):
+        """Run THD sequence all-to-all in the forward pass."""
+        ctx.group = group
+        ctx.scatter_dim = scatter_dim
+        ctx.gather_dim = gather_dim
+        return _thd_all_to_all(input_, scatter_dim, gather_dim, group)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Run inverse THD sequence all-to-all for gradient propagation."""
+        return _thd_all_to_all(grad_output, ctx.gather_dim, ctx.scatter_dim, ctx.group), None, None, None
+
+
+def _thd_compact(x, cu_actual, cu_padded):
+    """Remove inter-sample padding from a THD tensor, returning compact tensor and indices."""
+    num_sequences = cu_actual.shape[0] - 1
+    indices = []
+    for sequence_index in range(num_sequences):
+        start_padded = cu_padded[sequence_index].item()
+        actual_len = cu_actual[sequence_index + 1].item() - cu_actual[sequence_index].item()
+        for token_offset in range(actual_len):
+            indices.append(start_padded + token_offset)
+    indices_t = torch.tensor(indices, dtype=torch.long, device=x.device)
+    return x.index_select(0, indices_t), indices_t
+
+
+def _thd_expand(x_compact, indices, total_padded_len, extra_dims):
+    """Scatter compact attention output back to padded positions."""
+    out = torch.zeros(
+        total_padded_len, *extra_dims, dtype=x_compact.dtype, device=x_compact.device
+    )
+    out.index_copy_(0, indices, x_compact)
+    return out
 
 
 class WanSelfAttention(SelfAttention):
@@ -40,14 +91,11 @@ class WanSelfAttention(SelfAttention):
     def __init__(self, config, submodules, **kwargs):
         super().__init__(config, submodules, **kwargs)
 
-        q_hidden_size = self.num_attention_heads_per_partition * self.hidden_size_per_attention_head
-        k_hidden_size = self.num_query_groups_per_partition * self.hidden_size_per_attention_head
-
         # Override q_layernorm and k_layernorm with custom ones if specified
         if submodules.q_layernorm is not None:
             self.q_layernorm = build_module(
                 submodules.q_layernorm,
-                hidden_size=q_hidden_size,
+                hidden_size=self.config.hidden_size,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
@@ -56,7 +104,7 @@ class WanSelfAttention(SelfAttention):
         if submodules.k_layernorm is not None:
             self.k_layernorm = build_module(
                 submodules.k_layernorm,
-                hidden_size=k_hidden_size,
+                hidden_size=self.config.hidden_size,
                 config=self.config,
                 eps=self.config.layernorm_epsilon,
             )
@@ -187,6 +235,77 @@ class WanSelfAttention(SelfAttention):
         # ==================================
         # core attention computation
         # ==================================
+        # Squeeze batch dim for THD packed format (TE requires 3D: [S, H, D])
+        thd_mode = (packed_seq_params is not None and
+                    getattr(packed_seq_params, 'qkv_format', None) == 'thd')
+        if thd_mode and query.dim() == 4:
+            query = query.squeeze(1)   # [sq, b, np, hn] -> [sq, np, hn]
+            key = key.squeeze(1)
+            value = value.squeeze(1)
+
+        saved_cp_group = None
+        saved_cp_global_ranks = None
+        saved_cp_comm_type = None
+        saved_num_gqa_groups = None
+        saved_num_attn_heads = None
+        ulysses_group = None
+        compact_indices = None
+        total_padded_len = None
+        if thd_mode and hasattr(self.core_attention, 'cp_group') and self.core_attention.cp_group is not None:
+            cp_group = self.core_attention.cp_group
+            is_hierarchical = isinstance(cp_group, list)
+            is_ulysses = getattr(self.core_attention, 'cp_comm_type', 'p2p') in ('a2a', 'all_to_all')
+            if is_hierarchical:
+                # [Packing][CP][Ulysses] Do Ulysses a2a outside TE, keep TE ring on the ring subgroup.
+                saved_cp_group = cp_group
+                ulysses_group = cp_group[0]
+                ring_group = cp_group[1]
+                self.core_attention.cp_group = ring_group
+                saved_cp_global_ranks = getattr(self.core_attention, 'cp_global_ranks', None)
+                if saved_cp_global_ranks is not None:
+                    self.core_attention.cp_global_ranks = dist.get_process_group_ranks(ring_group)
+                saved_cp_comm_type = getattr(self.core_attention, 'cp_comm_type', None)
+                self.core_attention.cp_comm_type = "p2p"
+            elif is_ulysses:
+                # [Packing][CP][Ulysses] Pure Ulysses uses external a2a and no TE ring.
+                saved_cp_group = cp_group
+                ulysses_group = cp_group
+                self.core_attention.cp_group = None
+
+        attn_packed_seq_params = packed_seq_params
+        if thd_mode:
+            cu_q = packed_seq_params.cu_seqlens_q
+            cu_q_padded = packed_seq_params.cu_seqlens_q_padded
+            has_padding = (cu_q_padded is not None
+                           and not torch.equal(cu_q_padded[:-1], cu_q[:-1]))
+            if has_padding:
+                total_padded_len = query.shape[0]
+                query, compact_indices = _thd_compact(query, cu_q, cu_q_padded)
+                key, _ = _thd_compact(key, cu_q, cu_q_padded)
+                value, _ = _thd_compact(value, cu_q, cu_q_padded)
+                compact_cu = cu_q - cu_q[0]
+                max_seqlen = (cu_q[1:] - cu_q[:-1]).max().item()
+                attn_packed_seq_params = PackedSeqParams(
+                    qkv_format="thd",
+                    cu_seqlens_q=compact_cu,
+                    cu_seqlens_kv=compact_cu,
+                    max_seqlen_q=max_seqlen,
+                    max_seqlen_kv=max_seqlen,
+                )
+
+        if ulysses_group is not None:
+            # [Packing][CP][Ulysses] THD layout is [S, H, D]: scatter heads, gather sequence.
+            query = _THDSeqAllToAll.apply(query, 1, 0, ulysses_group)
+            key = _THDSeqAllToAll.apply(key, 1, 0, ulysses_group)
+            value = _THDSeqAllToAll.apply(value, 1, 0, ulysses_group)
+            ulysses_degree = dist.get_world_size(ulysses_group)
+            saved_num_gqa_groups = getattr(self.core_attention, 'num_gqa_groups_per_partition', None)
+            saved_num_attn_heads = getattr(self.core_attention, 'num_attention_heads', None)
+            if saved_num_gqa_groups is not None:
+                self.core_attention.num_gqa_groups_per_partition = saved_num_gqa_groups // ulysses_degree
+            if saved_num_attn_heads is not None:
+                self.core_attention.num_attention_heads = saved_num_attn_heads // ulysses_degree
+
         if self.checkpoint_core_attention and self.training:
             core_attn_out = self._checkpointed_attention_forward(
                 query,
@@ -195,7 +314,7 @@ class WanSelfAttention(SelfAttention):
                 attention_mask,
                 attn_mask_type=attn_mask_type,
                 attention_bias=attention_bias,
-                packed_seq_params=packed_seq_params,
+                packed_seq_params=attn_packed_seq_params,
             )
         else:
             core_attn_out = self.core_attention(
@@ -205,8 +324,33 @@ class WanSelfAttention(SelfAttention):
                 attention_mask,
                 attn_mask_type=attn_mask_type,
                 attention_bias=attention_bias,
-                packed_seq_params=packed_seq_params,
+                packed_seq_params=attn_packed_seq_params,
             )
+
+        if ulysses_group is not None:
+            # [Packing][CP][Ulysses] Invert pre-attention a2a: scatter sequence, gather heads.
+            core_attn_out = _THDSeqAllToAll.apply(core_attn_out, 0, 1, ulysses_group)
+
+        if compact_indices is not None:
+            core_attn_out = _thd_expand(
+                core_attn_out, compact_indices, total_padded_len, core_attn_out.shape[1:]
+            )
+
+        if saved_cp_group is not None:
+            self.core_attention.cp_group = saved_cp_group
+        if saved_cp_global_ranks is not None:
+            self.core_attention.cp_global_ranks = saved_cp_global_ranks
+        if saved_cp_comm_type is not None:
+            self.core_attention.cp_comm_type = saved_cp_comm_type
+        if saved_num_gqa_groups is not None:
+            self.core_attention.num_gqa_groups_per_partition = saved_num_gqa_groups
+        if saved_num_attn_heads is not None:
+            self.core_attention.num_attention_heads = saved_num_attn_heads
+
+        # Unsqueeze batch dim back for THD mode
+        if thd_mode and core_attn_out.dim() == 2:
+            core_attn_out = core_attn_out.unsqueeze(1)  # [sq, h] -> [sq, b, h]
+
         # =================
         # Output. [sq, b, h]
         # =================
@@ -297,6 +441,85 @@ class WanCrossAttention(CrossAttention):
             )
         )
 
+        # Squeeze batch dim for THD packed format (TE requires 3D: [S, H, D])
+        thd_mode = (packed_seq_params is not None and
+                    getattr(packed_seq_params, 'qkv_format', None) == 'thd')
+        if thd_mode and query.dim() == 4:
+            query = query.squeeze(1)
+            key = key.squeeze(1)
+            value = value.squeeze(1)
+
+        saved_cp_group = None
+        saved_cp_global_ranks = None
+        saved_cp_comm_type = None
+        saved_num_gqa_groups = None
+        saved_num_attn_heads = None
+        ulysses_group = None
+        compact_indices_q = None
+        total_padded_len_q = None
+        if thd_mode and hasattr(self.core_attention, 'cp_group') and self.core_attention.cp_group is not None:
+            cp_group = self.core_attention.cp_group
+            is_hierarchical = isinstance(cp_group, list)
+            is_ulysses = getattr(self.core_attention, 'cp_comm_type', 'p2p') in ('a2a', 'all_to_all')
+            if is_hierarchical:
+                # [Packing][CP][Ulysses] Do Ulysses a2a outside TE, keep TE ring on the ring subgroup.
+                saved_cp_group = cp_group
+                ulysses_group = cp_group[0]
+                ring_group = cp_group[1]
+                self.core_attention.cp_group = ring_group
+                saved_cp_global_ranks = getattr(self.core_attention, 'cp_global_ranks', None)
+                if saved_cp_global_ranks is not None:
+                    self.core_attention.cp_global_ranks = dist.get_process_group_ranks(ring_group)
+                saved_cp_comm_type = getattr(self.core_attention, 'cp_comm_type', None)
+                self.core_attention.cp_comm_type = "p2p"
+            elif is_ulysses:
+                # [Packing][CP][Ulysses] Pure Ulysses uses external a2a and no TE ring.
+                saved_cp_group = cp_group
+                ulysses_group = cp_group
+                self.core_attention.cp_group = None
+
+        attn_packed_seq_params = packed_seq_params
+        if thd_mode:
+            cu_q = packed_seq_params.cu_seqlens_q
+            cu_q_padded = packed_seq_params.cu_seqlens_q_padded
+            cu_kv = packed_seq_params.cu_seqlens_kv
+            cu_kv_padded = packed_seq_params.cu_seqlens_kv_padded
+            has_q_padding = (cu_q_padded is not None
+                             and not torch.equal(cu_q_padded[:-1], cu_q[:-1]))
+            has_kv_padding = (cu_kv_padded is not None
+                              and not torch.equal(cu_kv_padded[:-1], cu_kv[:-1]))
+            if has_q_padding or has_kv_padding:
+                total_padded_len_q = query.shape[0]
+                if has_q_padding:
+                    query, compact_indices_q = _thd_compact(query, cu_q, cu_q_padded)
+                if has_kv_padding:
+                    key, _ = _thd_compact(key, cu_kv, cu_kv_padded)
+                    value, _ = _thd_compact(value, cu_kv, cu_kv_padded)
+                compact_cu_q = cu_q - cu_q[0] if has_q_padding else cu_q
+                compact_cu_kv = cu_kv - cu_kv[0] if has_kv_padding else cu_kv
+                max_seqlen_q = (cu_q[1:] - cu_q[:-1]).max().item()
+                max_seqlen_kv = (cu_kv[1:] - cu_kv[:-1]).max().item()
+                attn_packed_seq_params = PackedSeqParams(
+                    qkv_format="thd",
+                    cu_seqlens_q=compact_cu_q,
+                    cu_seqlens_kv=compact_cu_kv,
+                    max_seqlen_q=max_seqlen_q,
+                    max_seqlen_kv=max_seqlen_kv,
+                )
+
+        if ulysses_group is not None:
+            # [Packing][CP][Ulysses] THD layout is [S, H, D]: scatter heads, gather sequence.
+            query = _THDSeqAllToAll.apply(query, 1, 0, ulysses_group)
+            key = _THDSeqAllToAll.apply(key, 1, 0, ulysses_group)
+            value = _THDSeqAllToAll.apply(value, 1, 0, ulysses_group)
+            ulysses_degree = dist.get_world_size(ulysses_group)
+            saved_num_gqa_groups = getattr(self.core_attention, 'num_gqa_groups_per_partition', None)
+            saved_num_attn_heads = getattr(self.core_attention, 'num_attention_heads', None)
+            if saved_num_gqa_groups is not None:
+                self.core_attention.num_gqa_groups_per_partition = saved_num_gqa_groups // ulysses_degree
+            if saved_num_attn_heads is not None:
+                self.core_attention.num_attention_heads = saved_num_attn_heads // ulysses_degree
+
         core_attn_out = self.core_attention(
             query,
             key,
@@ -304,8 +527,32 @@ class WanCrossAttention(CrossAttention):
             attention_mask,
             attn_mask_type=attn_mask_type,
             attention_bias=attention_bias,
-            packed_seq_params=packed_seq_params,
+            packed_seq_params=attn_packed_seq_params,
         )
+
+        if ulysses_group is not None:
+            # [Packing][CP][Ulysses] Invert pre-attention a2a: scatter sequence, gather heads.
+            core_attn_out = _THDSeqAllToAll.apply(core_attn_out, 0, 1, ulysses_group)
+
+        if compact_indices_q is not None:
+            core_attn_out = _thd_expand(
+                core_attn_out, compact_indices_q, total_padded_len_q, core_attn_out.shape[1:]
+            )
+
+        if saved_cp_group is not None:
+            self.core_attention.cp_group = saved_cp_group
+        if saved_cp_global_ranks is not None:
+            self.core_attention.cp_global_ranks = saved_cp_global_ranks
+        if saved_cp_comm_type is not None:
+            self.core_attention.cp_comm_type = saved_cp_comm_type
+        if saved_num_gqa_groups is not None:
+            self.core_attention.num_gqa_groups_per_partition = saved_num_gqa_groups
+        if saved_num_attn_heads is not None:
+            self.core_attention.num_attention_heads = saved_num_attn_heads
+
+        # Unsqueeze batch dim back for THD mode
+        if thd_mode and core_attn_out.dim() == 2:
+            core_attn_out = core_attn_out.unsqueeze(1)
 
         # =================
         # Output. [sq, b, h]

--- a/loongforge/models/diffusion/wan/wan_layer.py
+++ b/loongforge/models/diffusion/wan/wan_layer.py
@@ -132,6 +132,12 @@ class WanLayer(TransformerLayer):
         self.recompute_cross_attn = _sel
 
         self.t_mod = None
+        self.t_s   = None
+
+        # Packing state (set by WanModel._forward_packed)
+        self._packing_cross_packed_seq_params = None
+        self._packing_num_samples = None
+        self._packing_cu_seqlens_q_padded = None
 
     def modulate(self, x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor):
         return x * (1 + scale) + shift
@@ -158,6 +164,13 @@ class WanLayer(TransformerLayer):
         timestep_mod=None,
         **kwargs,
     ):
+        if self._packing_num_samples is not None:
+            return self._forward_packed(
+                hidden_states, context, rotary_pos_emb,
+                rotary_pos_cos, rotary_pos_sin,
+                packed_seq_params, timestep_mod,
+            )
+
         x = hidden_states
         t_mod = timestep_mod if timestep_mod is not None else self.t_mod
         if t_mod is None:
@@ -211,6 +224,122 @@ class WanLayer(TransformerLayer):
             inp=x, requires_grad=x.requires_grad, keep_graph=True
         )
 
+        return output, context
+
+    def _expand_packed_modulation(self, t_mod_block, cu_seqlens_q_padded, num_samples):
+        """Expand each sample's timestep modulation to its local token span."""
+        hidden_size = self.config.hidden_size
+        if num_samples == 1:
+            return (self.modulation.to(dtype=t_mod_block.dtype) + t_mod_block).chunk(6, dim=0)
+
+        t_mod_by_sample = t_mod_block.squeeze(1).reshape(num_samples, 6, hidden_size)
+        shift_msa_list = []
+        scale_msa_list = []
+        gate_msa_list = []
+        shift_mlp_list = []
+        scale_mlp_list = []
+        gate_mlp_list = []
+        base_modulation = self.modulation.squeeze(1)
+        for sample_index in range(num_samples):
+            sample_start = cu_seqlens_q_padded[sample_index].item()
+            sample_end = cu_seqlens_q_padded[sample_index + 1].item()
+            token_count = sample_end - sample_start
+            sample_t_mod = t_mod_by_sample[sample_index]
+            modulated = base_modulation.to(dtype=sample_t_mod.dtype) + sample_t_mod
+            shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = modulated.chunk(6, dim=0)
+            shift_msa_list.append(shift_msa.expand(token_count, -1))
+            scale_msa_list.append(scale_msa.expand(token_count, -1))
+            gate_msa_list.append(gate_msa.expand(token_count, -1))
+            shift_mlp_list.append(shift_mlp.expand(token_count, -1))
+            scale_mlp_list.append(scale_mlp.expand(token_count, -1))
+            gate_mlp_list.append(gate_mlp.expand(token_count, -1))
+
+        return (
+            torch.cat(shift_msa_list, dim=0).unsqueeze(1),
+            torch.cat(scale_msa_list, dim=0).unsqueeze(1),
+            torch.cat(gate_msa_list, dim=0).unsqueeze(1),
+            torch.cat(shift_mlp_list, dim=0).unsqueeze(1),
+            torch.cat(scale_mlp_list, dim=0).unsqueeze(1),
+            torch.cat(gate_mlp_list, dim=0).unsqueeze(1),
+        )
+
+    def _forward_packed(
+        self, hidden_states, context, rotary_pos_emb,
+        rotary_pos_cos, rotary_pos_sin,
+        packed_seq_params, timestep_mod,
+    ):
+        """Forward for packed multi-sample sequences.
+
+        Layout: [video_tokens(S_local), t_mod(6*N), t_s(N)] concatenated in hidden_states.
+        Uses packed_seq_params for THD flash attention and per-sample modulation.
+        """
+        num_samples = self._packing_num_samples
+        cu_seqlens_q_padded = self._packing_cu_seqlens_q_padded
+        ca_params = self._packing_cross_packed_seq_params
+        dim = self.config.hidden_size
+
+        # Extract video, trailing t_mod, t_s from concatenated hidden_states
+        num_trailing = 7 * num_samples
+        x = hidden_states[:-num_trailing]
+        t_mod_start = hidden_states.shape[0] - num_trailing
+        t_mod_end = hidden_states.shape[0] - num_samples
+        t_s_start = hidden_states.shape[0] - num_samples
+        t_mod_block = hidden_states[t_mod_start:t_mod_end]
+        t_s_block = hidden_states[t_s_start:]
+
+        shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = (
+            self._expand_packed_modulation(t_mod_block, cu_seqlens_q_padded, num_samples)
+        )
+
+        # Self-attention
+        norm1 = self.norm1(x)
+        input_x = norm1 * (1 + scale_msa) + shift_msa
+        self_att_out, bias = self.self_attention(
+            input_x,
+            attention_mask=None,
+            rotary_pos_emb=rotary_pos_emb,
+            rotary_pos_cos=rotary_pos_cos,
+            rotary_pos_sin=rotary_pos_sin,
+            packed_seq_params=packed_seq_params,
+        )
+        self_att_out = self_att_out + bias
+        self_att_out = x + gate_msa * self_att_out
+
+        # Cross-attention
+        norm3 = self.norm3(self_att_out)
+        if self.recompute_cross_attn and self.training:
+            def _cross_attn_fwd(norm3, context):
+                out, bias = self.cross_attn(
+                    norm3, attention_mask=None, key_value_states=context,
+                    packed_seq_params=ca_params,
+                )
+                return out, bias
+            cross_out, bias = torch.utils.checkpoint.checkpoint(
+                _cross_attn_fwd, norm3, context, use_reentrant=False
+            )
+        else:
+            cross_out, bias = self.cross_attn(
+                norm3, attention_mask=None, key_value_states=context,
+                packed_seq_params=ca_params,
+            )
+        cross_out = cross_out + bias
+        cross_out = self_att_out + cross_out
+
+        # FFN
+        input_x = self.norm2(cross_out) * (1 + scale_mlp) + shift_mlp
+        if self.recompute_ffn and self.training:
+            ffn_out = torch.utils.checkpoint.checkpoint(
+                self.ffn, input_x, use_reentrant=False
+            )
+        else:
+            ffn_out = self.ffn(input_x)
+        x = cross_out + gate_mlp * ffn_out
+
+        # Reconstruct concatenated output with trailing tokens
+        output = torch.cat([x, t_mod_block, t_s_block], dim=0)
+        output = make_viewless_tensor(
+            inp=output, requires_grad=output.requires_grad, keep_graph=True
+        )
         return output, context
 
     def sharded_state_dict(

--- a/loongforge/models/diffusion/wan/wan_model.py
+++ b/loongforge/models/diffusion/wan/wan_model.py
@@ -8,7 +8,7 @@ import torch.nn as nn
 from torch import Tensor
 
 import math
-from typing import Tuple, Dict, Literal, Optional
+from typing import Tuple, Dict, Literal, Optional, Any
 from einops import rearrange
 from megatron.core.models.common.vision_module.vision_module import VisionModule
 from megatron.core.transformer.spec_utils import ModuleSpec
@@ -22,8 +22,97 @@ from .communications import (
 from megatron.core.parallel_state import (
     get_context_parallel_group,
 )
+from megatron.core import parallel_state
+from megatron.core.packed_seq_params import PackedSeqParams
 from torch.amp import autocast
 
+
+# ---------------------------------------------------------------------------
+# Per-sample boundary CP split helpers
+# ---------------------------------------------------------------------------
+
+def _build_thd_reorder_indices(seq_len_padded, cp_size):
+    """Build indices that restore per-sample global THD order after CP gather.
+
+    Per-sample boundary CP split gathers tokens in chunk-major order:
+    ``[sample0_chunk0, sample1_chunk0, ..., sample0_chunk1, ...]``.
+    Packed attention and loss expect sample-major order:
+    ``[sample0_full, sample1_full, ...]``.
+    """
+    sample_lengths = [seq_len_padded[index].item() for index in range(seq_len_padded.shape[0])]
+    total_length = sum(sample_lengths)
+    chunk_lengths = [sample_length // cp_size for sample_length in sample_lengths]
+
+    sample_offsets = [0]
+    for sample_length in sample_lengths:
+        sample_offsets.append(sample_offsets[-1] + sample_length)
+
+    gathered_to_global = torch.empty(total_length, dtype=torch.long)
+    gathered_offset = 0
+    for cp_chunk_index in range(cp_size):
+        for sample_index, chunk_length in enumerate(chunk_lengths):
+            global_offset = sample_offsets[sample_index] + cp_chunk_index * chunk_length
+            for token_offset in range(chunk_length):
+                gathered_to_global[gathered_offset + token_offset] = global_offset + token_offset
+            gathered_offset += chunk_length
+
+    global_to_gathered = torch.empty(total_length, dtype=torch.long)
+    for global_index in range(total_length):
+        global_to_gathered[gathered_to_global[global_index].item()] = global_index
+
+    return gathered_to_global, global_to_gathered
+
+
+class _THDSplitForCP(torch.autograd.Function):
+    """Autograd function for per-sample boundary CP split with tight packing.
+
+    Forward: select this CP rank's per-sample chunks.
+    Backward: scatter gradients back to original positions.
+    """
+
+    @staticmethod
+    def forward(ctx, x, cu_seqlens, seq_len_padded, cp_size, cp_rank):
+        """Select this CP rank THD chunks for forward propagation."""
+        num_sequences = cu_seqlens.shape[0] - 1
+        indices = []
+        total_actual = cu_seqlens[-1].item()
+        for sequence_index in range(num_sequences):
+            actual_start = cu_seqlens[sequence_index].item()
+            actual_len = cu_seqlens[sequence_index + 1].item() - actual_start
+            padded_len = seq_len_padded[sequence_index].item()
+            chunk_len = padded_len // cp_size
+            local_offset = cp_rank * chunk_len
+            actual_take = min(chunk_len, max(0, actual_len - local_offset))
+            for token_offset in range(actual_take):
+                indices.append(actual_start + local_offset + token_offset)
+            for pad_offset in range(chunk_len - actual_take):
+                indices.append(total_actual + pad_offset)
+        indices_t = torch.tensor(indices, dtype=torch.long, device=x.device)
+        ctx.save_for_backward(indices_t)
+        ctx.cp_size = cp_size
+        ctx.total_len = x.shape[0]
+        return x.index_select(0, indices_t)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Scatter local THD chunk gradients back to original sequence positions."""
+        indices_t, = ctx.saved_tensors
+        grad_input = torch.zeros(
+            ctx.total_len, *grad_output.shape[1:],
+            dtype=grad_output.dtype, device=grad_output.device,
+        )
+        grad_input.index_add_(0, indices_t, grad_output)
+        return grad_input, None, None, None, None
+
+
+def thd_split_for_cp(x, cu_seqlens, seq_len_padded, cp_size, cp_rank):
+    """Per-sample boundary CP split with correct autograd."""
+    return _THDSplitForCP.apply(x, cu_seqlens, seq_len_padded, cp_size, cp_rank)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
 
 def modulate(x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor):
     return x * (1 + scale) + shift
@@ -103,6 +192,7 @@ class Head(nn.Module):
         ).chunk(2, dim=1)
         x = self.head(self.norm(x) * (1 + scale) + shift)
         return x
+
 
 from .wan_config import WanConfig
 class WanModel(VisionModule):
@@ -220,6 +310,32 @@ class WanModel(VisionModule):
             clip = torch.cat([clip, pad], dim=1)
         return pad_num, clip
 
+    def _build_packed_freqs(self, grid_sizes, seq_len_q_padded):
+        """Build per-sample 3D RoPE frequencies for packing mode."""
+        all_freqs = []
+        f_freqs = self.freqs_f
+        h_freqs = self.freqs_h
+        w_freqs = self.freqs_w
+        for i, (f, h, w) in enumerate(grid_sizes.tolist()):
+            seq_len = f * h * w
+            freq_i = torch.cat(
+                [
+                    f_freqs[:f].view(f, 1, 1, -1).expand(f, h, w, -1),
+                    h_freqs[:h].view(1, h, 1, -1).expand(f, h, w, -1),
+                    w_freqs[:w].view(1, 1, w, -1).expand(f, h, w, -1),
+                ],
+                dim=-1,
+            ).reshape(seq_len, 1, -1)
+            padded_len = seq_len_q_padded[i].item()
+            if freq_i.shape[0] < padded_len:
+                pad_shape = (padded_len - freq_i.shape[0], 1, freq_i.shape[2])
+                freq_i = torch.cat(
+                    [freq_i, torch.zeros(pad_shape, dtype=freq_i.dtype, device=freq_i.device)],
+                    dim=0,
+                )
+            all_freqs.append(freq_i)
+        return torch.cat(all_freqs, dim=0)
+
     def forward(
         self,
         x: torch.Tensor,
@@ -227,10 +343,30 @@ class WanModel(VisionModule):
         context: torch.Tensor,
         clip_feature: Optional[torch.Tensor] = None,
         y: Optional[torch.Tensor] = None,
+        packed_seq_params: Optional[Any] = None,
+        grid_sizes: Optional[torch.Tensor] = None,
         use_gradient_checkpointing: bool = False,
         use_gradient_checkpointing_offload: bool = False,
         **kwargs,
     ):
+        """Wan forward. Dispatches to _forward_packed or _forward_single."""
+        use_packing = grid_sizes is not None
+
+        if use_packing:
+            return self._forward_packed(
+                x, timestep, context, clip_feature, y,
+                packed_seq_params, grid_sizes, **kwargs,
+            )
+        else:
+            return self._forward_single(
+                x, timestep, context, clip_feature, y, **kwargs,
+            )
+
+
+    def _forward_single(
+        self, x, timestep, context, clip_feature, y, **kwargs,
+    ):
+        """Non-packing forward path (matches new baseline exactly)."""
         f, h, w = self._grid_f, self._grid_h, self._grid_w
         freqs = self.freqs_3d
         rotary_pos_cos = self.freqs_3d_cos
@@ -243,6 +379,7 @@ class WanModel(VisionModule):
         timestep_mod = None
         if self.pre_process:
             t = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, timestep))
+            t_s = t.unsqueeze(0)
             t_for_head = t
 
             timestep_mod = self.time_projection(t).unflatten(1, (6, self.hidden_size))
@@ -283,6 +420,11 @@ class WanModel(VisionModule):
                     rotary_pos_sin, get_context_parallel_group(), dim=0, grad_scale="down"
                 )
 
+            for layer in self.decoder.layers:
+                layer.t_s = t_s
+                layer._packing_cross_packed_seq_params = None
+                layer._packing_num_samples = None
+                layer._packing_cu_seqlens_q_padded = None
         else:
             x = None
             context = None
@@ -320,6 +462,222 @@ class WanModel(VisionModule):
 
         x = self.unpatchify(x, (f, h, w))
         return x
+
+
+    def _project_packed_latents(self, x, grid_sizes, seq_len_q_padded, cu_seqlens_q_padded):
+        """Apply Conv3d patch projection to each packed sample independently."""
+        patch_frames, patch_height, patch_width = self.patch_size
+        patch_chunks = []
+        for sample_index, grid_size in enumerate(grid_sizes.tolist()):
+            frame_count, height_count, width_count = grid_size
+            sample_seq_len = frame_count * height_count * width_count
+            sample_start = cu_seqlens_q_padded[sample_index].item()
+            sample_tokens = x[sample_start:sample_start + sample_seq_len].squeeze(1)
+            input_channels = sample_tokens.shape[-1] // (patch_frames * patch_height * patch_width)
+            sample_5d = sample_tokens.reshape(
+                frame_count, height_count, width_count,
+                input_channels, patch_frames, patch_height, patch_width,
+            )
+            sample_5d = sample_5d.permute(3, 0, 4, 1, 5, 2, 6).contiguous()
+            sample_5d = sample_5d.reshape(
+                1,
+                input_channels,
+                frame_count * patch_frames,
+                height_count * patch_height,
+                width_count * patch_width,
+            )
+            projected_5d = self.patch_embedding(sample_5d)
+            projected = projected_5d.squeeze(0).permute(1, 2, 3, 0).reshape(
+                -1, 1, self.hidden_size
+            )
+            pad_len = seq_len_q_padded[sample_index].item() - projected.shape[0]
+            if pad_len > 0:
+                projected = torch.nn.functional.pad(projected, (0, 0, 0, 0, 0, pad_len))
+            patch_chunks.append(projected)
+        return torch.cat(patch_chunks, dim=0)
+
+    def _embed_packed_context(self, context, cross_attn_params, num_samples):
+        """Apply text embedding without crossing packed sample boundaries."""
+        if num_samples == 1:
+            return self.text_embedding(context)
+
+        cu_seqlens_kv_padded = cross_attn_params.cu_seqlens_kv_padded
+        embedded_chunks = []
+        for sample_index in range(num_samples):
+            sample_start = cu_seqlens_kv_padded[sample_index].item()
+            sample_end = cu_seqlens_kv_padded[sample_index + 1].item()
+            embedded_chunks.append(self.text_embedding(context[sample_start:sample_end]))
+        return torch.cat(embedded_chunks, dim=0)
+
+    @staticmethod
+    def _build_local_padded_cu_seqlens(seq_len_padded, cp_size, device):
+        """Build local per-sample boundaries after CP split."""
+        boundaries = [0]
+        for sample_index in range(seq_len_padded.shape[0]):
+            local_len = seq_len_padded[sample_index].item() // cp_size
+            boundaries.append(boundaries[-1] + local_len)
+        return torch.tensor(boundaries, dtype=torch.int32, device=device)
+
+    def _split_packed_inputs_for_cp(
+        self,
+        x,
+        context,
+        freqs,
+        freqs_cos,
+        freqs_sin,
+        self_attn_params,
+        cross_attn_params,
+    ):
+        """Split packed video, text, and RoPE tensors on per-sample boundaries."""
+        cp_size = self.config.context_parallel_size
+        if cp_size <= 1:
+            return x, context, freqs, freqs_cos, freqs_sin, None
+
+        cp_rank = parallel_state.get_context_parallel_rank()
+        seq_len_q_padded = self_attn_params._seq_len_q_padded
+        cu_seqlens_q_padded = self_attn_params.cu_seqlens_q_padded
+        seq_len_kv_padded = cross_attn_params._seq_len_kv_padded
+        cu_seqlens_kv_padded = cross_attn_params.cu_seqlens_kv_padded
+
+        x = thd_split_for_cp(x, cu_seqlens_q_padded, seq_len_q_padded, cp_size, cp_rank)
+        context = thd_split_for_cp(
+            context, cu_seqlens_kv_padded, seq_len_kv_padded, cp_size, cp_rank
+        )
+        freqs = thd_split_for_cp(freqs, cu_seqlens_q_padded, seq_len_q_padded, cp_size, cp_rank)
+        freqs_cos = thd_split_for_cp(
+            freqs_cos.unsqueeze(1), cu_seqlens_q_padded, seq_len_q_padded, cp_size, cp_rank
+        ).squeeze(1)
+        freqs_sin = thd_split_for_cp(
+            freqs_sin.unsqueeze(1), cu_seqlens_q_padded, seq_len_q_padded, cp_size, cp_rank
+        ).squeeze(1)
+        local_cu_seqlens_q_padded = self._build_local_padded_cu_seqlens(
+            seq_len_q_padded, cp_size, self_attn_params.cu_seqlens_q.device
+        )
+        return x, context, freqs, freqs_cos, freqs_sin, local_cu_seqlens_q_padded
+
+    def _set_packing_state_on_layers(
+        self,
+        self_attn_params,
+        cross_attn_params,
+        num_samples,
+        local_cu_seqlens_q_padded,
+    ):
+        """Expose packed metadata needed by WAN layers."""
+        cp_size = self.config.context_parallel_size
+        for layer in self.decoder.layers:
+            layer._packing_cross_packed_seq_params = cross_attn_params
+            layer._packing_num_samples = num_samples
+            if cp_size > 1 and local_cu_seqlens_q_padded is not None:
+                layer._packing_cu_seqlens_q_padded = local_cu_seqlens_q_padded
+            else:
+                layer._packing_cu_seqlens_q_padded = self_attn_params.cu_seqlens_q_padded
+            layer.t_s = None
+
+    def _restore_packed_output_order(self, x, timestep_state, seq_len_q_padded, num_samples):
+        """Gather CP shards and restore packed sample-major token order."""
+        cp_size = self.config.context_parallel_size
+        if cp_size > 1:
+            num_trailing_tokens = 7 * num_samples
+            local_video_len = x.shape[0] - num_trailing_tokens
+            timestep_state = x[-num_samples:, :, :]
+            x_video_local = x[:local_video_len, :, :]
+            x_gathered = gather_forward_split_backward(
+                x_video_local, get_context_parallel_group(), dim=0, grad_scale="up"
+            )
+            _, global_to_gathered = _build_thd_reorder_indices(seq_len_q_padded, cp_size)
+            return x_gathered.index_select(0, global_to_gathered.to(x_gathered.device)), timestep_state
+
+        num_trailing_tokens = 7 * num_samples
+        timestep_state = x[-num_samples:, :, :]
+        return x[:-num_trailing_tokens, :, :], timestep_state
+
+    def _apply_packed_head(self, x, timestep_state, self_attn_params, seq_len_q_padded, num_samples):
+        """Apply output head independently for each packed sample."""
+        cp_size = self.config.context_parallel_size
+        if cp_size > 1:
+            packed_boundaries = [0]
+            for sample_index in range(num_samples):
+                packed_boundaries.append(
+                    packed_boundaries[-1] + seq_len_q_padded[sample_index].item()
+                )
+        else:
+            packed_boundaries = self_attn_params.cu_seqlens_q.tolist()
+
+        head_outputs = []
+        for sample_index in range(num_samples):
+            sample_start = packed_boundaries[sample_index]
+            sample_end = packed_boundaries[sample_index + 1]
+            sample_x = x[:, sample_start:sample_end, :]
+            sample_timestep_state = timestep_state[sample_index:sample_index + 1, 0, :].to(torch.bfloat16)
+            head_outputs.append(self.head(sample_x, sample_timestep_state))
+        return torch.cat(head_outputs, dim=1)
+
+    def _forward_packed(
+        self, x, timestep, context, clip_feature, y,
+        packed_seq_params, grid_sizes, **kwargs,
+    ):
+        """Forward pass for packed variable-length sequences."""
+        self_attn_params = packed_seq_params["self_attention"]
+        cross_attn_params = packed_seq_params["cross_attention"]
+        num_samples = grid_sizes.shape[0]
+        seq_len_q_padded = self_attn_params._seq_len_q_padded
+        freqs = self._build_packed_freqs(grid_sizes, seq_len_q_padded)
+        freqs_cos = freqs.real.squeeze(1).contiguous()
+        freqs_sin = freqs.imag.squeeze(1).contiguous()
+
+        if self.pre_process:
+            timestep_state = self.time_embedding(sinusoidal_embedding_1d(self.freq_dim, timestep))
+            timestep_mod = self.time_projection(timestep_state).unflatten(1, (6, self.hidden_size))
+            timestep_mod = rearrange(timestep_mod, "B S C -> S B C").contiguous()
+
+            x = x.to(dtype=self.patch_embedding.weight.dtype)
+            x = self._project_packed_latents(
+                x, grid_sizes, seq_len_q_padded, self_attn_params.cu_seqlens_q_padded
+            )
+            context = self._embed_packed_context(context, cross_attn_params, num_samples)
+            x, context, freqs, freqs_cos, freqs_sin, local_cu_seqlens_q_padded = (
+                self._split_packed_inputs_for_cp(
+                    x, context, freqs, freqs_cos, freqs_sin, self_attn_params, cross_attn_params
+                )
+            )
+            trailing_timestep_mod = timestep_mod.permute(1, 0, 2).reshape(-1, 1, self.hidden_size)
+            trailing_timestep_state = timestep_state.unsqueeze(1)
+            x = torch.cat([x, trailing_timestep_mod, trailing_timestep_state], dim=0)
+        else:
+            x = None
+            context = None
+            timestep_mod = None
+            timestep_state = None
+            local_cu_seqlens_q_padded = None
+
+        self._set_packing_state_on_layers(
+            self_attn_params, cross_attn_params, num_samples, local_cu_seqlens_q_padded
+        )
+
+        x = self.decoder(
+            hidden_states=x,
+            attention_mask=None,
+            context=context,
+            context_mask=None,
+            inference_params=None,
+            packed_seq_params=self_attn_params,
+            rotary_pos_emb=freqs,
+            rotary_pos_cos=freqs_cos,
+            rotary_pos_sin=freqs_sin,
+            timestep_mod=timestep_mod,
+        )
+        if not self.post_process:
+            return x
+
+        x, timestep_state = self._restore_packed_output_order(
+            x, timestep_state, seq_len_q_padded, num_samples
+        )
+        x = x.to(torch.bfloat16)
+        x = rearrange(x, "S B C -> B S C").contiguous()
+        x = self._apply_packed_head(
+            x, timestep_state, self_attn_params, seq_len_q_padded, num_samples
+        )
+        return rearrange(x, "B S C -> S B C").contiguous()
 
     def set_input_tensor(self, input_tensor: Tensor) -> None:
         if not isinstance(input_tensor, list):

--- a/loongforge/train/diffusion/pretrain_wan.py
+++ b/loongforge/train/diffusion/pretrain_wan.py
@@ -4,7 +4,6 @@
 """default pretrain for video diffusion model"""
 
 import torch
-import os
 from functools import partial
 
 from megatron.core import mpu, tensor_parallel
@@ -20,8 +19,16 @@ from loongforge.utils.constants import TrainingPhase, CustomModelFamilies
 
 from loongforge.data.video.latent_dataset import TensorDataset
 
+
+from loongforge.data.video.packed_dataset import (
+    PackedDataset,
+    _patchify_for_conv3d,
+    _patchify_latent,
+)
+
 from loongforge.models import get_model_provider, get_model_family
 from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
+from megatron.core.packed_seq_params import PackedSeqParams
 
 from loongforge.train.megatron_trainer import MegatronTrainer
 from loongforge.train.trainer_builder import register_model_trainer
@@ -47,6 +54,7 @@ from loongforge.models.diffusion.wan.wan_provider import wan2_2_i2v_model_provid
 SUPPORTED_MODELS = [
     CustomModelFamilies.WAN2_2_I2V
 ]
+WAN_PATCH_SIZE = (1, 2, 2)
 
 
 stimer = StragglerDetector()
@@ -129,27 +137,97 @@ def gen_time_steps(batch):
     return timestep, noisy_latents, training_target, scale
 
 
+
+def _build_packed_seq_params(batch):
+    """Build separate PackedSeqParams for self-attention and cross-attention."""
+    device = batch["seq_len_q"].device
+    zero = torch.zeros(1, dtype=torch.int32, device=device)
+
+    cu_seqlens_q_padded = torch.cat([zero, batch["seq_len_q_padded"].cumsum(0).to(torch.int32)])
+    cu_seqlens_kv_padded = torch.cat([zero, batch["seq_len_kv_padded"].cumsum(0).to(torch.int32)])
+
+    if batch["seq_len_q_padded"].sum() == batch["loss_mask"].shape[0]:
+        cu_seqlens_q = cu_seqlens_q_padded
+    else:
+        cu_seqlens_q = torch.cat([zero, batch["seq_len_q"].cumsum(0).to(torch.int32)])
+
+    if batch["seq_len_kv_padded"].sum() == batch["context"].shape[0]:
+        cu_seqlens_kv = cu_seqlens_kv_padded
+    else:
+        cu_seqlens_kv = torch.cat([zero, batch["seq_len_kv"].cumsum(0).to(torch.int32)])
+
+    max_seqlen_q = batch["seq_len_q_padded"].max().item()
+    max_seqlen_kv = batch["seq_len_kv_padded"].max().item()
+
+    self_attn_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_q_padded=cu_seqlens_q_padded,
+        cu_seqlens_kv=cu_seqlens_q,
+        cu_seqlens_kv_padded=cu_seqlens_q_padded,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=max_seqlen_q,
+    )
+    cross_attn_params = PackedSeqParams(
+        qkv_format="thd",
+        cu_seqlens_q=cu_seqlens_q,
+        cu_seqlens_q_padded=cu_seqlens_q_padded,
+        cu_seqlens_kv=cu_seqlens_kv,
+        cu_seqlens_kv_padded=cu_seqlens_kv_padded,
+        max_seqlen_q=max_seqlen_q,
+        max_seqlen_kv=max_seqlen_kv,
+    )
+
+    self_attn_params._seq_len_q = batch["seq_len_q"].clone()
+    self_attn_params._seq_len_q_padded = batch["seq_len_q_padded"].clone()
+    cross_attn_params._seq_len_kv = batch["seq_len_kv"].clone()
+    cross_attn_params._seq_len_kv_padded = batch["seq_len_kv_padded"].clone()
+
+    return {
+        "self_attention": self_attn_params,
+        "cross_attention": cross_attn_params,
+    }
+
+
 def get_batch(data_iterator):
-    """Generate a batch"""
-    # TODO: this is pretty hacky, find a better way
+    """Generate a batch."""
     args = get_args()
-    if data_iterator is not None and mpu.get_context_parallel_rank() == 0:
+    use_packing = getattr(args, 'packing_sft_data', False)
+
+    if use_packing:
+        should_load_data = data_iterator is not None
+    else:
+        should_load_data = data_iterator is not None and mpu.get_context_parallel_rank() == 0
+
+    if should_load_data:
         batch = next(data_iterator)
-        batch["timestep"], batch["latents"], batch["training_target"], \
-            batch["scale"] = gen_time_steps(batch)
-        if args.model_name == "wan2-2-i2v":
-            batch.setdefault("prompt_emb", {})["context"] = batch.pop("context")
-            batch.setdefault("image_emb", {})["y"] = batch.pop("y")
+        packed_seq_params = None
+        grid_sizes = None
+
+        if not use_packing:
+            batch["timestep"], batch["latents"], batch["training_target"], \
+                batch["scale"] = gen_time_steps(batch)
+            if args.model_name == "wan2-2-i2v":
+                batch.setdefault("prompt_emb", {})["context"] = batch.pop("context")
+                batch.setdefault("image_emb", {})["y"] = batch.pop("y")
+        else:
+            packed_seq_params = _build_packed_seq_params(batch)
+            grid_sizes = batch.get("grid_sizes")
+            if "context" in batch:
+                batch["prompt_emb"] = {"context": batch.pop("context")}
+            if "image_emb" not in batch:
+                batch["image_emb"] = {}
     else:
         batch = None
-
-    # get batches on TP0 and CP0 only
-    def move_to_device(x):
-        if x is not None and isinstance(x, torch.Tensor):
-            return x.cuda()
+        packed_seq_params = None
+        grid_sizes = None
 
     if batch:
-        # batch["timestep"] = batch["timestep"][0]
+        def move_to_device(x):
+            if x is not None and isinstance(x, torch.Tensor):
+                return x.cuda()
+            return x
+
         for key, val in batch.items():
             if not isinstance(val, dict):
                 batch[key] = move_to_device(val)
@@ -157,19 +235,99 @@ def get_batch(data_iterator):
                 for k, v in val.items():
                     batch[key][k] = move_to_device(v)
 
-    batch = broadcast_on_cp_group(batch)
-    video = batch["latents"]  # B in T H W
+        if grid_sizes is not None:
+            grid_sizes = grid_sizes.cuda()
+        if packed_seq_params is not None:
+            for attention_name, params in packed_seq_params.items():
+                device_params = PackedSeqParams(
+                    qkv_format=params.qkv_format,
+                    cu_seqlens_q=params.cu_seqlens_q.cuda(),
+                    cu_seqlens_q_padded=params.cu_seqlens_q_padded.cuda(),
+                    cu_seqlens_kv=params.cu_seqlens_kv.cuda(),
+                    cu_seqlens_kv_padded=params.cu_seqlens_kv_padded.cuda(),
+                    max_seqlen_q=params.max_seqlen_q,
+                    max_seqlen_kv=params.max_seqlen_kv,
+                )
+                if hasattr(params, '_seq_len_q'):
+                    device_params._seq_len_q = params._seq_len_q.cuda()
+                if hasattr(params, '_seq_len_q_padded'):
+                    device_params._seq_len_q_padded = params._seq_len_q_padded.cuda()
+                if hasattr(params, '_seq_len_kv'):
+                    device_params._seq_len_kv = params._seq_len_kv.cuda()
+                if hasattr(params, '_seq_len_kv_padded'):
+                    device_params._seq_len_kv_padded = params._seq_len_kv_padded.cuda()
+                packed_seq_params[attention_name] = device_params
+
+        if use_packing and "input_latents_raw" in batch:
+            input_latents_raw_list = batch.pop("input_latents_raw")
+            y_raw_list = batch.pop("y_raw")
+            noise_raw_list = batch.pop("noise_raw")
+            timestep_id = batch.pop("timestep_id")
+
+            timestep = scheduler.timesteps[timestep_id.cpu()].to(
+                dtype=torch.bfloat16, device='cuda')
+
+            latents_patched_list = []
+            target_patched_list = []
+            seq_len_q_padded = batch["seq_len_q_padded"]
+            for sample_index, input_latents_raw in enumerate(input_latents_raw_list):
+                input_latents = input_latents_raw.cuda()
+                noise = noise_raw_list[sample_index].cuda()
+                sample_timestep = timestep[sample_index:sample_index + 1]
+
+                noisy_latents_without_y = scheduler.add_noise(input_latents, noise, sample_timestep)
+                training_target_raw = scheduler.training_target(input_latents, noise, sample_timestep)
+
+                y_raw = y_raw_list[sample_index]
+                if y_raw is not None:
+                    y_cuda = y_raw.to(device=input_latents.device, dtype=input_latents.dtype)
+                    noisy_latents_with_y = torch.cat([noisy_latents_without_y, y_cuda], dim=0)
+                else:
+                    noisy_latents_with_y = noisy_latents_without_y
+
+                latent_patched = _patchify_for_conv3d(noisy_latents_with_y, WAN_PATCH_SIZE)
+                target_patched = _patchify_latent(training_target_raw, WAN_PATCH_SIZE)
+                padded_len = seq_len_q_padded[sample_index].item()
+                pad_q = int(padded_len - latent_patched.shape[0])
+                if pad_q > 0:
+                    latent_patched = torch.nn.functional.pad(latent_patched, (0, 0, 0, pad_q))
+                    target_patched = torch.nn.functional.pad(target_patched, (0, 0, 0, pad_q))
+                latents_patched_list.append(latent_patched)
+                target_patched_list.append(target_patched)
+
+            noisy_latents = torch.cat(latents_patched_list, dim=0)
+            training_target = torch.cat(target_patched_list, dim=0)
+
+            batch["latents"] = noisy_latents.unsqueeze(1)
+            batch["training_target"] = training_target.unsqueeze(1)
+            batch["timestep"] = timestep
+
+    if not use_packing:
+        batch = broadcast_on_cp_group(batch)
+
+    if batch is None:
+        return None, None, None, None, None, None, None, None, None, None, None
+
+    video = batch["latents"]
     training_target = batch["training_target"]
     timestep = batch["timestep"]
-    text = batch["prompt_emb"]["context"]  # B in T H W
+    text = batch.get("prompt_emb", {}).get("context", batch.get("context"))
     scale = batch["scale"]
-
-    image_emb = batch["image_emb"]
+    image_emb = batch.get("image_emb", {})
     if "clip_feature" in image_emb:
         image_emb["clip_feature"] = image_emb["clip_feature"][0].cuda()
     if "y" in image_emb:
         image_emb["y"] = image_emb["y"][0].cuda()
-    return video, timestep, text, image_emb, training_target, scale
+
+    loss_mask = batch.get("loss_mask", None)
+    seq_len_q_padded = batch.get("seq_len_q_padded", None)
+    seq_len_q = batch.get("seq_len_q", None)
+
+    return (
+        video, timestep, text, image_emb, training_target, scale,
+        packed_seq_params, grid_sizes, loss_mask, seq_len_q_padded, seq_len_q,
+    )
+
 
 def gaussian_diffusion():
     """Build a diffusion."""
@@ -186,15 +344,47 @@ def gaussian_diffusion():
     )
 
 
-def loss_func(training_target, timestep, scale, noise_pred):
+def loss_func(training_target, timestep, scale, loss_mask, seq_len_q_padded, seq_len_q, noise_pred):
     """Compute the loss."""
-    loss = torch.nn.functional.mse_loss(noise_pred.float(), training_target.float())
-    loss = loss * scale
-    dp_cp_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
-    averaged_losses = torch.cat([loss.clone().detach().view(1)])
-    torch.distributed.all_reduce(averaged_losses, group=dp_cp_group)
-    averaged_losses = averaged_losses / dp_cp_group.size()
-    return loss, {"lm loss": averaged_losses[0]}
+    if loss_mask is not None:
+        # Per-token MSE with loss_mask, scaled per-sample
+        diff = (noise_pred.float() - training_target.float()) ** 2
+        num_samples = scale.shape[0]
+
+        if num_samples == 1:
+            loss = (diff * loss_mask.unsqueeze(-1)).sum() / (loss_mask.sum() * diff.shape[-1] + 1e-8)
+            loss = loss * scale[0]
+        else:
+            offsets = torch.cat([
+                torch.zeros(1, dtype=seq_len_q_padded.dtype, device=seq_len_q_padded.device),
+                seq_len_q_padded.cumsum(0),
+            ])
+            sample_losses = []
+            for i in range(num_samples):
+                start = int(offsets[i].item())
+                end = int(offsets[i + 1].item())
+                sample_diff = diff[start:end]
+                sample_mask = loss_mask[start:end]
+                sample_mse = (sample_diff * sample_mask.unsqueeze(-1)).sum() / (
+                    sample_mask.sum() * sample_diff.shape[-1] + 1e-8
+                )
+                sample_losses.append(sample_mse * scale[i])
+            loss = sum(sample_losses) / num_samples
+
+        dp_cp_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        averaged_losses = torch.cat([loss.clone().detach().view(1)])
+        torch.distributed.all_reduce(averaged_losses, group=dp_cp_group)
+        averaged_losses = averaged_losses / dp_cp_group.size()
+        return loss, {"lm loss": averaged_losses[0]}
+    else:
+        # Standard MSE loss
+        loss = torch.nn.functional.mse_loss(noise_pred.float(), training_target.float())
+        loss = loss * scale
+        dp_cp_group = parallel_state.get_data_parallel_group(with_context_parallel=True)
+        averaged_losses = torch.cat([loss.clone().detach().view(1)])
+        torch.distributed.all_reduce(averaged_losses, group=dp_cp_group)
+        averaged_losses = averaged_losses / dp_cp_group.size()
+        return loss, {"lm loss": averaged_losses[0]}
 
 
 def forward_step(diffusion, data_iterator, model):
@@ -205,59 +395,105 @@ def forward_step(diffusion, data_iterator, model):
         model: Megatron Model
     """
     timers = get_timers()
+    args = get_args()
+    use_packing = getattr(args, 'packing_sft_data', False)
 
     # Get the batch.
     timers("batch-generator", log_level=2).start()
 
     global stimer
     with stimer(bdata=True):
-        noisy_latents, timestep, text_enc, image_emb, training_target, scale = (
-            get_batch(data_iterator)
-        )
+        noisy_latents, timestep, text_enc, image_emb, training_target, scale, \
+            packed_seq_params, grid_sizes, loss_mask, seq_len_q_padded, seq_len_q = get_batch(data_iterator)
     timers("batch-generator").stop()
 
     extra_input = {}
 
     with stimer:
-        t_enc = text_enc[0] if text_enc is not None else None
-        image_emb = image_emb if image_emb is not None else {}
-        noise_pred = model(
-            noisy_latents,
-            timestep,
-            t_enc,
-            **extra_input,
-            **image_emb,
-            use_gradient_checkpointing=True,
-            use_gradient_checkpointing_offload=False,
-        )
-    return noise_pred, partial(loss_func, training_target, timestep, scale)
+        if use_packing:
+            t_enc = text_enc if text_enc is not None else None
+            image_emb = image_emb if image_emb is not None else {}
+            noise_pred = model(
+                noisy_latents,
+                timestep,
+                t_enc,
+                **extra_input,
+                **image_emb,
+                packed_seq_params=packed_seq_params,
+                grid_sizes=grid_sizes,
+                use_gradient_checkpointing=True,
+                use_gradient_checkpointing_offload=False,
+            )
+        else:
+            t_enc = text_enc[0] if text_enc is not None else None
+            image_emb = image_emb if image_emb is not None else {}
+            noise_pred = model(
+                noisy_latents,
+                timestep,
+                t_enc,
+                **extra_input,
+                **image_emb,
+                use_gradient_checkpointing=True,
+                use_gradient_checkpointing_offload=False,
+            )
+    return noise_pred, partial(loss_func, training_target, timestep, scale, loss_mask, seq_len_q_padded, seq_len_q)
 
 
 def train_valid_test_datasets_provider(diffusion, train_val_test_num_samples, vp_stage=None):
     """Build the train test and validation datasets."""
     args = get_args()
-
-    dataset = TensorDataset(
-        args.data_path[0], args.train_iters * args.global_batch_size
-    )
+    use_packing = getattr(args, 'packing_sft_data', False)
 
     dp_rank = parallel_state.get_data_parallel_rank()
     dp_world_size = parallel_state.get_data_parallel_world_size()
 
-    sampler = torch.utils.data.DistributedSampler(
-        dataset, shuffle=False, num_replicas=dp_world_size, rank=dp_rank
-    )
-    # TODO: Batched inference is not supported yet.
-    dataloader = torch.utils.data.DataLoader(
-        dataset,
-        batch_size=1,
-        num_workers=args.num_workers,
-        sampler=sampler,
-        pin_memory=True,
-    )
+    if use_packing:
+        packing_buffer_size = getattr(args, 'packing_buffer_size', 512)
+        seq_length = args.seq_length
+
+        # steps_per_epoch controls how many packed bins PackedDataset produces
+        # per epoch.  It is set large enough so the trainer never exhausts the
+        # iterator before train_iters steps are done.
+        steps_per_epoch = args.train_iters * args.global_batch_size
+
+        dataset = PackedDataset(
+            data_path=args.data_path[0],
+            steps_per_epoch=steps_per_epoch,
+            args=args,
+            scheduler=scheduler,
+            packing_buffer_size=packing_buffer_size,
+            seq_length=seq_length,
+            dp_rank=dp_rank,
+            dp_world_size=dp_world_size,
+        )
+        # batch_size=None: DataLoader yields each item as-is (no batching /
+        # collation).  PackedDataset already produces fully-merged packed
+        # batches so no further assembly is needed.
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=None,
+            num_workers=0,
+            pin_memory=True,
+        )
+    else:
+        dataset = TensorDataset(
+            args.data_path[0], args.train_iters * args.global_batch_size
+        )
+        sampler = torch.utils.data.DistributedSampler(
+            dataset, shuffle=False, num_replicas=dp_world_size, rank=dp_rank
+        )
+        dataloader = torch.utils.data.DataLoader(
+            dataset,
+            batch_size=1,
+            num_workers=args.num_workers,
+            sampler=sampler,
+            pin_memory=True,
+        )
+
     print_rank_0(f"> finished creating {args.model_name} datasets ...")
 
     return iter(dataloader), None, None
+
 
 # Set random number seed
 @register_model_trainer(

--- a/loongforge/train/validators.py
+++ b/loongforge/train/validators.py
@@ -36,6 +36,7 @@ def validate_loongforge_extra_args(args, config):
 
 def validate_megatron_args(args):
     """Validate Megatron arguments"""
+    _align_wan_packing_seq_length(args)
     _validate_legacy_pipeline_args(args)
     validate_args(args)
 
@@ -43,6 +44,29 @@ def validate_megatron_args(args):
 def validate_custom_model_args(name, args):
     """Validate non foundational model arguments"""
     _validate_custom_model_args(name, args)
+
+
+def _get_wan_packing_cp_alignment(cp_size):
+    """Return WAN packing sequence alignment required by CP split."""
+    return 2 * cp_size
+
+
+def _align_wan_packing_seq_length(args):
+    """Align WAN packing seq-length before Megatron validation."""
+    if getattr(args, "model_name", None) != "wan2-2-i2v":
+        return
+    if not getattr(args, "packing_sft_data", False):
+        return
+    cp_size = getattr(args, "context_parallel_size", 1)
+    seq_length = getattr(args, "seq_length", None)
+    if cp_size <= 1 or seq_length is None:
+        return
+    alignment = _get_wan_packing_cp_alignment(cp_size)
+    aligned_seq_length = ((seq_length + alignment - 1) // alignment) * alignment
+    args.seq_length = aligned_seq_length
+    if getattr(args, "encoder_seq_length", None) is not None:
+        args.encoder_seq_length = aligned_seq_length
+    args.max_position_embeddings = max(args.max_position_embeddings, aligned_seq_length)
 
 
 # YAML key → args attribute name, for cases where TransformerConfig field
@@ -408,6 +432,14 @@ def _validate_custom_model_args(name, args, defaults={}):
     if args.num_virtual_stages_per_pipeline_rank is not None:
         warnings.warn(f"WARNING: Now for {name}, we do not support num_virtual_stages_per_pipeline_rank.")
         args.num_virtual_stages_per_pipeline_rank = None
+
+    if args.context_parallel_ulysses_degree is not None:
+        warnings.warn(f"WARNING: Now for {name}, we do not support context_parallel_ulysses_degree.")
+        args.context_parallel_ulysses_degree = 1
+
+    if args.context_parallel_size > 1:
+        warnings.warn(f"WARNING: Now for {name}, we only support context parallel size 1.")
+        args.context_parallel_size = 1
 
     if args.tp_comm_overlap:
         warnings.warn(f"WARNING: Now for {name}, we do not support tp_comm_overlap.")


### PR DESCRIPTION
This feature adds packing support for WAN2.2 training. It enables multiple variable-length video/text samples to be concatenated into one packed training sequence and uses THD-format packed attention metadata to preserve sample boundaries during self-attention, cross-attention, loss computation, and context-parallel execution.
Closes #57