### PR TITLE
[xpu] ci: support lerobot v0.5.0 && update xpytorch and ops

### DIFF
--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -42,7 +42,7 @@ RUN set -exuo pipefail && \
         XPYTORCH_URL=$(python3 -c "import json; print(json.load(open('/workspace/LoongForge/docker/xpu_packages.json'))['torch25']['xpytorch']['url'])"); \
         echo "use default xpytorch version from json: ${XPYTORCH_URL}"; \
     fi && \
-    export http_proxy=http://10.63.229.53:8891 && export https_proxy=http://10.63.229.53:8891 && download_xpytorch "${XPYTORCH_URL}"
+    download_xpytorch "${XPYTORCH_URL}"
 
 # ======================== Fix xpytorch_import_hook ========================
 RUN source /opt/loongforge_kunlun/bin/activate && bash /workspace/LoongForge/docker/fix_xpytorch_hook.sh

--- a/docker/Dockerfile.xpu
+++ b/docker/Dockerfile.xpu
@@ -8,6 +8,7 @@ FROM ${BASE_IMAGE}
 # Enable only when training VLA models (e.g., Pi0.5, GR00T).
 ARG ENABLE_LEROBOT="false"
 ARG XPYTORCH_URL_ARG=""
+ARG KUNLUN_OPS_URL_ARG=""
 
 # =========================================================
 # Base System Configuration + APT Source Replacement
@@ -38,24 +39,30 @@ RUN set -exuo pipefail && \
         XPYTORCH_URL="${XPYTORCH_URL_ARG}"; \
         echo "use specified xpytorch version: ${XPYTORCH_URL}"; \
     else \
-        xpytorch_info="/workspace/LoongForge/docker/xpytorch_info.txt"; \
-        if [ ! -f "${xpytorch_info}" ]; then \
-            echo "xpytorch info file not exist: ${xpytorch_info}" && exit 1; \
-        fi; \
-        DEFAULT_XPYTORCH_URL=$(cat "${xpytorch_info}" | tr -d '[:space:]'); \
-        if [ -z "${DEFAULT_XPYTORCH_URL}" ]; then \
-            echo "Error: xpytorch_info.txt file content is empty" && exit 1; \
-        fi; \
-        XPYTORCH_URL="${DEFAULT_XPYTORCH_URL}"; \
-        echo "use default xpytorch version: ${XPYTORCH_URL}"; \
+        XPYTORCH_URL=$(python3 -c "import json; print(json.load(open('/workspace/LoongForge/docker/xpu_packages.json'))['torch25']['xpytorch']['url'])"); \
+        echo "use default xpytorch version from json: ${XPYTORCH_URL}"; \
     fi && \
-    download_xpytorch "${XPYTORCH_URL}"
+    export http_proxy=http://10.63.229.53:8891 && export https_proxy=http://10.63.229.53:8891 && download_xpytorch "${XPYTORCH_URL}"
+
+# ======================== Fix xpytorch_import_hook ========================
+RUN source /opt/loongforge_kunlun/bin/activate && bash /workspace/LoongForge/docker/fix_xpytorch_hook.sh
+
+# ======================== Install XPU Packages ========================
+RUN source /opt/loongforge_kunlun/bin/activate && \
+    COCOPOD_URL=$(python3 -c "import json; print(json.load(open('/workspace/LoongForge/docker/xpu_packages.json'))['torch25']['cocopod']['url'])") && \
+    XSPEEDGATE_URL=$(python3 -c "import json; print(json.load(open('/workspace/LoongForge/docker/xpu_packages.json'))['torch25']['xspeedgate']['url'])") && \
+    if [ -n "${KUNLUN_OPS_URL_ARG}" ]; then \
+        KUNLUN_OPS_URL="${KUNLUN_OPS_URL_ARG}"; \
+    else \
+        KUNLUN_OPS_URL=$(python3 -c "import json; print(json.load(open('/workspace/LoongForge/docker/xpu_packages.json'))['torch25']['kunlun_ops']['url'])"); \
+    fi && \
+    pip install "${COCOPOD_URL}" "${XSPEEDGATE_URL}" "${KUNLUN_OPS_URL}"
 
 # ======================== Install Base Requirements ========================
 RUN set -exuo pipefail && \
     source /opt/loongforge_kunlun/bin/activate && \
     # for deepspeed cpu adam
