### PR TITLE
Auto-feature latest blog post by date

### DIFF
--- a/assets/data/posts.json
+++ b/assets/data/posts.json
@@ -2,7 +2,7 @@
     {
         "slug": "2026-06-loongforge-groot-n16-acceleration",
         "date": "2026-06-02",
-        "featured": true,
+        "featured": false,
         "tags_en": [
             "LoongForge",
             "VLA",
@@ -85,7 +85,7 @@
     {
         "slug": "2026-05-loongforge-v0.1.0-release",
         "date": "2026-05-09",
-        "featured": true,
+        "featured": false,
         "tags_en": [
             "Release",
             "v0.1.0"

--- a/assets/js/blog.js
+++ b/assets/js/blog.js
@@ -99,9 +99,10 @@
     const filtered = (activeTag === allLabel || activeTag === 'All' || activeTag === '全部')
       ? views
       : views.filter(v => v.tags.includes(activeTag));
-    const featured = views.find(v => v.featured) || views[0];
+    // Always feature the most recent post (allPosts is already date-desc sorted).
+    const featured = views[0];
     renderFeatured(featured, lang);
-    renderList(filtered.filter(v => !v.featured));
+    renderList(filtered.filter(v => v.url !== (featured && featured.url)));
     renderTags(views.flatMap(v => v.tags), lang);
   }
 

--- a/skill/wechat-article-blog-import/SKILL.md
+++ b/skill/wechat-article-blog-import/SKILL.md
@@ -46,7 +46,7 @@ Default outcome: import the article, update indexes/site references, run local p
 3. **Convert content deliberately**
    - Chinese page: preserve wording and order; only convert structure (headings/lists/code) and approved cleanup.
    - English page: translate faithfully with the same structure.
-   - Remove WeChat-hosted images unless explicitly requested otherwise.
+   - Image policy: prefer download-and-localize over removal. WeChat image URLs (`mmbiz.qpic.cn`) expire/hot-link-block, so save them under `assets/blog/{slug}/NN.png` (zero-padded, sequential) and rewrite `<img src>` to the local path. Skip purely decorative leading GIFs/banners; start numbering from the first content image. Only remove images entirely when the user explicitly asks.
    - Wrap code/commands/ASCII in `<pre><code class="language-*">`; use `language-python` for Python-like pseudocode, `language-bash` for shell, `language-yaml` for YAML, and `language-text` for diagrams/logs.
    - Avoid long box-drawing diagrams when CJK/full-width text causes alignment issues; prefer stable arrow/indent diagrams.
 
@@ -55,6 +55,7 @@ Default outcome: import the article, update indexes/site references, run local p
    - Update sitemap and README if the site tracks explicit post files.
    - Update homepage cards/benchmark text only when requested or directly relevant.
    - If shared JS text changes and the page references an unversioned JS file, add a cache-busting query string following site convention.
+   - **Featured/highlight slot**: inspect the list renderer (e.g. `blog.js`) before touching any `featured` field. If the renderer uses a "find featured" pattern, only **one** post may be `featured: true` at a time — leaving the previous one as `featured: true` while adding a new one will hide the previous post from the list entirely. Prefer renderers that always promote the most recent post by date so new imports do not require flipping flags. If forced to use the flag, flip the previous featured to `false` in the same change.
 
 5. **Load syntax dependencies**
    - Adding `language-*` classes is not enough. Ensure Prism/Highlight.js language components are loaded on every page that uses them.
@@ -109,7 +110,9 @@ Do not claim completion if local preview or source comparison was skipped. Say e
 | --- | --- |
 | Trusting WeChat fetch output without checking for verification pages | Search for verification text and refetch/ask for local source if blocked |
 | Changing Chinese wording during cleanup | Preserve text; only change markup unless user approves edits |
-| Removing images but leaving broken WeChat URLs | Grep for `mmbiz.qpic.cn`, `wx_fmt`, and `<img>` |
+| Removing images instead of localizing them | Default to download + rewrite `<img src>` to local; only remove if user asks |
+| Leaving broken WeChat URLs after edits | Grep for `mmbiz.qpic.cn` and `wx_fmt`; every `<img>` should resolve to a local file |
+| Two posts marked `featured: true` (when renderer expects one) | Flip the previous to `false` in the same change, or rewrite renderer to always feature the latest by date |
 | Adding `language-python` but no Prism Python component | Add the matching component script and hard-refresh/cache-bust |
 | Box-drawing diagrams misalign in CJK text | Use simpler arrow/indent text diagrams |
 | Updating JS i18n but user sees old copy | Add or update a cache-busting query on the script reference |


### PR DESCRIPTION
- blog.js: always feature views[0] (most recent) instead of looking up featured flag, so adding a new post automatically promotes it and pushes the previous featured back into the main list.
- posts.json: clear featured flag on the new GR00T post (no longer needed by the renderer).
- skill: document image localization default and featured-slot rule to avoid the "two featured" pitfall on future imports.