### PR TITLE
Update homepage benchmark and contributor count

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -820,13 +820,14 @@ footer a:hover {
 }
 
 .bench-label {
-  flex: 0 0 190px;
+  flex: 0 0 230px;
   font-size: 0.9rem;
   font-weight: 600;
   color: #111827;
   display: flex;
   align-items: center;
   gap: 0.4rem;
+  white-space: nowrap;
 }
 
 .dark .bench-label {
@@ -841,6 +842,8 @@ footer a:hover {
   border-radius: 999px;
   background: #eef2ff;
   color: #4f46e5;
+  white-space: nowrap;
+  flex-shrink: 0;
 }
 
 .dark .bench-type {
@@ -882,6 +885,8 @@ footer a:hover {
   color: #fff;
   font-weight: 700;
   font-size: 0.9rem;
+  position: relative;
+  z-index: 3;
 }
 
 .bench-baseline {
@@ -927,6 +932,15 @@ footer a:hover {
   font-size: 0.95rem;
   color: #111827;
   margin-bottom: 0.25rem;
+}
+
+.bench-callout-title strong {
+  font-weight: 800;
+  color: var(--lf-primary, #6366F1);
+}
+
+.dark .bench-callout-title strong {
+  color: #a5b4fc;
 }
 
 .dark .bench-callout-title {

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -143,10 +143,10 @@
       'about.ack.body': 'LoongForge is built upon NVIDIA\'s Megatron-LM. We also referenced and drew inspiration from excellent open-source projects including Transformers, LLaMA-Factory, and Megatron-Bridge. We sincerely thank these communities for their outstanding contributions.',
 
       'bench.title': '📊 Benchmark',
-      'bench.subtitle': 'Measured on latest LoongForge across LLM, VLM, and VLA workloads',
+      'bench.subtitle': 'Measured on latest LoongForge across LLM, VLM, VLA, and DIT workloads',
       'bench.baseline': '1.0× baseline',
-      'bench.ds.title': 'DeepSeek-V3.2 · DSA operator-level optimizations',
-      'bench.ds.desc': 'Validated on reduced-layer configuration.',
+      'bench.ds.title': '<strong>DeepSeek-V3.2 Lite</strong> · DSA operator-level optimizations',
+      'bench.ds.desc': 'Validated on a reduced-layer configuration due to test-bed scale limits.',
       'hw.title': '💎 Hardware Compatibility',
       'hw.subtitle': 'One codebase, two silicon stacks — production-ready on NVIDIA GPU and Baidu Kunlun XPU',
       'hw.nv.t': 'NVIDIA GPU',
@@ -308,10 +308,10 @@
       'about.ack.body': 'LoongForge 构建于 NVIDIA 的 Megatron-LM 之上，同时借鉴并参考了 Transformers、LLaMA-Factory、Megatron-Bridge 等优秀开源项目。真诚感谢这些社区的卓越贡献。',
 
       'bench.title': '📊 性能基准',
-      'bench.subtitle': '基于 latest，在 A800 上覆盖 LLM、VLM、VLA 工作负载实测',
+      'bench.subtitle': '基于 latest，在 A800 上覆盖 LLM、VLM、VLA、DIT 工作负载实测',
       'bench.baseline': '1.0× 基线',
-      'bench.ds.title': 'DeepSeek-V3.2 · DSA 算子级优化',
-      'bench.ds.desc': '基于裁剪层数配置实测。',
+      'bench.ds.title': '<strong>DeepSeek-V3.2 Lite</strong> · DSA 算子级优化',
+      'bench.ds.desc': '受测试集群规模限制，基于减层模型配置验证。',
 
       'hw.title': '💎 硬件兼容性',
       'hw.subtitle': '同一套代码，两套芯片栈 —— NVIDIA GPU 与百度昆仑芯 XPU 均已生产化落地',
@@ -671,7 +671,7 @@
         .catch(() => { });
     }
     if (contribEl) {
-      fetch('https://api.github.com/repos/baidu-baige/LoongForge/contributors?per_page=1&anon=true')
+      fetch('https://api.github.com/repos/baidu-baige/LoongForge/contributors?per_page=1')
         .then(r => {
           const link = r.headers.get('Link') || '';
           const m = link.match(/page=(\d+)>;\s*rel="last"/);

--- a/index.html
+++ b/index.html
@@ -216,43 +216,50 @@
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="bench.title">📊 Benchmark</h2>
         <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="bench.subtitle">Measured on
-          latest LoongForge across LLM, VLM, and VLA workloads</p>
+          latest LoongForge across LLM, VLM, VLA, and DIT workloads</p>
       </div>
       <div class="max-w-3xl mx-auto">
         <div class="space-y-4">
           <div class="bench-row">
             <div class="bench-label">GR00T N1.6 <span class="bench-type">VLA</span></div>
             <div class="bench-track">
-              <div class="bench-bar bench-bar-top" style="width: 100%"><span class="bench-val">2.30×</span></div>
+              <div class="bench-bar bench-bar-top" style="width: 100%"><span class="bench-val">2.31×</span></div>
+            </div>
+          </div>
+          <div class="bench-row">
+            <div class="bench-label">Wan2.2 <span class="bench-type">DIT</span></div>
+            <div class="bench-track">
+              <div class="bench-bar" style="width: 93.5%"><span class="bench-val">2.16×</span></div>
             </div>
           </div>
           <div class="bench-row">
             <div class="bench-label">Pi0.5 <span class="bench-type">VLA</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 71.7%"><span class="bench-val">1.65×</span></div>
+              <div class="bench-bar" style="width: 71.4%"><span class="bench-val">1.65×</span></div>
             </div>
           </div>
           <div class="bench-row">
             <div class="bench-label">Qwen3-VL-30B-A3B <span class="bench-type">VLM</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 63%"><span class="bench-val">1.45×</span></div>
+              <div class="bench-bar" style="width: 62.8%"><span class="bench-val">1.45×</span></div>
             </div>
           </div>
           <div class="bench-row">
             <div class="bench-label">Qwen3-30B-A3B <span class="bench-type">MoE</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 50.4%"><span class="bench-val">1.16×</span></div>
+              <div class="bench-bar" style="width: 50.2%"><span class="bench-val">1.16×</span></div>
             </div>
           </div>
         </div>
         <div class="bench-baseline" data-i18n="bench.baseline">1.0× baseline</div>
 
         <div class="bench-callout mt-8">
-          <div class="bench-callout-num">~5×</div>
+          <div class="bench-callout-num">5.04×</div>
           <div class="bench-callout-body">
-            <div class="bench-callout-title" data-i18n="bench.ds.title">DeepSeek-V3.2 · DSA operator-level optimizations
-            </div>
-            <div class="bench-callout-desc" data-i18n="bench.ds.desc">Validated on reduced-layer configuration</div>
+            <div class="bench-callout-title" data-i18n-html="bench.ds.title"><strong>DeepSeek-V3.2 Lite</strong> · DSA
+              operator-level optimizations</div>
+            <div class="bench-callout-desc" data-i18n="bench.ds.desc">Validated on a reduced-layer configuration due to
+              test-bed scale limits.</div>
           </div>
         </div>
       </div>
@@ -725,7 +732,8 @@ MODEL_PARALLEL_ARGS=(
         </div>
         <div>
           <a href="https://github.com/baidu-baige/LoongForge/graphs/contributors" target="_blank" rel="noopener"
-            class="text-2xl font-bold text-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-300"><span id="gh-contrib">14+</span></a>
+            class="text-2xl font-bold text-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-300"><span
+              id="gh-contrib">14+</span></a>
           <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1" data-i18n="stats.contrib">
             Contributors</div>
         </div>


### PR DESCRIPTION
- Add Wan2.2 (DIT, 2.16x) to benchmark bars
- Update DeepSeek-V3.2 callout: ~5x -> 5.04x, rename to "DeepSeek-V3.2 Lite", bold the model name, clarify reduced-layer reason in description
- Add DIT to benchmark subtitle (en + zh)
- Drop anon=true from contributors API call so the count matches GitHub UI