-    DS_BUILD_CPU_ADAM=1  BUILD_UTILS=1  pip install deepspeed==0.18.5 -U && \
+    DS_BUILD_CPU_ADAM=1  BUILD_UTILS=1  pip install --no-build-isolation deepspeed==0.18.5 -U && \
     echo "alias ll='ls -alF'" > /etc/profile.d/alias.sh; \
     echo "source /etc/profile.d/alias.sh" >> ~/.bashrc && \
     cd /workspace/LoongForge/ && \
@@ -74,23 +81,35 @@ RUN set -exuo pipefail && \
         fi && \
         git clone --no-checkout https://github.com/huggingface/lerobot.git && \
         cd lerobot && \
-        git checkout tags/v0.4.3 && \
+        git checkout tags/v0.5.0 && \
         if [ -f "requirements-ubuntu.txt" ]; then \
             sed -i '/evdev/d' requirements-ubuntu.txt; \
         fi && \
-        pip install func_timeout pytest-xdist prettytable==3.11.0 peft==0.17.0 && \
+        pip install func_timeout pytest-xdist prettytable==3.11.0 huggingface-hub==0.34.0 && \
+        sed -i 's/^class Backtrackable\[T\]:$/from typing import Iterable, TypeVar, Generic\nT = TypeVar('\''T'\'')\nclass Backtrackable(Generic[T]):/' ./src/lerobot/datasets/utils.py && \
+        sed -i 's/^def deserialize_json_into_object\[T: JsonLike\](fpath: Path, obj: T) -> T:$/from typing import TypeVar\nT = TypeVar('\''T'\'', bound=JsonLike)\ndef deserialize_json_into_object(fpath: Path, obj: T) -> T:/' ./src/lerobot/utils/io_utils.py && \
+        sed -i '/^@dataclass$/{N; s/^@dataclass\nclass DataProcessorPipeline\[TInput, TOutput\](HubMixin):$/from typing import TypeVar, Generic\nTInput = TypeVar('\''TInput'\'')\nTOutput = TypeVar('\''TOutput'\'')\n@dataclass\nclass DataProcessorPipeline(Generic[TInput, TOutput], HubMixin):/}' ./src/lerobot/processor/pipeline.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import TYPE_CHECKING, Literal, TypedDict, Unpack$/\1from typing import TYPE_CHECKING, Literal, TypedDict\n\1from typing_extensions import Unpack/' ./src/lerobot/policies/pi0_fast/modeling_pi0_fast.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import TYPE_CHECKING, Literal, TypedDict, Unpack$/\1from typing import TYPE_CHECKING, Literal, TypedDict\n\1from typing_extensions import Unpack/' ./src/lerobot/policies/pi05/modeling_pi05.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import TYPE_CHECKING, Literal, TypedDict, Unpack$/\1from typing import TYPE_CHECKING, Literal, TypedDict\n\1from typing_extensions import Unpack/' ./src/lerobot/policies/pi0/modeling_pi0.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import TypedDict, Unpack$/\1from typing import TypedDict\n\1from typing_extensions import Unpack/' ./src/lerobot/policies/smolvla/modeling_smolvla.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import TypedDict, TypeVar, Unpack$/\1from typing import TypedDict, TypeVar\n\1from typing_extensions import Unpack/'  ./src/lerobot/policies/pretrained.py && \
+        sed -i 's/^\([[:space:]]*\)from typing import Any, TypedDict, Unpack$/\1from typing import Any, TypedDict\n\1from typing_extensions import Unpack/' ./src/lerobot/policies/factory.py && \
+        sed -i '/^[[:space:]]*type NameOrID = str | int$/{N; s/^\([[:space:]]*\)type NameOrID = str | int\n[[:space:]]*type Value = int | float$/from typing import TypeAlias, Union\n\1NameOrID: TypeAlias = Union[str, int]\n\1Value: TypeAlias = Union[int, float]/}' ./src/lerobot/motors/motors_bus.py && \
         sed -i -e '/"torch[>=<]/d' \
            -e 's/"torchvision[^"]*",/"torchvision==0.20.1",/' \
            -e '/python-can/d' \
            -e '/lerobot\[can-dep\]/d' \
            -e '/lerobot\[damiao\]/d' \
-           -e '/unitree_g1 = \[/,/\]/ { /matplotlib/d; /pin/d; /meshcat/d; /casadi/d; }' \
+           -e '/unitree_g1 = \[/,/]/ { /matplotlib/d; /pin/d; /meshcat/d; /casadi/d; }' \
            -e '/lerobot-setup-can/d' \
            -e '/\[tool.setuptools.package-data\]/d' \
            -e '/lerobot = \["envs\/\*\.json"\]/d' \
            -e '/"OT_VALUE"/d' \
