### PR TITLE
[xpu] fix: pi0.5 grad norm nan

### DIFF
--- a/docs/source/kunlun_tutorial/quick_start_vla_p800.md
+++ b/docs/source/kunlun_tutorial/quick_start_vla_p800.md
@@ -63,17 +63,17 @@ DATA_PATH=${DATA_PATH:-"/workspace/libero/"}
 TOKENIZER_PATH=${TOKENIZER_PATH:-"/workspace/paligemma-3b-pt-224/"}
 CHECKPOINT_PATH=${CHECKPOINT_PATH:-"/workspace/ckpt/"}
 
-export XMLIR_ENABLE_FAST_FC=true         # Used in torch.nn.linear.py (e.g., LinearWithActFunction)
-export XMLIR_MATMUL_FAST_MODE=1          # Accumulation acceleration for XBLAS fully-connected (FC) computation under BF16 precision
-export XMLIR_ENABLE_LINEAR_FC_FUSION=1   # Allows linear layers to bypass XBLAS FC fusion in certain scenarios (e.g., using addmm instead), default value is 1
-export XMLIR_PARALLEL_SAVE_MEMORY=false  # When set to false, GPU memory usage increases but performance is improved; when set to true, memory usage decreases but performance drops
-export XDNN_USE_FAST_GELU=true           # High-precision implementation of the GELU operator
-export BKCL_FORCE_SYNC=1                 # Force CPU synchronization before communication (this will reduce performance)
-export BKCL_TREE_THRESHOLD=0             # Set to 0 to disable the tree algorithm
-export BKCL_ENABLE_XDR=1                 # Enable XDR (XPU Direct RDMA) and direct RDMA. Traffic will then flow directly from the XPU to the RDMA NIC, which is required for multi-node training.
-export BKCL_RDMA_VERBS=1                 # Used in conjunction with BKCL_QPS_PER_CONNECTION; only required for Hygon servers currently
-export BKCL_RDMA_NICS=eth1,eth1,eth2,eth2,eth3,eth3,eth4,eth4   # Subject to actual conditions; for multi-node training, configure according to the NIC connectivity of the server environment
-export XTE_USE_MULTI_TENSOR_ADAMW=True   # Align the Adam optimizer with the GPU multi_tensor_adamw implementation
+export XMLIR_ENABLE_FAST_FC=true         # Used in torch.nn.linear.py (LinearWithActFunction, etc.)
+export XMLIR_MATMUL_FAST_MODE=1          # Accelerate xblas fc computation accumulation under bf16
+export XMLIR_ENABLE_LINEAR_FC_FUSION=1   # Allow linear to bypass xblas fcfusion in certain scenarios, e.g., use addmm; default is 1
+export XMLIR_PARALLEL_SAVE_MEMORY=false  # false: higher memory usage but better performance; true: lower memory usage but reduced performance
+export XDNN_USE_FAST_GELU=true           # High-precision gelu operator implementation
+export BKCL_FORCE_SYNC=1                 # Force CPU synchronization before communication; reduces performance
+export BKCL_TREE_THRESHOLD=0             # Set to 0 to disable tree algorithm
+export BKCL_ENABLE_XDR=1                 # Enable XDR (XPU direct RDMA); enables direct RDMA from XPU to RDMA NIC, required for multi-node training
+export BKCL_RDMA_VERBS=1                 # Used together with BKCL_QPS_PER_CONNECTION; currently only needed for Hygon machines
+export BKCL_RDMA_NICS=eth1,eth1,eth2,eth2,eth3,eth3,eth4,eth4   # Adjust based on actual environment; configure according to NIC connectivity for multi-node setup
+export XTE_USE_MULTI_TENSOR_ADAMW=True   # Optimizer adam aligned with GPU multi_tensor_adamw implementation
 
 # Distributed launch (defaults single node)
 GPUS_PER_NODE=${GPUS_PER_NODE:-8}