+           -e 's/requires-python = ">=3\.12"/requires-python = ">=3\.10"/g' \
+           -e '/huggingface-hub>=1\.0\.0,<2\.0\.0/d' \
            pyproject.toml && \
-        pip install --no-build-isolation -e ".[pi]" && \
+        pip install --no-build-isolation -e ".[pi,peft-dep,scipy-dep]" && \
         sed -i 's|tokenizer_name="google/paligemma-3b-pt-224",|tokenizer_name=config.tokenizer_name,|g' ./src/lerobot/policies/pi05/processor_pi05.py && \
         echo "Lerobot installation completed"; \
     }; \

--- a/docker/fix_xpytorch_hook.sh
+++ b/docker/fix_xpytorch_hook.sh
@@ -1,0 +1,137 @@
+#!/bin/bash
+# Fix xpytorch_import_hook.py and torch_xray_import_hook.py
+# Auto-detect pip isolated build environment and skip hook
+
+set -e
+
+echo "Patching xpytorch and xray import hooks..."
+
+python3 << 'EOFPY'
+import os
+import re
+import site
+import sys
+
+patched_count = 0
+
+# ======================== Fix xpytorch_import_hook.py ========================
+hook_files = []
+for path in site.getsitepackages():
+    candidate = os.path.join(path, "xpytorch_import_hook.py")
+    if os.path.exists(candidate):
+        hook_files.append(candidate)
+
+if not hook_files:
+    print("xpytorch_import_hook.py not found, skipping patch")
+else:
+    for hook_file in hook_files:
+        with open(hook_file, "r") as f:
+            content = f.read()
+        
+        if "# patched: auto-detect pip isolated env" in content:
+            print(f"[xpytorch] Already patched: {hook_file}")
+            patched_count += 1
+            continue
+        
+        # Fix 1: Add pip isolated environment detection at the beginning of _custom_import
+        old_func_start = r"def _custom_import\(module_name, globals=None, locals=None, fromlist=\(\), level=0\):\n( *)global SYMBOL_REWRITE_REGISTER"
+        
+        def make_func_patch(m):
+            indent = m.group(1)
+            detection_code = (
+                f"{indent}# patched: auto-detect pip isolated build environment\n"
+                f"{indent}if any('pip-' in p or 'pip_' in p for p in sys.path):\n"
+                f"{indent}    return builtins.__origin__import__(module_name, globals, locals, fromlist, level)\n"
+            )
+            return (
+                "def _custom_import(module_name, globals=None, locals=None, fromlist=(), level=0):\n"
+                + detection_code +
+                f"{indent}global SYMBOL_REWRITE_REGISTER"
+            )
+        
+        content, count1 = re.subn(old_func_start, make_func_patch, content)
+        
+        # Fix 1 is critical, fail if not matched
+        if count1 == 0:
+            print(f"ERROR: Function pattern not found in {hook_file}", file=sys.stderr)
+            print("This is a critical patch. Build cannot continue.", file=sys.stderr)
+            sys.exit(1)
+        
+        # Fix 2: torch_version = version('torch') with fallback
+        old_pattern2 = r"^( *)torch_version = version\('torch'\)"
+        
+        def make_patch2(m):
+            indent = m.group(1)
+            return (
+                f"{indent}try:\n"
+                f"{indent}    torch_version = version('torch')\n"
+                f"{indent}except Exception:\n"
+                f"{indent}    try:\n"
+                f"{indent}        torch_version = __import__('torch').__version__  # patched\n"
+                f"{indent}    except ImportError:\n"
+                f"{indent}        torch_version = \"0.0.0\"  # patched fallback"
+            )
+        
+        content, count2 = re.subn(old_pattern2, make_patch2, content, flags=re.MULTILINE)
+        
+        with open(hook_file, "w") as f:
+            f.write(content)
+        
+        patched_count += 1
+        print(f"[xpytorch] Patched: {hook_file} (func={count1}, version={count2})")
+
+    # Check if at least one file was patched
+    if patched_count == 0:
+        print("ERROR: No xpytorch_import_hook.py files were successfully patched", file=sys.stderr)
+        sys.exit(1)
+
+# ======================== Fix torch_xray_import_hook.py ========================
+xray_files = []
+for path in site.getsitepackages():
+    candidate = os.path.join(path, "torch_xray_import_hook.py")
+    if os.path.exists(candidate):
+        xray_files.append(candidate)
+
+xray_patched_count = 0
+
+if not xray_files:
+    print("torch_xray_import_hook.py not found, skipping patch")
+else:
+    for xray_file in xray_files:
+        with open(xray_file, "r") as f:
+            content = f.read()
+        
+        if "if spec is not None and spec.loader is not None:" in content:
+            print(f"[xray] Already patched: {xray_file}")
+            xray_patched_count += 1
+            continue
+        
+        old_pattern = r"^( *)spec\.loader = XrayMetaPathLoader\(spec\.loader\)"
+        
+        def make_xray_patch(m):
+            indent = m.group(1)
+            return (
+                f"{indent}if spec is not None and spec.loader is not None:\n"
+                f"{indent}    spec.loader = XrayMetaPathLoader(spec.loader)"
+            )
+        
+        content, count = re.subn(old_pattern, make_xray_patch, content, flags=re.MULTILINE)
+        
+        if count == 0:
+            print(f"ERROR: Pattern not found in {xray_file}", file=sys.stderr)
+            print("This is a critical patch. Build cannot continue.", file=sys.stderr)
+            sys.exit(1)
+        
+        with open(xray_file, "w") as f:
+            f.write(content)
+        
+        xray_patched_count += 1
+        print(f"[xray] Patched: {xray_file}")
+
+    # Check if at least one xray file was patched
+    if xray_patched_count == 0:
+        print("ERROR: No torch_xray_import_hook.py files were successfully patched", file=sys.stderr)
+        sys.exit(1)
+
+print("All import hook fixes applied successfully!")
+EOFPY