@@ -101,18 +101,16 @@ DATA_ARGS=(
 
 # Core training args — pi05 trainer only needs minimal Megatron flags
 TRAINING_ARGS=(
-    --use-megatron-fsdp
-    --data-parallel-sharding-strategy optim
     --training-phase sft
-    --micro-batch-size 16
-    --global-batch-size 128
-    --train-iters 30000
+    --micro-batch-size 12
+    --global-batch-size 96
+    --train-iters 50
     --seq-length 762
     --max-position-embeddings 762
     --tensor-model-parallel-size 1
     --pipeline-model-parallel-size 1
     --no-masked-softmax-fusion
-    --ckpt-format fsdp_dtensor
+    --ckpt-format torch
     --load $CHECKPOINT_PATH
     --no-load-optim
     --no-load-rng
@@ -127,27 +125,37 @@ TRAINING_ARGS=(
     --adam-eps 1e-8
     --adam-beta2 0.95
     --weight-decay 0.01
-    --no-strict-fsdp-dtensor-load
     --finetune
     --bf16
-    --grad-reduce-in-bf16
+    --init-model-with-meta-device
     --use-precision-aware-optimizer
-    --main-grads-dtype bf16
+    --exp-avg-dtype bf16
+    --exp-avg-sq-dtype bf16
     --num-distributed-optimizer-instances 1
     --save $CHECKPOINT_PATH
-    --save-interval 30000
+    --save-interval 30
+    --optimizer-cpu-offload
+    --optimizer-offload-fraction 0.05
 )
 
 MODEL_CONFIG_ARGS=(
     --model-name pi05
     --use-distributed-optimizer
     --distributed-backend nccl
-    #--random-fallback-cpu
+    --random-fallback-cpu
 )
 
 LOGGING_ARGS=(
     --log-interval 1
+    --tensorboard-dir ${TENSORBOARD_PATH}
 )
+
+#if [ -n "${WANDB_API_KEY}" ]; then
+#    LOGGING_ARGS+=(
+#        --wandb-project ${WANDB_PROJECT}
+#        --wandb-exp-name ${WANDB_NAME}
+#    )
+#fi
 
 PYTHONPATH=$MEGATRON_PATH:$LOONGFORGE_PATH:${PYTHONPATH:-} \
     torchrun ${DISTRIBUTED_ARGS[@]} \
@@ -156,7 +164,6 @@ PYTHONPATH=$MEGATRON_PATH:$LOONGFORGE_PATH:${PYTHONPATH:-} \
     ${DATA_ARGS[@]} \
     ${TRAINING_ARGS[@]} \
     ${LOGGING_ARGS[@]}
-
 ```
 
 ## Monitoring Logs

--- a/examples_xpu/pi05/finetuning/sft_pi05.sh
+++ b/examples_xpu/pi05/finetuning/sft_pi05.sh
@@ -50,18 +50,16 @@ DATA_ARGS=(
 
 # Core training args — pi05 trainer only needs minimal Megatron flags
 TRAINING_ARGS=(
-    --use-megatron-fsdp
-    --data-parallel-sharding-strategy optim
     --training-phase sft
-    --micro-batch-size 16
-    --global-batch-size 128
-    --train-iters 30000
+    --micro-batch-size 12
+    --global-batch-size 96
+    --train-iters 50
     --seq-length 762
     --max-position-embeddings 762
     --tensor-model-parallel-size 1
     --pipeline-model-parallel-size 1
     --no-masked-softmax-fusion
-    --ckpt-format fsdp_dtensor
+    --ckpt-format torch
     --load $CHECKPOINT_PATH
     --no-load-optim
     --no-load-rng
@@ -76,27 +74,37 @@ TRAINING_ARGS=(
     --adam-eps 1e-8
     --adam-beta2 0.95
     --weight-decay 0.01
-    --no-strict-fsdp-dtensor-load
     --finetune
     --bf16
-    --grad-reduce-in-bf16
+    --init-model-with-meta-device
     --use-precision-aware-optimizer
-    --main-grads-dtype bf16
+    --exp-avg-dtype bf16
+    --exp-avg-sq-dtype bf16
     --num-distributed-optimizer-instances 1
     --save $CHECKPOINT_PATH
-    --save-interval 30000
+    --save-interval 30
+    --optimizer-cpu-offload
+    --optimizer-offload-fraction 0.05
 )
 
 MODEL_CONFIG_ARGS=(
     --model-name pi05
     --use-distributed-optimizer
     --distributed-backend nccl
-    #--random-fallback-cpu
+    --random-fallback-cpu
 )
 
 LOGGING_ARGS=(
     --log-interval 1
+    --tensorboard-dir ${TENSORBOARD_PATH}
 )
+
+#if [ -n "${WANDB_API_KEY}" ]; then
+#    LOGGING_ARGS+=(
+#        --wandb-project ${WANDB_PROJECT}
+#        --wandb-exp-name ${WANDB_NAME}
+#    )
+#fi
 
 PYTHONPATH=$MEGATRON_PATH:$LOONGFORGE_PATH:${PYTHONPATH:-} \
     torchrun ${DISTRIBUTED_ARGS[@]} \

--- a/loongforge/models/embodied/pi05/modeling_pi05.py
+++ b/loongforge/models/embodied/pi05/modeling_pi05.py
@@ -24,7 +24,8 @@ import logging
 import math
 from collections import deque
 from pathlib import Path
-from typing import TYPE_CHECKING, Literal, TypedDict, Unpack
+from typing import TYPE_CHECKING, Literal, TypedDict
+from typing_extensions import Unpack
 
 import torch
 import torch.nn.functional as F  # noqa: N812
@@ -494,22 +495,22 @@ class PaliGemmaWithExpertModel(nn.Module):
             if name in param_dict and param_dict[name] is not None:
                 param_dict[name].data = param_dict[name].data.to(dtype=torch.float32)
         # Fix inv_freq: GemmaRotaryEmbedding.inv_freq is persistent=False and not saved in
-        # checkpoints. Float16Module.bfloat16() converts all buffers including inv_freq, but
-        # if inv_freq somehow ends up all-zero (e.g. meta-device init without materialization),
-        # RoPE becomes an identity transform and positional information is lost.
+        # checkpoints. After init_model_with_meta_device + to_empty_if_meta_device, inv_freq
+        # contains uninitialized garbage (not all-zero). Always reinitialize from config
+        # when the tensor is on a real device (not meta).
         for module in self.modules():
             if type(module).__name__ == 'GemmaRotaryEmbedding' and hasattr(module, 'inv_freq'):
                 inv_freq = module.inv_freq
                 if inv_freq.device.type == 'meta':
                     continue  # not yet materialized; fix will run after to_empty_if_meta_device
-                if not inv_freq.any().item():
-                    new_inv_freq, _ = type(module).compute_default_rope_parameters(
-                        module.config, device=module.inv_freq.device
-                    )
-                    # Cast to match the current model dtype (bfloat16 after Float16Module wraps).
-                    new_inv_freq = new_inv_freq.to(dtype=module.inv_freq.dtype)
-                    module.register_buffer('inv_freq', new_inv_freq, persistent=False)
-                    module.register_buffer('original_inv_freq', new_inv_freq.clone(), persistent=False)
+                # Always reinitialize: after to_empty_if_meta_device, inv_freq has garbage values
+                # that may not be all-zero, but are still wrong.
+                new_inv_freq, _ = type(module).compute_default_rope_parameters(
+                    module.config, device=module.inv_freq.device
+                )
+                new_inv_freq = new_inv_freq.to(dtype=module.inv_freq.dtype)
+                module.register_buffer('inv_freq', new_inv_freq, persistent=False)
+                module.register_buffer('original_inv_freq', new_inv_freq.clone(), persistent=False)
         self._tie_paligemma_language_weights()
         return self
 


### PR DESCRIPTION
before:
<img width="1822" height="758" alt="image" src="https://github.com/user-attachments/assets/c5185a7d-a83c-46ff-9506-a91ca961e2be" />

after fix:
<img width="1677" height="868" alt="070070cdb6e94accb8b1c9b43082cb1b" src="https://github.com/user-attachments/assets/aae63976-af99-401a-b175-311cb24e9ebe" />

Two main issues lead to precision errors: incorrect initialization of GemmaRotaryEmbedding.inv_freq when using init_model_with_meta_device, and dtensor precision problems with the XTE optimizer.

Fixed precision now aligns with GPU percentiles.
<img width="536" height="362" alt="image" src="https://github.com/user-attachments/assets/ebcd0c22-aef8-4b20-ad47-3c67c0a1ce6c" />