--- a/docker/fix_xpytorch_hook.sh
+++ b/docker/fix_xpytorch_hook.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
 # Fix xpytorch_import_hook.py and torch_xray_import_hook.py
 # Auto-detect pip isolated build environment and skip hook
 

--- a/docker/xpu_packages.json
+++ b/docker/xpu_packages.json
@@ -1,0 +1,24 @@
+{
+    "torch25": {
+        "xpytorch": {
+            "version": "3.6.0.0",
+            "url": "https://baidu-kunlun-public.su.bcebos.com/baidu-kunlun-share/20260428/torch25/xpytorch-cp310-torch251-ubuntu2004-x64.run",
+            "type": "run"
+        },
+        "kunlun_ops": {
+            "version": "0.1.122",
+            "url": "https://baidu-kunlun-public.su.bcebos.com/baidu-kunlun-share/20260428/torch25/kunlun_ops-0.1.122%2Bb4984657-cp310-cp310-linux_x86_64.whl",
+            "type": "wheel"
+        },
+        "cocopod": {
+            "version": "0.0.0",
+            "url": "https://vllm-ai-models.bj.bcebos.com/aiak_share/latest/torch25/cocopod-0.0.0+torch25-cp310-cp310-linux_x86_64.whl",
+            "type": "wheel"
+        },
+        "xspeedgate": {
+            "version": "0.0.0",
+            "url": "https://aihc-private-hcd.bj.bcebos.com/xspeedgate_release/latest/torch25/xspeedgate_ops-0.0.0+torch25-cp310-cp310-linux_x86_64.whl",
+            "type": "wheel"
+        }
+    }
+}

--- a/docker/xpytorch_info.txt
+++ b/docker/xpytorch_info.txt
@@ -1,1 +1,0 @@
-https://baidu-kunlun-public.su.bcebos.com/baidu-kunlun-share/20260409/torch25/xpytorch-cp310-torch251-ubuntu2004-x64.run


### PR DESCRIPTION
LeRobot v0.5.0 adopts syntax features of Python 3.12. However, the latest official P800 images only support Python 3.10. For this reason, we have refactored certain syntaxes in the code to ensure compatibility with Python 3.10.

Additionally, we added support for installing third-party Kunlun operator libraries, including kunlun_ops, XSpeedGate, and CoCoPod. 

We also fixed issues with the xpytorch hook to resolve build failures when compiling the DeepSpeed CPU Adam optimizer during image construction.
before:
<img width="1483" height="492" alt="image" src="https://github.com/user-attachments/assets/e66d9bfa-2909-4977-8dac-fa9372966392" />

after fix:
<img width="1516" height="245" alt="image" src="https://github.com/user-attachments/assets/fc70bfd4-e644-4fa2-a354-c8be3222d65e" />

