### PR TITLE
[data, tools] feat: support Kimi K2.5 tool-calling SFT

### DIFF
--- a/configs/data/sft_dataset_config.yaml
+++ b/configs/data/sft_dataset_config.yaml
@@ -32,6 +32,19 @@ sharegpt:
     assistant_tag: assistant
     system_tag: system
 
+openai_chat_completions:
+  format: openai_chat_completions
+  columns:
+    messages: messages
+    tools: tools
+  tags:
+    role_tag: role
+    content_tag: content
+    user_tag: user
+    assistant_tag: assistant
+    system_tag: system
+    tool_tag: tool
+
 multimodal:
   format: sharegpt
   columns:

--- a/loongforge/data/__init__.py
+++ b/loongforge/data/__init__.py
@@ -8,7 +8,11 @@ from .blended_hf_dataset_builder import BlendedHuggingFaceDatasetBuilder
 
 from .sft_dataset import SFTDataset, SFTDatasetConfig
 
-from .chat_template import ChatTemplate, get_support_templates
+from .chat_template import (
+    ChatTemplate,
+    HFChatTemplate,
+    get_support_templates,
+)
 
 from .mm_plugin import MMPlugin
 
@@ -25,6 +29,7 @@ __all__ = [
     "SFTDataset",
     "SFTDatasetConfig",
     "ChatTemplate",
+    "HFChatTemplate",
     "get_support_templates",
     "MMPlugin",
     "DataCollatorForSupervisedDataset",

--- a/loongforge/data/chat_template.py
+++ b/loongforge/data/chat_template.py
@@ -19,6 +19,8 @@
 
 """Chat templates"""
 
+import importlib.resources as resources
+import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
@@ -26,6 +28,7 @@ from typing import (
     TYPE_CHECKING,
     Type,
     Dict,
+    Any,
     List,
     Optional,
     Sequence,
@@ -37,6 +40,9 @@ from typing import (
 from loongforge.utils.constants import DataRoles
 from .mm_plugin import MMPlugin, Qwen2VLPlugin, Qwen3VLPlugin
 from .kimi_k25_plugin import KimiK25Plugin
+
+
+logger = logging.getLogger(__name__)
 
 
 if TYPE_CHECKING:
@@ -178,6 +184,23 @@ class ChatTemplate:
         answer_ids = encoded_messages[-1]
         return prompt_ids, answer_ids
 
+    def encode_openai(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, Any]],
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+        train_on_prompt: bool = False,
+        history_mask_loss: bool = False,
+        ignore_index: int = -100,
+        max_length: Optional[int] = None,
+    ) -> Tuple[List[int], List[int], List[int], int]:
+        """Encode OpenAI-style messages. Only HFChatTemplate supports this."""
+        raise NotImplementedError(
+            "OpenAI-style SFT data requires an HFChatTemplate registered for "
+            "the target model, usually selected by a model-specific `*-hf` "
+            "chat template name."
+        )
+
     def _encode(
         self,
         tokenizer: "AutoTokenizerFromHF",
@@ -255,6 +278,408 @@ class ChatTemplate:
 
 
 @dataclass
+class HFChatTemplate(ChatTemplate):
+    """Chat template backed by HuggingFace tokenizer.apply_chat_template."""
+
+    chat_template: Optional[str] = None
+    chat_template_kwargs: Dict[str, Any] = field(default_factory=dict)
+
+    def _encode(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, str]],
+        system: Optional[str],
+    ) -> List[List[int]]:
+        """Reject legacy prompt/response encoding for HF Jinja templates."""
+        raise NotImplementedError(
+            "HFChatTemplate only supports OpenAI-style `messages` data through "
+            "encode_openai(). Use an OpenAI chat-completions dataset format "
+            "with a registered model-specific `*-hf` chat template."
+        )
+
+    @staticmethod
+    def _require_generation_template(chat_template: Optional[str]) -> str:
+        """Return a template that contains HF generation blocks, or fail fast."""
+        if chat_template is None:
+            raise ValueError("HFChatTemplate does not provide a chat_template.")
+        has_start = re.search(r"{%-?\s*generation\s*-?%}", chat_template)
+        has_end = re.search(r"{%-?\s*endgeneration\s*-?%}", chat_template)
+        if has_start and has_end:
+            return chat_template
+        raise ValueError(
+            "HF chat_template must contain paired `{% generation %}` / "
+            "`{% endgeneration %}` blocks for OpenAI-style assistant loss masks. "
+            "Use a registered model-specific `*-hf` training template."
+        )
+
+    @staticmethod
+    def _as_list(value) -> List[int]:
+        """Normalize tokenizer outputs to a flat Python list of token ids."""
+        if hasattr(value, "tolist"):
+            value = value.tolist()
+        if value and isinstance(value[0], list):
+            return list(value[0])
+        return list(value)
+
+    def _tokenize(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, Any]],
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+        add_generation_prompt: bool = False,
+    ) -> List[int]:
+        """Tokenize chat messages with the tokenizer's HF chat template path."""
+        hf_tokenizer = tokenizer.hf_tokenizer()
+        kwargs = dict(self.chat_template_kwargs)
+        if tools:
+            kwargs["tools"] = tools
+        kwargs.update(
+            {
+                "tokenize": True,
+                "return_dict": False,
+                "add_generation_prompt": add_generation_prompt,
+            }
+        )
+
+        rendered = hf_tokenizer.apply_chat_template(
+            list(messages),
+            chat_template=self.chat_template,
+            **kwargs,
+        )
+        return self._as_list(rendered)
+
+    @staticmethod
+    def _encode_text(hf_tokenizer, text: str) -> List[int]:
+        """Encode already-rendered chat text without adding special tokens."""
+        if not text:
+            return []
+        return list(hf_tokenizer.encode(text, add_special_tokens=False))
+
+    @staticmethod
+    def _prepare_tools_for_render(
+        hf_tokenizer,
+        tools: Optional[Sequence[Dict[str, Any]]],
+        kwargs: Dict[str, Any],
+    ) -> Tuple[Optional[List[Dict[str, Any]]], Dict[str, Any]]:
+        """Prepare tools for direct Jinja rendering outside apply_chat_template."""
+        if not tools:
+            return None, kwargs
+
+        tools = list(tools)
+        apply_chat_template = hf_tokenizer.apply_chat_template
+        if hasattr(apply_chat_template, "__func__"):
+            apply_chat_template = apply_chat_template.__func__
+        apply_globals = getattr(apply_chat_template, "__globals__", {})
+        deep_sort_dict = apply_globals.get("deep_sort_dict")
+        encode_tools_to_typescript_style = apply_globals.get(
+            "encode_tools_to_typescript_style"
+        )
+
+        if deep_sort_dict is not None:
+            tools = deep_sort_dict(tools)
+
+        if (
+            "tools_ts_str" not in kwargs
+            and encode_tools_to_typescript_style is not None
+        ):
+            try:
+                kwargs["tools_ts_str"] = encode_tools_to_typescript_style(tools)
+            except Exception as exc:
+                logger.warning(
+                    "Failed to render tools_ts_str with HF tokenizer helper; "
+                    "falling back to raw tools for chat template rendering: %s",
+                    exc,
+                )
+
+        return tools, kwargs
+
+    def _render_with_generation_indices(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, Any]],
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> Tuple[str, List[Tuple[int, int]]]:
+        """Render chat text and return assistant generation character ranges."""
+        from transformers.utils.chat_template_utils import render_jinja_template
+
+        hf_tokenizer = tokenizer.hf_tokenizer()
+        chat_template = self._require_generation_template(self.chat_template)
+
+        kwargs = dict(self.chat_template_kwargs)
+        documents = kwargs.get("documents")
+        tools, kwargs = self._prepare_tools_for_render(hf_tokenizer, tools, kwargs)
+        render_kwargs = {**hf_tokenizer.special_tokens_map, **kwargs}
+        render_kwargs.update(
+            {
+                "conversations": [list(messages)],
+                "tools": tools,
+                "documents": documents,
+                "chat_template": chat_template,
+                "return_assistant_tokens_mask": True,
+                "continue_final_message": False,
+                "add_generation_prompt": False,
+            }
+        )
+        rendered_chats, generation_indices = render_jinja_template(**render_kwargs)
+        return rendered_chats[0], generation_indices[0]
+
+    @staticmethod
+    def _offsets_from_tokenizer(
+        hf_tokenizer,
+        text: str,
+        input_ids: List[int],
+    ) -> Optional[List[Tuple[int, int]]]:
+        """Return token character offsets using fast offsets or decode offsets."""
+        try:
+            encoded = hf_tokenizer(
+                text,
+                add_special_tokens=False,
+                return_offsets_mapping=True,
+            )
+            encoded_ids = encoded.get("input_ids")
+            offsets = encoded.get("offset_mapping")
+            if encoded_ids == input_ids and offsets is not None:
+                return [(int(start), int(end)) for start, end in offsets]
+        except (NotImplementedError, TypeError, ValueError):
+            pass
+
+        model = getattr(hf_tokenizer, "model", None)
+        if hasattr(model, "decode_with_offsets"):
+            decoded_text, offsets = model.decode_with_offsets(input_ids)
+            if decoded_text == text and len(offsets) == len(input_ids):
+                starts = [int(offset) for offset in offsets]
+                ends = starts[1:] + [len(text)]
+                return list(zip(starts, ends))
+
+        return None
+
+    @staticmethod
+    def _span_mask_from_offsets(
+        offsets: List[Tuple[int, int]],
+        generation_ranges: List[Tuple[int, int]],
+    ) -> List[int]:
+        """Convert generation character ranges into a per-token assistant mask."""
+        mask: List[int] = []
+        range_index = 0
+
+        for token_start, token_end in offsets:
+            while (
+                range_index < len(generation_ranges)
+                and generation_ranges[range_index][1] <= token_start
+            ):
+                range_index += 1
+
+            if range_index >= len(generation_ranges):
+                mask.append(0)
+                continue
+
+            range_start, range_end = generation_ranges[range_index]
+            overlaps = token_start < range_end and token_end > range_start
+            if not overlaps:
+                mask.append(0)
+                continue
+
+            if token_start < range_start or token_end > range_end:
+                raise ValueError(
+                    "HuggingFace generation boundary splits a token. "
+                    "Move `{% generation %}` boundaries to tokenizer boundaries."
+                )
+            mask.append(1)
+
+        return mask
+
+    def _chunk_tokenize_mask(
+        self,
+        hf_tokenizer,
+        text: str,
+        input_ids: List[int],
+        generation_ranges: List[Tuple[int, int]],
+    ) -> Optional[List[int]]:
+        """Fallback mask builder that tokenizes generation/non-generation chunks."""
+        boundaries = sorted(
+            {0, len(text)}
+            | {boundary for span in generation_ranges for boundary in span}
+        )
+        chunk_ids: List[int] = []
+        chunk_mask: List[int] = []
+
+        for start, end in zip(boundaries, boundaries[1:]):
+            chunk = text[start:end]
+            token_ids = self._encode_text(hf_tokenizer, chunk)
+            in_generation = any(
+                range_start <= start and end <= range_end
+                for range_start, range_end in generation_ranges
+            )
+            chunk_ids.extend(token_ids)
+            chunk_mask.extend([1 if in_generation else 0] * len(token_ids))
+
+        if chunk_ids == input_ids:
+            return chunk_mask
+        return None
+
+    def _assistant_mask_from_generation_ranges(
+        self,
+        hf_tokenizer,
+        text: str,
+        input_ids: List[int],
+        generation_ranges: List[Tuple[int, int]],
+    ) -> List[int]:
+        """Align assistant generation character ranges to input token positions."""
+        offsets = self._offsets_from_tokenizer(hf_tokenizer, text, input_ids)
+        if offsets is not None:
+            return self._span_mask_from_offsets(offsets, generation_ranges)
+
+        chunk_mask = self._chunk_tokenize_mask(
+            hf_tokenizer=hf_tokenizer,
+            text=text,
+            input_ids=input_ids,
+            generation_ranges=generation_ranges,
+        )
+        if chunk_mask is not None:
+            return chunk_mask
+
+        raise ValueError(
+            "Unable to align HuggingFace generation ranges to token positions. "
+            "Use a fast tokenizer with offsets, a tokenizer exposing decode_with_offsets, "
+            "or place `{% generation %}` boundaries exactly on tokenizer boundaries."
+        )
+
+    def _tokenize_with_generation_indices(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, Any]],
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+    ) -> Tuple[List[int], List[int]]:
+        """Render OpenAI chat messages and build assistant-token masks."""
+        hf_tokenizer = tokenizer.hf_tokenizer()
+        rendered, generation_ranges = self._render_with_generation_indices(
+            tokenizer=tokenizer,
+            messages=messages,
+            tools=tools,
+        )
+        input_ids = self._encode_text(hf_tokenizer, rendered)
+        assistant_masks = self._assistant_mask_from_generation_ranges(
+            hf_tokenizer=hf_tokenizer,
+            text=rendered,
+            input_ids=input_ids,
+            generation_ranges=generation_ranges,
+        )
+        return input_ids, assistant_masks
+
+    @staticmethod
+    def _mask_to_final_span(mask: List[int]) -> List[int]:
+        """Keep only the final contiguous trainable assistant span."""
+        last_start = None
+        last_end = None
+        index = 0
+        while index < len(mask):
+            if mask[index]:
+                start = index
+                while index < len(mask) and mask[index]:
+                    index += 1
+                last_start, last_end = start, index
+            else:
+                index += 1
+
+        final_mask = [0] * len(mask)
+        if last_start is not None:
+            final_mask[last_start:last_end] = [1] * (last_end - last_start)
+        return final_mask
+
+    @staticmethod
+    def _truncate_to_assistant_boundary(
+        input_ids: List[int],
+        assistant_masks: List[int],
+        max_length: Optional[int],
+    ) -> Tuple[List[int], List[int]]:
+        """Keep a prefix whose final token is inside assistant generation."""
+        if len(input_ids) != len(assistant_masks):
+            raise ValueError(
+                "assistant mask length must match input_ids length, got "
+                f"{len(assistant_masks)} vs {len(input_ids)}"
+            )
+        if max_length is None or len(input_ids) <= max_length:
+            return input_ids, assistant_masks
+        if max_length <= 0:
+            return [], []
+
+        end = max_length
+        if assistant_masks[end - 1]:
+            return input_ids[:end], assistant_masks[:end]
+
+        # If the nominal boundary is in source/user/tool text, roll back to the
+        # previous assistant token so the kept sample ends at a trainable answer.
+        boundary = end - 1
+        while boundary >= 0 and not assistant_masks[boundary]:
+            boundary -= 1
+
+        if boundary < 0:
+            return [], []
+
+        end = boundary + 1
+        return input_ids[:end], assistant_masks[:end]
+
+    @classmethod
+    def _build_labels_from_assistant_mask(
+        cls,
+        input_ids: List[int],
+        assistant_masks: List[int],
+        ignore_index: int,
+        history_mask_loss: bool,
+    ) -> Tuple[List[int], List[int]]:
+        """Build labels and loss mask from the assistant-token mask."""
+        if len(input_ids) != len(assistant_masks):
+            raise ValueError(
+                "assistant mask length must match input_ids length, got "
+                f"{len(assistant_masks)} vs {len(input_ids)}"
+            )
+
+        loss_mask = [1 if mask else 0 for mask in assistant_masks]
+        if history_mask_loss:
+            loss_mask = cls._mask_to_final_span(loss_mask)
+        labels = [
+            token_id if mask else ignore_index
+            for token_id, mask in zip(input_ids, loss_mask)
+        ]
+        return labels, loss_mask
+
+    def encode_openai(
+        self,
+        tokenizer: "AutoTokenizerFromHF",
+        messages: Sequence[Dict[str, Any]],
+        tools: Optional[Sequence[Dict[str, Any]]] = None,
+        train_on_prompt: bool = False,
+        history_mask_loss: bool = False,
+        ignore_index: int = -100,
+        max_length: Optional[int] = None,
+    ) -> Tuple[List[int], List[int], List[int], int]:
+        """Encode OpenAI-style chat data into input ids, labels, and loss mask."""
+        input_ids, assistant_masks = self._tokenize_with_generation_indices(
+            tokenizer=tokenizer,
+            messages=messages,
+            tools=tools,
+        )
+        ori_total_len = len(input_ids)
+        input_ids, assistant_masks = self._truncate_to_assistant_boundary(
+            input_ids=input_ids,
+            assistant_masks=assistant_masks,
+            max_length=max_length,
+        )
+
+        if train_on_prompt:
+            labels = list(input_ids)
+            return input_ids, labels, [1] * len(input_ids), ori_total_len
+
+        labels, loss_mask = self._build_labels_from_assistant_mask(
+            input_ids=input_ids,
+            assistant_masks=assistant_masks,
+            ignore_index=ignore_index,
+            history_mask_loss=history_mask_loss,
+        )
+        return input_ids, labels, loss_mask, ori_total_len
+
+
+@dataclass
 class Llama2Template(ChatTemplate):
     """LLaMA-2 Template"""
 
@@ -314,6 +739,8 @@ def _register_chat_template(
     efficient_eos: bool = False,
     replace_eos: bool = False,
     mm_plugin: Optional[MMPlugin] = None,
+    chat_template: Optional[str] = None,
+    chat_template_kwargs: Optional[Dict[str, Any]] = None,
 ) -> None:
     """
     Registers a chat template.
@@ -344,7 +771,7 @@ def _register_chat_template(
     if name in MAPPING_NAME_TO_TEMPLATE:
         raise ValueError(f"Cannot register duplicate template with name {name}.")
 
-    MAPPING_NAME_TO_TEMPLATE[name] = cls(
+    template = cls(
         format_user=format_user,
         format_assistant=format_assistant,
         format_system=format_system,
@@ -356,6 +783,16 @@ def _register_chat_template(
         replace_eos=replace_eos,
         mm_plugin=mm_plugin,
     )
+    if chat_template is not None:
+        if not isinstance(template, HFChatTemplate):
+            raise ValueError("chat_template can only be set for HFChatTemplate.")
+        template.chat_template = chat_template
+    if chat_template_kwargs is not None:
+        if not isinstance(template, HFChatTemplate):
+            raise ValueError("chat_template_kwargs can only be set for HFChatTemplate.")
+        template.chat_template_kwargs = dict(chat_template_kwargs)
+
+    MAPPING_NAME_TO_TEMPLATE[name] = template
 
 
 def get_support_templates() -> List[str]:
@@ -363,6 +800,23 @@ def get_support_templates() -> List[str]:
     Returns a list of supported chat templates.
     """
     return list(MAPPING_NAME_TO_TEMPLATE.keys())
+
+
+_register_chat_template(
+    name="kimi-k2.5-hf",
+    cls=HFChatTemplate,
+    chat_template=(
+        resources.files("loongforge.data.chat_templates")
+        .joinpath("kimi_k2_5_training.jinja")
+        .read_text(encoding="utf-8")
+    ),
+    mm_plugin=KimiK25Plugin(
+        image_token="<|media_content|>",
+        video_token="<|media_content|>",
+        merge_kernel_size=(2, 2),
+        temporal_merge_kernel_size=4,
+    ),
+)
 
 
 _register_chat_template(

--- a/loongforge/data/chat_templates/__init__.py
+++ b/loongforge/data/chat_templates/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Built-in HuggingFace Jinja chat templates for SFT preprocessing."""

--- a/loongforge/data/chat_templates/kimi_k2_5_training.jinja
+++ b/loongforge/data/chat_templates/kimi_k2_5_training.jinja
@@ -1,0 +1,123 @@
+{# LoongForge Kimi K2.5 SFT training template.
+   Assistant generation blocks include the assistant body and its <|im_end|>
+   turn terminator, matching assistant-only loss training templates. #}
+{%- macro render_content(msg) -%}
+    {%- set c = msg.get('content') -%}
+    {%- if c is string -%}
+      {{ c }}
+    {%- elif c is not none -%}
+      {% for content in c -%}
+        {% if content['type'] == 'image' or content['type'] == 'image_url' -%}
+          <|media_begin|>image<|media_content|><|media_pad|><|media_end|>
+        {% elif content['type'] == 'video' or content['type']== 'video_url'-%}
+          <|kimi_k25_video_placeholder|>
+        {% else -%}
+          {{ content['text'] }}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+
+{% macro set_roles(message) -%}
+  {%- set role_name =  message.get('name') or  message['role'] -%}
+  {%- if message['role'] == 'user' -%}
+    <|im_user|>{{role_name}}<|im_middle|>
+  {%- elif message['role'] == 'assistant' -%}
+    <|im_assistant|>{{role_name}}<|im_middle|>
+  {%- else -%}
+    <|im_system|>{{role_name}}<|im_middle|>
+  {%- endif -%}
+{%- endmacro -%}
+
+
+{%- macro render_toolcalls(message) -%}
+  <|tool_calls_section_begin|>
+  {%- for tool_call in message['tool_calls'] -%}
+    {%- set formatted_id = tool_call['id'] -%}
+    <|tool_call_begin|>{{ formatted_id }}<|tool_call_argument_begin|>{% if tool_call['function']['arguments'] is string %}{{ tool_call['function']['arguments'] }}{% else %}{{ tool_call['function']['arguments'] | tojson }}{% endif %}<|tool_call_end|>
+  {%- endfor -%}
+  <|tool_calls_section_end|>
+{%- endmacro -%}
+
+
+{# Find last non-tool-call assistant message. #}
+{%- set ns = namespace(last_non_tool_call_assistant_msg=-1) -%}
+{%- for idx in range(messages|length-1, -1, -1) -%}
+    {%- if messages[idx]['role'] == 'assistant' and not messages[idx].get('tool_calls') -%}
+        {%- set ns.last_non_tool_call_assistant_msg = idx -%}
+        {%- break -%}
+    {%- endif -%}
+{%- endfor -%}
+
+{# split all messages into history & suffix, reasoning_content in suffix should be reserved. #}
+{%- set hist_msgs = messages[:ns.last_non_tool_call_assistant_msg+1] -%}
+{%- set suffix_msgs = messages[ns.last_non_tool_call_assistant_msg+1:] -%}
+
+{%- if tools -%}
+  {%- if tools_ts_str -%}
+    <|im_system|>tool_declare<|im_middle|>{{ tools_ts_str }}<|im_end|>
+  {%- else -%}
+    <|im_system|>tool_declare<|im_middle|>{{ tools | tojson(separators=(',', ':')) }}<|im_end|>
+  {%- endif -%}
+{%- endif -%}
+
+{%- for message in hist_msgs -%}
+  {{set_roles(message)}}
+  {%- if message['role'] == 'assistant' -%}
+    {%- generation -%}
+    <think></think>{{render_content(message)}}
+    {%- if message.get('tool_calls') -%}
+      {{render_toolcalls(message)}}
+    {%- endif -%}
+    {{- '<|im_end|>' -}}
+    {%- endgeneration -%}
+  {%- elif message['role'] == 'tool' -%}
+    {%- set tool_call_id = message.tool_call_id -%}
+    ## Return of {{ tool_call_id }}
+{{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- elif message['content'] is not none -%}
+    {{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- else -%}
+    {{- '<|im_end|>' -}}
+  {%- endif -%}
+{%- endfor -%}
+
+{%- for message in suffix_msgs -%}
+  {{set_roles(message)}}
+  {%- if message['role'] == 'assistant' -%}
+    {%- generation -%}
+    {%- if thinking is defined and thinking is false -%}
+    <think></think>{{render_content(message)}}
+    {%- else -%}
+    {%- set rc = message.get('reasoning_content', '') -%}
+    <think>{{rc}}</think>{{render_content(message)}}
+    {%- endif -%}
+    {%- if message.get('tool_calls') -%}
+     {{render_toolcalls(message)}}
+    {%- endif -%}
+    {{- '<|im_end|>' -}}
+    {%- endgeneration -%}
+  {%- elif message['role'] == 'tool' -%}
+    {%- set tool_call_id = message.tool_call_id -%}
+    ## Return of {{ tool_call_id }}
+{{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- elif message['content'] is not none -%}
+    {{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- else -%}
+    {{- '<|im_end|>' -}}
+  {%- endif -%}
+{%- endfor -%}
+
+
+{%- if add_generation_prompt -%}
+  <|im_assistant|>assistant<|im_middle|>
+  {%- if thinking is defined and thinking is false -%}
+  <think></think>
+  {%- else -%}
+  <think>
+  {%- endif -%}
+{%- endif -%}

--- a/loongforge/data/multimodal/__init__.py
+++ b/loongforge/data/multimodal/__init__.py
@@ -9,8 +9,10 @@ from loongforge.data.multimodal.flavors import (
     PackedCaptioningSample,
     PackedVQASample,
     PackedMultiMixQASample,
+    PackedChatMixSample,
     MultiVidQASample,
     MultiMixQASample,
+    ChatMixSample,
 )
 
 # Registry for multimodal task encoders so configs can swap them without
@@ -58,8 +60,10 @@ __all__ = [
     "PackedCaptioningSample",
     "PackedVQASample",
     "PackedMultiMixQASample",
+    "PackedChatMixSample",
     "MultiVidQASample",
     "MultiMixQASample",
+    "ChatMixSample",
     "TASK_ENCODER_REGISTRY",
     "resolve_task_encoder",
     "build_task_encoder",

--- a/loongforge/data/multimodal/base/task_encoder.py
+++ b/loongforge/data/multimodal/base/task_encoder.py
@@ -24,8 +24,10 @@ from loongforge.data.multimodal import (
     PackedCaptioningSample,
     PackedVQASample,
     PackedMultiMixQASample,
+    PackedChatMixSample,
     MultiVidQASample,
     MultiMixQASample,
+    ChatMixSample,
 )
 
 from megatron.energon import (
@@ -149,6 +151,9 @@ class BaseTaskBatchPacked(Batch):
 
 _vlm_tags_cache: Optional[Dict[str, Dict]] = None
 
+_IMAGE_EXTS: Tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif", ".tiff")
+_VIDEO_EXTS: Tuple[str, ...] = (".mp4", ".avi", ".mov", ".webm")
+
 
 def _load_vlm_tags(section: Optional[str] = None) -> Dict[str, any]:
     """Load and cache the VLM message tags from the dataset config file.
@@ -174,6 +179,8 @@ def _load_vlm_tags(section: Optional[str] = None) -> Dict[str, any]:
             user_tag: human
             assistant_tag: gpt
             system_tag: system
+            tool_tag: tool
+            function_tag: function
     """
     global _vlm_tags_cache
     args = get_args()
@@ -218,6 +225,7 @@ def _parse_messages(raw_messages, section: Optional[str] = None) -> Tuple[List[D
         tags.get("user_tag", "user"): "user",
         tags.get("assistant_tag", "assistant"): "assistant",
         tags.get("system_tag", "system"): "system",
+        tags.get("tool_tag", "tool"): "tool",
     }
 
     messages: List[Dict] = []
@@ -227,14 +235,24 @@ def _parse_messages(raw_messages, section: Optional[str] = None) -> Tuple[List[D
         role = message.get(role_tag)
         content = message.get(content_tag, "")
         role = role_map.get(role, role)
-        if role not in ("system", "user", "assistant"):
+        if role not in ("system", "user", "assistant", "tool"):
             raise ValueError(f"Unsupported role '{role}' in message: {message}")
         if role == "system":
             system = content
             continue
-        messages.append({"role": role, "content": content})
+        normalized = dict(message)
+        normalized["role"] = role
+        normalized["content"] = content
+        messages.append(normalized)
 
     return messages, system
+
+
+def _attach_tools(sample_obj, json_data: dict):
+    tools = json_data.get("tools")
+    if tools:
+        setattr(sample_obj, "tools", tools)
+    return sample_obj
 
 
 @stateless
@@ -251,7 +269,7 @@ def cooker_multi_mix_qa(sample: dict):
             image.append(sample.get(name))
 
     if _ENERGON_NEEDS_SUBFLAVOR:
-        return MultiMixQASample(
+        return _attach_tools(MultiMixQASample(
             __key__=sample["__key__"],
             __restore_key__=sample["__restore_key__"],
             __subflavor__=None,
@@ -260,9 +278,9 @@ def cooker_multi_mix_qa(sample: dict):
             image=image if len(image) > 0 else None,
             system=system,
             messages=messages,
-        )
+        ), sample["json"])
     else:
-        return MultiMixQASample(
+        return _attach_tools(MultiMixQASample(
             __key__=sample["__key__"],
             __restore_key__=sample["__restore_key__"],
             __subflavors__=sample.get("__subflavors__", {}),
@@ -270,7 +288,64 @@ def cooker_multi_mix_qa(sample: dict):
             image=image if len(image) > 0 else None,
             system=system,
             messages=messages,
+        ), sample["json"])
+
+@stateless
+def cooker_chat_mix(sample: dict) -> ChatMixSample:
+    """Convert raw sample dict into a ChatMixSample.
+
+    Expected json layout (one chat session per sample):
+      {
+        "messages": [...],          # OpenAI Chat Completions-style messages
+        "tools": [...],             # optional tool definitions
+        "media": "image"|"video"|"text",
+        "name": [...]               # media file names referenced by messages
+      }
+    """
+    data = sample["json"]
+    raw_messages = data.get("messages")
+    if raw_messages is None:
+        raise ValueError(
+            f"cooker_chat_mix: sample {sample.get('__key__')!r} has no "
+            "`messages` field. chat_mix shards must use OpenAI Chat "
+            "Completions-style `messages`."
         )
+
+    messages, system = _parse_messages(raw_messages)
+    tools = data.get("tools")
+
+    video: List = []
+    image: List = []
+    for name in data.get("name", []) or []:
+        obj = sample.get(name)
+        if obj is None:
+            continue
+        lower = name.lower()
+        if lower.endswith(_IMAGE_EXTS):
+            image.append(obj)
+        elif lower.endswith(_VIDEO_EXTS):
+            video.append(obj)
+        else:
+            raise ValueError(
+                f"cooker_chat_mix: sample {sample.get('__key__')!r} has media "
+                f"{name!r} with unrecognized extension; expected one of "
+                f"{_IMAGE_EXTS + _VIDEO_EXTS}"
+            )
+
+    init_kwargs = {
+        "__key__": sample["__key__"],
+        "__restore_key__": sample["__restore_key__"],
+        "__subflavors__": sample.get("__subflavors__", {}),
+        "messages": messages,
+        "image": image if len(image) > 0 else None,
+        "video": video if len(video) > 0 else None,
+        "system": system,
+        "tools": tools if tools else None,
+    }
+    if _ENERGON_NEEDS_SUBFLAVOR:
+        init_kwargs["__subflavor__"] = None
+    return ChatMixSample(**init_kwargs)
+
 
 @stateless
 def cooker_multi_vid_vqa(sample: dict):
@@ -288,7 +363,7 @@ def cooker_multi_vid_vqa(sample: dict):
             image.append(sample.get(name))
 
     if _ENERGON_NEEDS_SUBFLAVOR:
-        return MultiVidQASample(
+        return _attach_tools(MultiVidQASample(
             __key__=sample["__key__"],
             __restore_key__=sample["__restore_key__"],
             __subflavor__=None,
@@ -296,16 +371,16 @@ def cooker_multi_vid_vqa(sample: dict):
             video=video if len(video) > 0 else None,
             system=system,
             messages=messages,
-        )
+        ), sample["json"])
     else:
-        return MultiVidQASample(
+        return _attach_tools(MultiVidQASample(
             __key__=sample["__key__"],
             __restore_key__=sample["__restore_key__"],
             __subflavors__=sample.get("__subflavors__", {}),
             video=video if len(video) > 0 else None,
             system=system,
             messages=messages,
-        )
+        ), sample["json"])
 
 
 @stateless
@@ -456,6 +531,116 @@ def cooker_packed_multi_mix_qa(sample: dict):
             answer_weights=None,
         )
 
+
+@stateless
+def cooker_packed_chat_mix(sample: dict):
+    """
+    Convert packed full chat/tool-calling json into a PackedChatMixSample.
+
+    Expected json layout (example):
+    {
+      "messages": [          # len = N
+        {
+          "messages": [...],  # OpenAI Chat Completions-style messages
+          "tools": [...],     # optional tool definitions
+          "source": {...}     # optional source metadata
+        },
+        ...
+      ],
+      "media_files": [       # length = N
+        ["imgA.jpg", "imgB.jpg", ...],
+        ["imgC.jpg", ...],
+        ...
+      ],
+      "media_type": "image" | "video" | "text"
+    }
+    """
+    data = sample["json"]
+
+    messages = data.get("messages")
+    if messages is None:
+        messages = data.get("texts", []) or []
+    if not isinstance(messages, list):
+        raise ValueError(
+            f"[cooker_packed_chat_mix] expected `messages` to be a list "
+            f"for key={sample['__key__']}, got {type(messages).__name__}"
+        )
+
+    media_files = data.get("media_files", []) or []
+    media_type = (data.get("media_type") or "").lower()
+
+    if len(media_files) != len(messages):
+        raise ValueError(
+            f"[cooker_packed_chat_mix] media_files/messages length mismatch "
+            f"for key={sample['__key__']}: {len(media_files)} vs {len(messages)}"
+        )
+
+    images = None
+    videos = None
+
+    if media_type == "image":
+        images = []
+        for group in media_files:
+            image_group = []
+            if isinstance(group, (list, tuple)):
+                for name in group:
+                    img = sample.get(name)
+                    if img is not None:
+                        image_group.append(img)
+            elif isinstance(group, str):
+                img = sample.get(group)
+                if img is not None:
+                    image_group.append(img)
+            images.append(image_group)
+        if all(len(g) == 0 for g in images):
+            images = None
+        videos = None
+    elif media_type == "video":
+        videos = []
+        for group in media_files:
+            video_group = []
+            if isinstance(group, (list, tuple)):
+                for name in group:
+                    vid = sample.get(name)
+                    if vid is not None:
+                        video_group.append(vid)
+            elif isinstance(group, str):
+                vid = sample.get(group)
+                if vid is not None:
+                    video_group.append(vid)
+            videos.append(video_group)
+        if all(len(g) == 0 for g in videos):
+            videos = None
+        images = None
+    elif media_type == "text":
+        images = None
+        videos = None
+    else:
+        raise ValueError(
+            f"[cooker_packed_chat_mix] unknown media_type='{media_type}'. "
+            f"Expect 'image', 'video', or 'text'."
+        )
+
+    if _ENERGON_NEEDS_SUBFLAVOR:
+        return PackedChatMixSample(
+            __key__=sample["__key__"],
+            __restore_key__=sample["__restore_key__"],
+            __subflavor__=None,
+            __subflavors__=sample.get("__subflavors__", {}),
+            packed_messages=messages,
+            packed_images=images,
+            packed_videos=videos,
+        )
+    else:
+        return PackedChatMixSample(
+            __key__=sample["__key__"],
+            __restore_key__=sample["__restore_key__"],
+            __subflavors__=sample.get("__subflavors__", {}),
+            packed_messages=messages,
+            packed_images=images,
+            packed_videos=videos,
+        )
+
 @stateless
 def cooker_packed_caption(sample: dict):
     """Convert raw sample dict into a PackedCaptioningSample."""
@@ -489,6 +674,8 @@ def cooker_default(sample: dict):
     args = get_args()
     if args.sample_type == "multi_mix_qa":
         return cooker_multi_mix_qa(sample)
+    elif args.sample_type == "chat_mix":
+        return cooker_chat_mix(sample)
     elif args.sample_type == "feature_vqa":
         return cooker_feature_qa(sample)
     elif args.sample_type == "packed_captioning":
@@ -497,6 +684,8 @@ def cooker_default(sample: dict):
         return cooker_packed_vqa(sample)
     elif args.sample_type == "packed_multi_mix_qa":
         return cooker_packed_multi_mix_qa(sample)
+    elif args.sample_type == "packed_chat_mix":
+        return cooker_packed_chat_mix(sample)
     else:
         raise NotImplementedError("Sample format not supported", sample)
 
@@ -505,11 +694,13 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
     """A simple task encoder for VLMs."""
     cookers = [
         Cooker(cooker_multi_mix_qa, has_subflavors={"sample_type": "multi_mix_qa"}),
+        Cooker(cooker_chat_mix, has_subflavors={"sample_type": "chat_mix"}),
         Cooker(cooker_multi_vid_vqa, has_subflavors={"sample_type": "multi_vid_vqa"}),
         Cooker(cooker_feature_qa, has_subflavors={"sample_type": "feature_vqa"}),
         Cooker(cooker_packed_caption, has_subflavors={"sample_type": "packed_captioning"}),
         Cooker(cooker_packed_vqa, has_subflavors={"sample_type": "packed_vqa"}),
         Cooker(cooker_packed_multi_mix_qa, has_subflavors={"sample_type": "packed_multi_mix_qa"}),
+        Cooker(cooker_packed_chat_mix, has_subflavors={"sample_type": "packed_chat_mix"}),
         Cooker(cooker_default,)
     ]
 
@@ -530,7 +721,12 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
         """Generates an encoded sample from a raw sample."""
         assert not (
             self.args.packing_sft_data
-            and isinstance(sample, (PackedCaptioningSample, PackedVQASample, PackedMultiMixQASample))
+            and isinstance(sample, (
+                PackedCaptioningSample,
+                PackedVQASample,
+                PackedMultiMixQASample,
+                PackedChatMixSample,
+            ))
         ), (
             f"Configuration conflict: --packing-sft-data is enabled (online packing), "
             f"but the dataset contains offline-packed samples of type '{type(sample).__name__}'. "
@@ -543,6 +739,8 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
             yield self.encode_vqa(sample)
         elif isinstance(sample, MultiVidQASample):
             yield self.encode_multi_vid_qa(sample)
+        elif isinstance(sample, ChatMixSample):
+            yield self.encode_chat_mix(sample)
         elif isinstance(sample, MultiMixQASample):
             yield self.encode_multi_mix_qa(sample)
         elif isinstance(sample, PackedCaptioningSample):
@@ -551,6 +749,8 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
             yield self.encode_packed_vqa(sample)
         elif isinstance(sample, PackedMultiMixQASample):
             yield self.encode_packed_multi_mix_qa(sample)
+        elif isinstance(sample, PackedChatMixSample):
+            yield self.encode_packed_chat_mix(sample)
         else:
             raise NotImplementedError("Sample format not supported", sample)
 
@@ -565,6 +765,14 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
     def encode_multi_mix_qa(self, sample: MultiMixQASample) -> BaseTaskSample:
         """Generates an encoded multi_mix_qa sample from a raw sample."""
         raise NotImplementedError("encode_multi_mix_qa not supported", sample)
+
+    def encode_chat_mix(self, sample: ChatMixSample) -> BaseTaskSample:
+        """Generates an encoded chat-format multimodal sample (with tool calling)."""
+        raise NotImplementedError(
+            f"{type(self).__name__} must implement encode_chat_mix to use "
+            f"chat_mix or packed_chat_mix sample types.",
+            sample,
+        )
 
     def encode_multi_vid_qa(self, sample: MultiVidQASample) -> BaseTaskSample:
         """Generates an encoded vid_qa sample from a raw sample."""
@@ -588,6 +796,10 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
     def encode_packed_multi_mix_qa(self, sample: PackedMultiMixQASample) -> BaseTaskSample:
         """Generates an encoded multimodal packed multimix sample from a raw sample."""
         raise NotImplementedError("encode_packed_multi_mix_qa not supported", sample)
+
+    def encode_packed_chat_mix(self, sample: PackedChatMixSample) -> BaseTaskSample:
+        """Generates an encoded multimodal packed chat (incl. tool calling) sample from a raw sample."""
+        raise NotImplementedError("encode_packed_chat_mix not supported", sample)
 
     def process_images(self, samples: List[Union[BaseTaskSample, BaseTaskSamplePacked]]) -> torch.Tensor:
         """Stack images to [num_tiles, c, h, w]. If there are no images (text-only), then use a dummy image."""

--- a/loongforge/data/multimodal/dataloader_provider.py
+++ b/loongforge/data/multimodal/dataloader_provider.py
@@ -51,8 +51,22 @@ def _fp8_padding_factor(fp8_recipe=None):
     return 16
 
 
-def _needs_packed_alignment(args):
-    return args.packing_sft_data and (
+def _has_packed_cu_lengths(batch: Dict[str, Any]) -> bool:
+    """Return whether a collated batch carries real packed sequence boundaries."""
+    cu_lengths = batch.get("cu_lengths")
+    if cu_lengths is None:
+        return False
+    if not torch.is_tensor(cu_lengths):
+        cu_lengths = torch.as_tensor(cu_lengths)
+    return cu_lengths.ndim >= 2 and cu_lengths.shape[-1] > 1
+
+
+def _needs_packed_alignment(args, batch: Optional[Dict[str, Any]] = None):
+    is_packed = args.packing_sft_data
+    if batch is not None:
+        is_packed = is_packed or _has_packed_cu_lengths(batch)
+
+    return is_packed and (
         args.context_parallel_size > 1
         or args.sequence_parallel
         or (
@@ -69,6 +83,7 @@ def seq_padding_for_cp(
     has_sp=False,
     fp8_enabled=False,
     fp8_recipe=None,
+    pad_token_id=PAD_TOKEN_ID,
 ):
     """Sequence padding for CP and/or SP
 
@@ -79,6 +94,10 @@ def seq_padding_for_cp(
         has_sp (bool): Model uses sequence parallelism.
         fp8_enabled (bool): Model uses FP8 execution.
         fp8_recipe (str): FP8 recipe. Affects required padding.
+        pad_token_id (int): Token id used to pad token slots that the
+            attention mask will mark as padded. Defaults to the module-level
+            ``PAD_TOKEN_ID`` when the caller cannot resolve a tokenizer-aware
+            value.
 
     Returns:
         data (dict): Padded data.
@@ -106,7 +125,7 @@ def seq_padding_for_cp(
             length, cp_size, tp_size, has_sp
         )
 
-        input_ids = F.pad(token, (0, mp_padding_needed), "constant", PAD_TOKEN_ID)
+        input_ids = F.pad(token, (0, mp_padding_needed), "constant", pad_token_id)
         label = F.pad(label, (0, mp_padding_needed), "constant", IGNORE_INDEX)
         mask = F.pad(mask, (0, mp_padding_needed), "constant", True)
 
@@ -138,7 +157,7 @@ def seq_padding_for_cp(
 
     if final_padding_needed > 0 and valid_tokens:
         valid_tokens[-1] = F.pad(
-            valid_tokens[-1], (0, final_padding_needed), "constant", PAD_TOKEN_ID
+            valid_tokens[-1], (0, final_padding_needed), "constant", pad_token_id
         )
         valid_labels[-1] = F.pad(
             valid_labels[-1], (0, final_padding_needed), "constant", IGNORE_INDEX
@@ -176,12 +195,16 @@ class VLMPretrainCollator:
     label_pad_token_id: int = IGNORE_INDEX
     return_tensors: str = "pt"
 
+    def _resolve_pad_token_id(self) -> int:
+        pad_token_id = getattr(self.tokenizer, "pad_token_id", None)
+        return PAD_TOKEN_ID if pad_token_id is None else pad_token_id
+
     def collate_energon(self, batch: Dict[str, Any]) -> Dict[str, Any]:
         """Normalize raw Energon batch tensors, pad for TP/CP configs, then build masks/positions."""
         batch = self._ensure_tensor(batch)
         self._pad_sequences(batch)
         args = get_args()
-        if _needs_packed_alignment(args):
+        if _needs_packed_alignment(args, batch):
             seq_padding_for_cp(
                 batch,
                 tp_size=args.tensor_model_parallel_size,
@@ -189,6 +212,7 @@ class VLMPretrainCollator:
                 has_sp=args.sequence_parallel,
                 fp8_enabled=bool(getattr(args, "fp8", None)),
                 fp8_recipe=getattr(args, "fp8_recipe", None),
+                pad_token_id=self._resolve_pad_token_id(),
             )
         self._build_masks_and_positions(batch)
         return batch
@@ -233,8 +257,7 @@ class VLMPretrainCollator:
         pad_len = target_len - seq_len
         if pad_len <= 0:
             return
-        pad_token_id = getattr(self.tokenizer, "pad_token_id", None)
-        pad_token_id = PAD_TOKEN_ID if pad_token_id is None else pad_token_id
+        pad_token_id = self._resolve_pad_token_id()
         batch["tokens"] = F.pad(tokens, (0, pad_len), "constant", pad_token_id)
         batch["labels"] = F.pad(
             batch["labels"], (0, pad_len), "constant", self.label_pad_token_id

--- a/loongforge/data/multimodal/flavors/__init__.py
+++ b/loongforge/data/multimodal/flavors/__init__.py
@@ -12,11 +12,17 @@ from loongforge.data.multimodal.flavors.multi_mix_qa import MultiMixQASample
 from loongforge.data.multimodal.flavors.packed_multi_mix_qa import (
     PackedMultiMixQASample,
 )
+from loongforge.data.multimodal.flavors.packed_chat_mix import (
+    PackedChatMixSample,
+)
+from loongforge.data.multimodal.flavors.chat_mix import ChatMixSample
 
 __all__ = [
     "PackedCaptioningSample",
     "PackedVQASample",
     "PackedMultiMixQASample",
+    "PackedChatMixSample",
     "MultiVidQASample",
     "MultiMixQASample",
+    "ChatMixSample",
 ]

--- a/loongforge/data/multimodal/flavors/chat_mix.py
+++ b/loongforge/data/multimodal/flavors/chat_mix.py
@@ -1,0 +1,41 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Unpacked chat-format multimodal sample (supports tool calling).
+
+Counterpart of :class:`PackedChatMixSample` for the streaming / online path:
+each sample carries a single conversation (`messages`) plus optional tool
+definitions, optional system prompt, and optional image / video media.
+"""
+
+from dataclasses import dataclass
+from importlib.metadata import version
+from typing import Any, Dict, List, Optional
+
+import torch
+from megatron.energon.flavors.base_dataset import Sample
+
+if version("megatron-energon") < "7.0.0":
+    from megatron.energon.flavors.webdataset import VideoData as AVData
+else:
+    from megatron.energon.flavors.webdataset import AVData
+
+
+@dataclass
+class ChatMixSample(Sample):
+    """Unpacked multimodal sample using full chat schema (incl. tool calling)."""
+
+    #: OpenAI Chat Completions-style messages for a single conversation.
+    messages: List[Dict[str, Any]]
+
+    #: Optional list of image tensors referenced by the messages.
+    image: Optional[List[torch.Tensor]] = None
+
+    #: Optional list of video data referenced by the messages.
+    video: Optional[List[AVData]] = None
+
+    #: Optional system prompt (extracted from messages by the cooker).
+    system: Optional[str] = None
+
+    #: Optional tool definitions available to the assistant for this conversation.
+    tools: Optional[List[Dict[str, Any]]] = None

--- a/loongforge/data/multimodal/flavors/packed_chat_mix.py
+++ b/loongforge/data/multimodal/flavors/packed_chat_mix.py
@@ -1,0 +1,46 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Packed chat-format multimodal sample (supports tool calling).
+
+Counterpart of :class:`ChatMixSample` for the offline-packed path: each sample
+carries N original conversations packed together, where every entry of
+``packed_messages`` is a self-contained dict (typically with its own
+``messages`` and optional ``tools`` keys), aligned 1:1 with ``packed_images``
+/ ``packed_videos`` groups.
+"""
+
+from dataclasses import dataclass
+from importlib.metadata import version
+from typing import Any, Dict, List, Optional
+
+import torch
+from megatron.energon.flavors.base_dataset import Sample
+
+if version("megatron-energon") < "7.0.0":
+    from megatron.energon.flavors.webdataset import VideoData as AVData
+else:
+    from megatron.energon.flavors.webdataset import AVData
+
+
+@dataclass
+class PackedChatMixSample(Sample):
+    """Offline-packed multimodal sample using full chat schema (incl. tool calling)."""
+
+    #: List of N packed conversations; each entry is a dict carrying its own
+    #: ``messages`` (OpenAI Chat Completions-style) plus optional ``tools`` /
+    #: ``source`` metadata.
+    packed_messages: List[Dict[str, Any]]
+
+    #: Optional per-conversation image groups; ``packed_images[i]`` belongs to
+    #: ``packed_messages[i]``. ``None`` when ``media_type='video'`` or
+    #: ``'text'``.
+    packed_images: Optional[List[List[torch.Tensor]]] = None
+
+    #: Optional per-conversation video groups; ``packed_videos[i]`` belongs to
+    #: ``packed_messages[i]``. ``None`` when ``media_type='image'`` or
+    #: ``'text'``.
+    packed_videos: Optional[List[List[AVData]]] = None
+
+    #: Optional system prompt shared across the packed conversations.
+    system: Optional[str] = None

--- a/loongforge/data/multimodal/kimi_task_encoder.py
+++ b/loongforge/data/multimodal/kimi_task_encoder.py
@@ -27,8 +27,13 @@ else:
 
 
 from loongforge.utils import constants, get_chat_template
+from loongforge.data.chat_template import HFChatTemplate
 from megatron.energon.task_encoder.base import stateless
-from loongforge.data.multimodal import MultiMixQASample, MultiVidQASample
+from loongforge.data.multimodal import (
+    ChatMixSample,
+    MultiMixQASample,
+    MultiVidQASample,
+)
 from .base.task_encoder import (
     BaseTaskEncoder,
     BaseTaskSample,
@@ -99,34 +104,78 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
         else:
             self.merge_kernel_size = list(merge_kernel_size)
 
-    def _sample_sequence_limit(self) -> int:
-        sequence_limit = self.args.seq_length
-        packed_limit = getattr(self.args, "max_packed_tokens", None)
-        if self.is_packing_enabled and packed_limit is not None:
-            sequence_limit = min(sequence_limit, packed_limit)
-        return sequence_limit
+    def _gate_overlong(
+        self,
+        sample,
+        input_ids,
+        *,
+        image_grid_thw: Optional[torch.Tensor] = None,
+        video_grid_thw: Optional[torch.Tensor] = None,
+    ) -> bool:
+        """Drop-or-keep gate covering input length and visual-token budget.
 
-    def _should_discard_overlong(self, sample, input_ids) -> bool:
-        if not self.args.enable_discard_sample:
-            return False
+        Returns True when the caller should ``return None``.  Two independent
+        checks (previously inlined across every encode_xx method):
 
-        sequence_limit = self._sample_sequence_limit()
-        input_length = len(input_ids)
-        if input_length <= sequence_limit:
-            return False
+        - input-length gate: when ``enable_discard_sample`` is on, drop the
+          sample if ``len(input_ids)`` exceeds the relevant limit
+          (``min(seq_length, max_packed_tokens)`` when packing is enabled,
+          else ``seq_length``).
+        - visual-tokens trim-safety gate when ``enable_discard_sample`` is
+          off.  In that mode the batcher tail-trims silently, so any cut
+          point landing inside a media block desyncs ``pixel_values`` from
+          the expanded ``<|media_pad|>`` placeholders.  Requiring
+          ``visual_tokens <= seq_length`` guarantees at least one trim
+          point can preserve every media block intact.
 
-        logging.warning(
-            "discard overlong sample %s: input length %s > sequence limit %s",
-            sample.__key__,
-            input_length,
-            sequence_limit,
-        )
-        return True
+        All overlong cases log a warning and signal a drop instead of
+        raising, so upstream pipelines do not need ``except AssertionError``
+        to recover.
+        """
+        if self.args.enable_discard_sample:
+            sequence_limit = self.args.seq_length
+            packed_limit = getattr(self.args, "max_packed_tokens", None)
+            if self.is_packing_enabled and packed_limit is not None:
+                sequence_limit = min(sequence_limit, packed_limit)
+            if len(input_ids) > sequence_limit:
+                logging.warning(
+                    "discard overlong sample %s: input length %s > sequence limit %s",
+                    sample.__key__,
+                    len(input_ids),
+                    sequence_limit,
+                )
+                return True
+        else:
+            visual_tokens = 0
+            if video_grid_thw is not None:
+                for thw in video_grid_thw:
+                    visual_tokens += self._compute_image_tokens_from_grid_thw(thw)
+            if image_grid_thw is not None:
+                for thw in image_grid_thw:
+                    visual_tokens += self._compute_image_tokens_from_grid_thw(thw)
+            if visual_tokens > self.args.seq_length:
+                logging.warning(
+                    "discard sample %s: visual tokens %s > seq_length %s "
+                    "(video_grid_thw=%s, image_grid_thw=%s)",
+                    sample.__key__,
+                    visual_tokens,
+                    self.args.seq_length,
+                    video_grid_thw,
+                    image_grid_thw,
+                )
+                return True
+        return False
 
     @stateless(restore_seeds=True)
     def encode_sample(
         self,
-        sample: Union[CaptioningSample, VQASample, MultiVidQASample, MultiMixQASample],
+        sample: Union[
+            CaptioningSample,
+            VQASample,
+            MultiVidQASample,
+            MultiMixQASample,
+            ChatMixSample,
+        ],
     ):
         """Return tokenised multimodal sample."""
         if isinstance(sample, CaptioningSample):
@@ -135,6 +184,8 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
             encoded_sample = self.encode_vqa(sample)
         elif isinstance(sample, MultiVidQASample):
             encoded_sample = self.encode_multi_vid_qa(sample)
+        elif isinstance(sample, ChatMixSample):
+            encoded_sample = self.encode_chat_mix(sample)
         elif isinstance(sample, MultiMixQASample):
             encoded_sample = self.encode_multi_mix_qa(sample)
         else:
@@ -252,9 +303,9 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
     def _process(self, image, text):
         """Process the data to get the model's input for Kimi K2.5.
 
-        This method also expands <|media_content|> tokens to match the actual
-        image feature length, eliminating the need for _merge_input_ids_with_image_features
-        during model forward.
+        Expands `<|media_content|>` tokens to match the actual image feature
+        length, eliminating the need for ``_merge_input_ids_with_image_features``
+        during the model forward.
 
         Args:
             image: PIL Image or None
@@ -283,19 +334,15 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
             image_grid_thw = inputs["grid_thws"]
             pixel = [inputs["pixel_values"]]
 
-        # Build target labels - mask vision-related tokens
         target = input_ids.clone()
         media_begin_id, media_end_id, media_content_id, media_pad_id = (
             self._get_vision_token_ids()
         )
-
-        # Mask all vision tokens from loss computation
         target[target == media_begin_id] = IGNORE_INDEX
         target[target == media_end_id] = IGNORE_INDEX
         target[target == media_content_id] = IGNORE_INDEX
         target[target == media_pad_id] = IGNORE_INDEX
 
-        # Expand <|media_content|> tokens to match actual image feature length
         if image is not None and image_grid_thw is not None:
             input_ids, target, attn_mask = self._expand_media_content_tokens(
                 input_ids, target, attn_mask, image_grid_thw
@@ -323,16 +370,13 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
         )
         return text
 
-    def _mask_user_turns_in_target(self, input_ids, target, answer):
+    def _mask_user_turns_in_target(self, input_ids, target):
         """Mask user turns and special tokens in target, only keep assistant answer for loss.
 
         For SFT, we only want to compute loss on the assistant's answer portion.
         """
-        # Get special token IDs
-        im_assistant_id = self.tokenizer.convert_tokens_to_ids(IM_ASSISTANT)
         im_middle_id = self.tokenizer.convert_tokens_to_ids(IM_MIDDLE)
         im_end_id = self.tokenizer.convert_tokens_to_ids(IM_END)
-        think_start_id = self.tokenizer.convert_tokens_to_ids(THINK_START)
         think_end_id = self.tokenizer.convert_tokens_to_ids(THINK_END)
 
         # Find the position after <think></think> in assistant turn
@@ -377,10 +421,11 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
         text = self._build_kimi_chat_text(
             context, answer, has_image=(image is not None)
         )
-        input_ids, target, imgs, image_grid_thw, attn_mask = self._process(image, text)
+        input_ids, target, imgs, image_grid_thw, attn_mask = self._process(
+            image, text
+        )
 
-        # Mask user turns, only compute loss on assistant answer
-        target = self._mask_user_turns_in_target(input_ids, target, answer)
+        target = self._mask_user_turns_in_target(input_ids, target)
 
         return input_ids, target, attn_mask, imgs, image_grid_thw
 
@@ -400,40 +445,23 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
         )
         num_tiles = [len(image_grid_thw)] if image_grid_thw is not None else [0]
 
-        if self._should_discard_overlong(sample, input_ids):
+        if self._gate_overlong(
+            sample,
+            input_ids,
+            image_grid_thw=image_grid_thw,
+        ):
             return None
-        if not self.args.enable_discard_sample and image_grid_thw is not None:
-            assert (
-                image_grid_thw.prod() / 4 <= self.args.seq_length
-            ), f"{sample.__key__} thw {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def encode_vqa(self, sample: VQASample) -> BaseTaskSample:
         """Encode VQA sample for Kimi K2.5."""
@@ -460,43 +488,26 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
 
         num_tiles = [len(image_grid_thw)] if image_grid_thw is not None else [0]
 
-        if self._should_discard_overlong(sample, input_ids):
+        if self._gate_overlong(
+            sample,
+            input_ids,
+            image_grid_thw=image_grid_thw,
+        ):
             return None
-        if not self.args.enable_discard_sample and image_grid_thw is not None:
-            assert (
-                image_grid_thw.prod() / 4 <= self.args.seq_length
-            ), f"{sample.__key__} grid_thw: {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def process_sft_qa(
-        self, messages: list, system: str, raw_video: list, raw_image: list
+        self, messages: list, system: str, raw_video: list, raw_image: list, tools=None
     ):
         """Process multi-turn conversation data for SFT with Kimi K2.5 format.
 
@@ -515,6 +526,12 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
         pixel_values_images = []
         video = []
         image = []
+
+        if self.chat_template.mm_plugin is None:
+            raise ValueError(
+                "KimiTaskEncoder requires a chat template with KimiK25Plugin. "
+                "Use --chat-template kimi-k2.5 or kimi-k2.5-hf."
+            )
 
         if raw_image is not None:
             for i in raw_image:
@@ -539,17 +556,37 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
             image_grid_thw = mm_inputs["image_grid_thw"]
             pixel_values_images = [mm_inputs["pixel_values"]]
 
-        # Encode multi-turn conversation
-        encode_pairs = self.chat_template.encode_multiturn(
-            tokenizer=self.tokenizer,
-            messages=messages,
-            system=system,
-        )
+        if isinstance(self.chat_template, HFChatTemplate):
+            hf_messages = list(messages)
+            has_system_message = (
+                hf_messages
+                and hf_messages[0].get("role") == constants.DataRoles.SYSTEM
+            )
+            if system and not has_system_message:
+                hf_messages = [
+                    {"role": constants.DataRoles.SYSTEM, "content": system},
+                    *hf_messages,
+                ]
+            input_ids, target, _, _ = self.chat_template.encode_openai(
+                tokenizer=self.tokenizer,
+                messages=hf_messages,
+                tools=tools,
+                train_on_prompt=getattr(self.args, "train_on_prompt", False),
+                history_mask_loss=getattr(self.args, "history_mask_loss", False),
+                ignore_index=IGNORE_INDEX,
+            )
+        else:
+            # Encode multi-turn conversation
+            encode_pairs = self.chat_template.encode_multiturn(
+                tokenizer=self.tokenizer,
+                messages=messages,
+                system=system,
+            )
 
-        input_ids, target = [], []
-        for turn_idx, (source_ids, target_ids) in enumerate(encode_pairs):
-            input_ids += source_ids + target_ids
-            target += [IGNORE_INDEX] * len(source_ids) + target_ids
+            input_ids, target = [], []
+            for source_ids, target_ids in encode_pairs:
+                input_ids += source_ids + target_ids
+                target += [IGNORE_INDEX] * len(source_ids) + target_ids
 
         input_ids = torch.tensor(input_ids)
         target = torch.tensor(target)
@@ -597,7 +634,11 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
                 pixel_values_videos,
                 video_grid_thw,
             ) = self.process_sft_qa(
-                sample.messages, sample.system, sample.video, sample.image
+                sample.messages,
+                sample.system,
+                sample.video,
+                sample.image,
+                tools=getattr(sample, "tools", None),
             )
             if sample.video is not None:
                 num_tiles = [len(video_grid_thw)] if video_grid_thw is not None else []
@@ -608,56 +649,26 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
                 f"Unknown training phase {self.args.training_phase}"
             )
 
-        if self._should_discard_overlong(sample, input_ids):
+        if self._gate_overlong(
+            sample,
+            input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+        ):
             return None
-        if (
-            not self.args.enable_discard_sample
-            and sample.video is not None
-            and video_grid_thw is not None
-        ):
-            assert (
-                video_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
-            ), f"{sample.__key__} grid_thw: {video_grid_thw}"
-        elif (
-            not self.args.enable_discard_sample
-            and sample.image is not None
-            and image_grid_thw is not None
-        ):
-            assert (
-                image_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
-            ), f"{sample.__key__} grid_thw: {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def encode_multi_vid_qa(self, sample) -> BaseTaskSample:
         """Encode video QA sample for Kimi K2.5."""
@@ -670,47 +681,91 @@ class KimiVLMTaskEncoder(VLMTaskEncoder):
                 image_grid_thw,
                 video,
                 video_grid_thw,
-            ) = self.process_sft_qa(sample.messages, sample.system, sample.video, None)
+            ) = self.process_sft_qa(
+                sample.messages,
+                sample.system,
+                sample.video,
+                None,
+                tools=getattr(sample, "tools", None),
+            )
         else:
             raise NotImplementedError(
                 f"Unknown training phase {self.args.training_phase}"
             )
 
-        if self._should_discard_overlong(sample, input_ids):
+        if self._gate_overlong(
+            sample,
+            input_ids,
+            video_grid_thw=video_grid_thw,
+        ):
             return None
-        if not self.args.enable_discard_sample and video_grid_thw is not None:
-            assert (
-                video_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
-            ), f"{sample.__key__} grid_thw: {video_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=video,
-                video_grid_thw=video_grid_thw,
-                num_tiles=[len(video_grid_thw)] if video_grid_thw is not None else [],
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=video,
+            video_grid_thw=video_grid_thw,
+            num_tiles=[len(video_grid_thw)] if video_grid_thw is not None else [],
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
+
+    def encode_chat_mix(
+        self,
+        sample: ChatMixSample,
+    ) -> Optional["VLMTaskSample"]:
+        """Encode ChatMixSample for Kimi K2.5 (with optional tool calling).
+
+        Overlong samples are dropped via ``_gate_overlong`` (logs a warning
+        and returns ``None``).
+        """
+        if self.args.training_phase != constants.TrainingPhase.SFT:
+            raise NotImplementedError(
+                f"encode_chat_mix only supports SFT, got {self.args.training_phase}"
             )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=video,
-                video_grid_thw=video_grid_thw,
-                num_tiles=[len(video_grid_thw)] if video_grid_thw is not None else [],
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+
+        (
+            input_ids,
+            target,
+            attn_mask,
+            imgs,
+            image_grid_thw,
+            pixel_values_videos,
+            video_grid_thw,
+        ) = self.process_sft_qa(
+            sample.messages,
+            sample.system,
+            sample.video,
+            sample.image,
+            sample.tools,
+        )
+
+        num_tiles = []
+        if video_grid_thw is not None:
+            num_tiles.append(len(video_grid_thw))
+        if image_grid_thw is not None:
+            num_tiles.append(len(image_grid_thw))
+
+        if self._gate_overlong(
+            sample,
+            input_ids,
+            image_grid_thw=image_grid_thw,
+            video_grid_thw=video_grid_thw,
+        ):
+            return None
+
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )

--- a/loongforge/data/multimodal/vlm_task_encoder.py
+++ b/loongforge/data/multimodal/vlm_task_encoder.py
@@ -31,12 +31,16 @@ from .base.task_encoder import (
     BaseTaskSample,
     BaseTaskSamplePacked,
     BaseTaskBatchPacked,
+    _parse_messages,
 )
+from loongforge.data.chat_template import HFChatTemplate
 from loongforge.data.multimodal import (
     MultiMixQASample,
     PackedCaptioningSample,
     PackedVQASample,
     PackedMultiMixQASample,
+    PackedChatMixSample,
+    ChatMixSample,
 )
 
 IGNORE_INDEX = -100  # ID for labels that should be ignored.
@@ -244,13 +248,13 @@ class VLMTaskEncoder(BaseTaskEncoder):
             text = text[:-1]
         input_ids, _, imgs, image_grid_thw, attn_mask = self._process(image, text)
         target = torch.ones_like(input_ids) * IGNORE_INDEX
-        answer = self.tokenizer.tokenize(answer)
-        target[-len(answer) - 1 : -1] = torch.tensor(answer)
+        answer_ids = self.tokenizer.tokenize(answer)
+        target[-len(answer_ids) - 1 : -1] = torch.tensor(answer_ids)
 
         return input_ids, target, attn_mask, imgs, image_grid_thw
 
     def process_sft_qa(
-        self, messages: list, system: str, raw_video: list, raw_image: list
+        self, messages: list, system: str, raw_video: list, raw_image: list, tools=None
     ):
         """process the data for sft qa"""
         video_grid_thw = None
@@ -305,6 +309,27 @@ class VLMTaskEncoder(BaseTaskEncoder):
             video_grid_thw,
         )
 
+    def _make_sample_from(self, sample, *, cls=None, key=None, **fields):
+        """Derive a new sample from ``sample``, carrying its energon meta.
+
+        Forwards the source's ``__key__`` / ``__restore_key__`` /
+        ``__subflavors__`` (and ``__subflavor__`` on energon < 7.0) into a
+        freshly constructed ``cls`` instance. Used both for the final task
+        sample (``cls`` defaults to ``VLMTaskSample``) and for upstream
+        flavor samples re-fed into another encoder (e.g. ``ChatMixSample``).
+        Pass ``key`` to override ``sample.__key__`` (e.g. per-turn sub-keys).
+        """
+        if cls is None:
+            cls = VLMTaskSample
+        meta = {
+            "__key__": key if key is not None else sample.__key__,
+            "__restore_key__": sample.__restore_key__,
+            "__subflavors__": sample.__subflavors__,
+        }
+        if _ENERGON_NEEDS_SUBFLAVOR:
+            meta["__subflavor__"] = None
+        return cls(**meta, **fields)
+
     def encode_captioning(self, sample: CaptioningSample) -> BaseTaskSample:
         """Encode CaptioningSample."""
         """Preprocessing function for datasets like COCO, containing image-caption pairs.
@@ -327,34 +352,17 @@ class VLMTaskEncoder(BaseTaskEncoder):
             assert len(input_ids) <= self.args.seq_length, f"{sample.__key__} input length {len(input_ids)}"
         else:
             assert image_grid_thw.prod() / 4 <= self.args.seq_length, f"{sample.__key__} thw {image_grid_thw}"
-        
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def encode_vqa(self, sample: VQASample) -> BaseTaskSample:
         """Encode pretrain sample in Qwen2VL style."""
@@ -380,33 +388,16 @@ class VLMTaskEncoder(BaseTaskEncoder):
         else:
             assert image_grid_thw.prod() / 4 <= self.args.seq_length, f"{sample.__key__} grid_thw: {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def encode_multi_vid_qa(self, sample: VQASample) -> BaseTaskSample:
         """Encode sample in Qwen2VL style."""
@@ -419,7 +410,13 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 image_grid_thw,
                 video,
                 video_grid_thw,
-            ) = self.process_sft_qa(sample.messages, sample.system, sample.video, None)
+            ) = self.process_sft_qa(
+                sample.messages,
+                sample.system,
+                sample.video,
+                None,
+                tools=getattr(sample, "tools", None),
+            )
         else:
             raise NotImplementedError(
                 f"Unknown training phase {self.args.training_phase}"
@@ -435,37 +432,18 @@ class VLMTaskEncoder(BaseTaskEncoder):
             ), f"{sample.__key__} grid_thw: {video_grid_thw}"
 
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=video,
-                video_grid_thw=video_grid_thw,
-                num_tiles=[len(video_grid_thw)],
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=video,
-                video_grid_thw=video_grid_thw,
-                num_tiles=[len(video_grid_thw)],
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=video,
+            video_grid_thw=video_grid_thw,
+            num_tiles=[len(video_grid_thw)],
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
 
     def encode_multi_mix_qa(self, sample: MultiMixQASample) -> BaseTaskSample:
@@ -482,7 +460,11 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 pixel_values_videos,
                 video_grid_thw,
             ) = self.process_sft_qa(
-                sample.messages, sample.system, sample.video, sample.image
+                sample.messages,
+                sample.system,
+                sample.video,
+                sample.image,
+                tools=getattr(sample, "tools", None),
             )
             if sample.video is not None:
                 num_tiles = [len(video_grid_thw)]
@@ -507,37 +489,73 @@ class VLMTaskEncoder(BaseTaskEncoder):
             ), f"{sample.__key__} grid_thw: {image_grid_thw}"
 
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
+
+    def encode_chat_mix(self, sample: ChatMixSample) -> Optional[BaseTaskSample]:
+        """Encode chat-format multimodal sample (with optional tool calling)."""
+        if self.args.training_phase != constants.TrainingPhase.SFT:
+            raise NotImplementedError(
+                f"encode_chat_mix only supports SFT, got {self.args.training_phase}"
             )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+
+        (
+            input_ids,
+            target,
+            attn_mask,
+            imgs,
+            image_grid_thw,
+            pixel_values_videos,
+            video_grid_thw,
+        ) = self.process_sft_qa(
+            sample.messages,
+            sample.system,
+            sample.video,
+            sample.image,
+            tools=sample.tools,
+        )
+
+        num_tiles = []
+        if sample.video is not None:
+            num_tiles = [len(video_grid_thw)]
+        elif sample.image is not None:
+            num_tiles = [len(image_grid_thw)]
+
+        if self.args.enable_discard_sample:
+            assert (
+                len(input_ids) <= self.args.seq_length
+            ), f"{sample.__key__} input length {len(input_ids)}"
+        elif sample.video is not None:
+            assert (
+                video_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
+            ), f"{sample.__key__} grid_thw: {video_grid_thw}"
+        elif sample.image is not None:
+            assert (
+                image_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
+            ), f"{sample.__key__} grid_thw: {image_grid_thw}"
+
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def encode_packed_captioning(
         self, sample: PackedCaptioningSample
@@ -631,6 +649,7 @@ class VLMTaskEncoder(BaseTaskEncoder):
             else:
                 answer = answer_group or ""
 
+            system = None
             messages = [
                 {"role": "user", "content": context},
                 {"role": "assistant", "content": answer},
@@ -643,7 +662,7 @@ class VLMTaskEncoder(BaseTaskEncoder):
                     "messages": messages,
                     "image": media_group,
                     "video": None,
-                    "system": None,
+                    "system": system,
                 }
                 if _ENERGON_NEEDS_SUBFLAVOR:
                     init_kwargs["__subflavor__"] = None
@@ -656,7 +675,7 @@ class VLMTaskEncoder(BaseTaskEncoder):
                     "messages": messages,
                     "image": None,
                     "video": media_group,  # List[AVData]
-                    "system": None,
+                    "system": system,
                 }
                 if _ENERGON_NEEDS_SUBFLAVOR:
                     init_kwargs["__subflavor__"] = None
@@ -669,13 +688,88 @@ class VLMTaskEncoder(BaseTaskEncoder):
                     "messages": messages,
                     "image": None,
                     "video": None,
-                    "system": None,
+                    "system": system,
                 }
                 if _ENERGON_NEEDS_SUBFLAVOR:
                     init_kwargs["__subflavor__"] = None
                 cur_sample = MultiMixQASample(**init_kwargs)
             l_VLMTaskSample.append(self.encode_multi_mix_qa4packing(cur_sample))
         l_sample_packed = self.pack_selected_samples(l_VLMTaskSample)
+        self.is_packing_enabled = True
+        return l_sample_packed
+
+    def encode_packed_chat_mix(
+        self,
+        sample: PackedChatMixSample,
+    ) -> BaseTaskSamplePacked:
+        """Encode an offline-packed chat/tool-calling sample.
+
+        Generic skeleton: unpacks the offline artifact, re-encodes each turn
+        through ``self.encode_chat_mix``, and re-packs via
+        ``pack_selected_samples``. Subclasses customise per-turn encoding by
+        overriding ``encode_chat_mix``; tool-calling support requires the
+        active chat template to be ``HFChatTemplate``.
+        """
+        n_orig_sample = len(sample.packed_messages)
+        images = sample.packed_images if sample.packed_images is not None else []
+        videos = sample.packed_videos if sample.packed_videos is not None else []
+
+        has_images = len(images) > 0
+        has_videos = len(videos) > 0
+        if has_images and has_videos:
+            raise ValueError(
+                f"encode_packed_chat_mix: cannot mix images and videos "
+                f"in same sample for key={sample.__key__}"
+            )
+        has_text_only = not has_images and not has_videos
+        media_list = images if has_images else videos
+        if not has_text_only and len(media_list) != n_orig_sample:
+            raise ValueError(
+                f"encode_packed_chat_mix: media count ({len(media_list)}) "
+                f"!= messages count ({n_orig_sample}) for key={sample.__key__}"
+            )
+
+        encoded_members = []
+        for idx, raw_sample in enumerate(sample.packed_messages):
+            raw_sample = raw_sample or {}
+            raw_messages = raw_sample.get("messages") or raw_sample.get("texts")
+            if raw_messages is None:
+                raise ValueError(
+                    f"packed_chat_mix sample {sample.__key__}.q{idx:03d} "
+                    "has neither `messages` nor `texts`."
+                )
+
+            messages, system = _parse_messages(raw_messages)
+            tools = raw_sample.get("tools")
+            if tools and not isinstance(self.chat_template, HFChatTemplate):
+                raise ValueError(
+                    f"packed_chat_mix turn {sample.__key__}.q{idx:03d} carries "
+                    f"tool definitions but the active chat template "
+                    f"({type(self.chat_template).__name__}) cannot render "
+                    f"tool_calls. Use HFChatTemplate or strip tools from the data."
+                )
+            media_group = None if has_text_only else media_list[idx]
+
+            cur_sample = self._make_sample_from(
+                sample,
+                cls=ChatMixSample,
+                key=f"{sample.__key__}.q{idx:03d}",
+                messages=messages,
+                image=media_group if has_images else None,
+                video=media_group if has_videos else None,
+                system=system,
+                tools=tools if tools else None,
+            )
+            encoded = self.encode_chat_mix(cur_sample)
+            if encoded is None:
+                raise ValueError(
+                    f"encode_packed_chat_mix: member {cur_sample.__key__} was "
+                    f"dropped during encode_chat_mix. Offline packed artifacts "
+                    f"must pre-validate that every member fits within seq_length."
+                )
+            encoded_members.append(encoded)
+
+        l_sample_packed = self.pack_selected_samples(encoded_members)
         self.is_packing_enabled = True
         return l_sample_packed
 
@@ -692,7 +786,11 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 pixel_values_videos,
                 video_grid_thw,
             ) = self.process_sft_qa(
-                sample.messages, sample.system, sample.video, sample.image
+                sample.messages,
+                sample.system,
+                sample.video,
+                sample.image,
+                tools=getattr(sample, "tools", None),
             )
 
             num_tiles = []
@@ -718,37 +816,18 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 image_grid_thw.prod(dim=-1).sum() / 4 <= self.args.seq_length
             ), f"{sample.__key__} grid_thw: {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                pixel_values_videos=pixel_values_videos,
-                video_grid_thw=video_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            pixel_values_videos=pixel_values_videos,
+            video_grid_thw=video_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
     
 
     def encode_vqa4packing(self, sample: VQASample) -> BaseTaskSample:
@@ -784,33 +863,16 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 image_grid_thw.prod() / 4 <= self.args.seq_length
             ), f"{sample.__key__} grid_thw: {image_grid_thw}"
 
-        if _ENERGON_NEEDS_SUBFLAVOR:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavor__=None,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
-        else:
-            return VLMTaskSample(
-                __key__=sample.__key__,
-                __restore_key__=sample.__restore_key__,
-                __subflavors__=sample.__subflavors__,
-                imgs=imgs,
-                image_grid_thw=image_grid_thw,
-                num_tiles=num_tiles,
-                tokens=input_ids,
-                labels=target,
-                attn_mask=attn_mask,
-                total_len=len(input_ids),
-            )
+        return self._make_sample_from(
+            sample,
+            imgs=imgs,
+            image_grid_thw=image_grid_thw,
+            num_tiles=num_tiles,
+            tokens=input_ids,
+            labels=target,
+            attn_mask=attn_mask,
+            total_len=len(input_ids),
+        )
 
     def process_samples_grid(self, samples):
         """concat grid_thw for image and video"""

--- a/loongforge/data/sft_dataset.py
+++ b/loongforge/data/sft_dataset.py
@@ -83,6 +83,23 @@ class ShareGPTColumns(Columns):
 
 
 @dataclass
+class OpenAIChatColumns(Columns):
+    """The field of OpenAI Chat Completions-style datasets."""
+
+    messages: Optional[str] = "messages"
+    """The messages for sft"""
+
+    tools: Optional[str] = "tools"
+    """The tools metadata for sft"""
+
+    images: Optional[str] = None
+    """Optional image paths"""
+
+    videos: Optional[str] = None
+    """Optional video paths"""
+
+
+@dataclass
 class ShareGPTTags(object):
     """The tag of the dataset."""
 
@@ -388,6 +405,13 @@ class SFTDataset(HuggingFaceDataset):
                 )
                 sft_format.tags.function_tag = _desc_tags.get("function_tag", None)
                 sft_format.tags.system_tag = _desc_tags.get("system_tag", None)
+        elif sft_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+            sft_format.columns = OpenAIChatColumns()
+            if _desc_columns is not None:
+                sft_format.columns.messages = _desc_columns.get("messages", "messages")
+                sft_format.columns.tools = _desc_columns.get("tools", "tools")
+                sft_format.columns.images = _desc_columns.get("images", None)
+                sft_format.columns.videos = _desc_columns.get("videos", None)
         else:
             raise ValueError(f"Unknown dataset format {sft_format.format}")
 

--- a/loongforge/data/sft_format_utils.py
+++ b/loongforge/data/sft_format_utils.py
@@ -20,6 +20,7 @@
 """Preprocess data to unified format"""
 
 import os
+import json
 import logging
 from functools import partial
 
@@ -38,6 +39,7 @@ if TYPE_CHECKING:
         AlpacaColumns,
         ShareGPTColumns,
         ShareGPTTags,
+        OpenAIChatColumns,
     )
 
 
@@ -212,6 +214,122 @@ def _convert_sharegpt(
     return outputs
 
 
+def _json_dumps(value: Any) -> str:
+    """Serialize nested chat data for stable HF Dataset features."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, ensure_ascii=False)
+
+
+def _content_len(value: Any) -> int:
+    if value is None:
+        return 0
+    if isinstance(value, str):
+        return len(value)
+    return len(json.dumps(value, ensure_ascii=False))
+
+
+def _normalize_openai_chat_message(
+    message: Dict[str, Any], index: int
+) -> Dict[str, Any]:
+    """Normalize OpenAI Chat Completions fields without flattening tools."""
+    normalized = dict(message)
+    role = normalized.get("role")
+
+    if role == "function":
+        normalized["role"] = "tool"
+        normalized.setdefault(
+            "tool_call_id", normalized.get("name", f"function_{index}")
+        )
+
+    if "function_call" in normalized and "tool_calls" not in normalized:
+        function_call = normalized.pop("function_call")
+        if function_call:
+            normalized["tool_calls"] = [
+                {
+                    "id": function_call.get("id", f"call_{index}"),
+                    "type": "function",
+                    "function": {
+                        "name": function_call.get("name", ""),
+                        "arguments": function_call.get("arguments", "{}"),
+                    },
+                }
+            ]
+
+    if (
+        normalized.get("role") == DataRoles.ASSISTANT
+        and normalized.get("content") is None
+    ):
+        normalized["content"] = ""
+
+    return normalized
+
+
+def _convert_openai_chat_completions(
+    samples: Dict[str, Any],
+    openai_columns: "OpenAIChatColumns",
+    dataset_dir: str,
+):
+    """
+    Preserve OpenAI Chat Completions-style messages/tools for chat templates.
+    """
+    outputs = {
+        "messages": [],
+        "tools": [],
+        "d_len": [],
+        "videos": [],
+        "images": [],
+    }
+    convert_path = partial(_convert_path, dataset_dir=dataset_dir)
+
+    messages_column = openai_columns.messages or "messages"
+    tools_column = openai_columns.tools
+    images_column = openai_columns.images
+    videos_column = openai_columns.videos
+
+    for i, raw_messages in enumerate(samples[messages_column]):
+        if isinstance(raw_messages, str):
+            raw_messages = json.loads(raw_messages)
+
+        messages = [
+            _normalize_openai_chat_message(message, index)
+            for index, message in enumerate(raw_messages or [])
+        ]
+
+        tools = (
+            samples[tools_column][i]
+            if tools_column and tools_column in samples
+            else None
+        )
+        images = (
+            samples[images_column][i]
+            if images_column and images_column in samples
+            else []
+        )
+        videos = (
+            samples[videos_column][i]
+            if videos_column and videos_column in samples
+            else []
+        )
+
+        d_len = sum(
+            _content_len(message.get("content"))
+            + _content_len(message.get("tool_calls"))
+            + _content_len(message.get("tool_call_id"))
+            for message in messages
+        ) + _content_len(tools)
+
+        outputs["messages"].append(_json_dumps(messages))
+        outputs["tools"].append(_json_dumps(tools))
+        outputs["d_len"].append(d_len)
+        outputs["videos"].append(convert_path(videos or []))
+        outputs["images"].append(convert_path(images or []))
+
+    return outputs
+
+
 def convert_to_unified_format(
     dataset: Union["Dataset", "IterableDataset"],
     dataset_path: str,
@@ -229,6 +347,12 @@ def convert_to_unified_format(
             sharegpt_tags=data_format.tags,
             dataset_dir=os.path.dirname(dataset_path),
         )
+    elif data_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+        convert_func = partial(
+            _convert_openai_chat_completions,
+            openai_columns=data_format.columns,
+            dataset_dir=os.path.dirname(dataset_path),
+        )
     else:
         raise NotImplementedError()
 
@@ -236,20 +360,31 @@ def convert_to_unified_format(
         col for col in next(iter(dataset)).keys() if col not in ["images", "videos"]
     ]
 
-    features = Features(
-        {
-            "prompt": [
-                {"role": Value(dtype="string"), "content": Value(dtype="string")}
-            ],
-            "response": [
-                {"role": Value(dtype="string"), "content": Value(dtype="string")}
-            ],
-            "system": Value(dtype="string"),
-            "d_len": Value(dtype="int64"),
-            "videos": [Value(dtype="string")],
-            "images": [Value(dtype="string")],
-        }
-    )
+    if data_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+        features = Features(
+            {
+                "messages": Value(dtype="string"),
+                "tools": Value(dtype="string"),
+                "d_len": Value(dtype="int64"),
+                "videos": [Value(dtype="string")],
+                "images": [Value(dtype="string")],
+            }
+        )
+    else:
+        features = Features(
+            {
+                "prompt": [
+                    {"role": Value(dtype="string"), "content": Value(dtype="string")}
+                ],
+                "response": [
+                    {"role": Value(dtype="string"), "content": Value(dtype="string")}
+                ],
+                "system": Value(dtype="string"),
+                "d_len": Value(dtype="int64"),
+                "videos": [Value(dtype="string")],
+                "images": [Value(dtype="string")],
+            }
+        )
 
     kwargs = {}
     if not config.streaming:

--- a/loongforge/data/sft_supervised_utils.py
+++ b/loongforge/data/sft_supervised_utils.py
@@ -20,6 +20,7 @@
 
 import logging
 import bisect
+import json
 from functools import partial
 from collections import defaultdict
 
@@ -28,6 +29,7 @@ import datasets
 from datasets import Dataset, IterableDataset
 
 from loongforge.utils import constants
+from .chat_template import HFChatTemplate
 
 if TYPE_CHECKING:
     from datasets import Dataset, IterableDataset
@@ -140,6 +142,38 @@ def _encode_supervised_example(
     return input_ids, labels, loss_mask, ori_total_len
 
 
+def _encode_openai_example(
+    messages_json: str,
+    tools_json: Optional[str],
+    config: "SFTDatasetConfig",
+) -> Tuple[List[int], List[int], List[int], int]:
+    """Preprocess a single OpenAI-style messages/tools sample."""
+    messages = (
+        json.loads(messages_json)
+        if isinstance(messages_json, str)
+        else messages_json
+    )
+    if tools_json in (None, ""):
+        tools = None
+    else:
+        tools = json.loads(tools_json) if isinstance(tools_json, str) else tools_json
+    if not isinstance(messages, list):
+        raise ValueError(
+            f"OpenAI-style sample messages must be a list, got {type(messages)}"
+        )
+
+    input_ids, labels, loss_mask, ori_total_len = config.chat_template.encode_openai(
+        tokenizer=config.tokenizer,
+        messages=messages,
+        tools=tools,
+        train_on_prompt=config.train_on_prompt,
+        history_mask_loss=config.history_mask_loss,
+        ignore_index=config.ignore_index,
+        max_length=config.sequence_length,
+    )
+    return input_ids, labels, loss_mask, ori_total_len
+
+
 def _build_knapsacks(numbers: List[int], capacity: int) -> List[List[int]]:
     """
     An efficient greedy algorithm with binary search for the knapsack problem.
@@ -175,6 +209,81 @@ def _pad_sequence_to_multiple(config, sequence, multiple_of, pad_token_id):
     return [pad_token_id] * padding_length + sequence
 
 
+def _split_long_sequence(
+    input_ids: List[int],
+    labels: List[int],
+    loss_mask: List[int],
+    chunksize: int,
+    pad_token_id: int,
+    ignore_index: int,
+    mtp_num_layers: int = 0,
+) -> List[Tuple[List[int], List[int], List[int]]]:
+    """
+    Split a long sequence (len > chunksize) into chunks with a base length of chunksize.
+    Labels and loss_mask are pre-shifted to next-token prediction format:
+      - Non-final chunks: labels[i] = original_labels[start+i+1], covering the chunk boundary.
+      - Final chunk: last label is IGNORE (no next token to predict).
+    When MTP is enabled, append mtp_num_layers bridge tokens after the base chunk.
+    """
+    chunks = []
+    seq_len = len(input_ids)
+    num_chunks = (seq_len + chunksize - 1) // chunksize
+
+    for chunk_idx in range(num_chunks):
+        start = chunk_idx * chunksize
+        end = min(start + chunksize, seq_len)
+        is_final_chunk = (chunk_idx == num_chunks - 1)
+
+        chunk_input_ids = input_ids[start:end]
+
+        # Pre-shift labels and loss_mask for next-token prediction
+        if not is_final_chunk:
+            # Non-final chunk: shift by 1, end+1 naturally includes the boundary token
+            chunk_labels = labels[start + 1 : end + 1]
+            chunk_loss_mask = loss_mask[start + 1 : end + 1]
+        else:
+            # Final chunk: shift by 1, append IGNORE/0 at the end
+            chunk_labels = labels[start + 1 : end] + [ignore_index]
+            chunk_loss_mask = loss_mask[start + 1 : end] + [0]
+
+        # Pad the base chunk if needed
+        padding_len = chunksize - len(chunk_input_ids)
+        if padding_len > 0:
+            chunk_input_ids = chunk_input_ids + [pad_token_id] * padding_len
+            chunk_labels = chunk_labels + [ignore_index] * padding_len
+            chunk_loss_mask = chunk_loss_mask + [0] * padding_len
+
+        if mtp_num_layers > 0:
+            if not is_final_chunk:
+                bridge_end = min(end + mtp_num_layers, seq_len)
+                bridge_input_ids = input_ids[end:bridge_end]
+
+                bridge_label_end = min(end + 1 + mtp_num_layers, seq_len)
+                bridge_labels = labels[end + 1:bridge_label_end]
+                bridge_loss_mask = loss_mask[end + 1:bridge_label_end]
+
+                bridge_padding_len = mtp_num_layers - len(bridge_input_ids)
+                if bridge_padding_len > 0:
+                    bridge_input_ids += [pad_token_id] * bridge_padding_len
+
+                bridge_label_padding_len = mtp_num_layers - len(bridge_labels)
+                if bridge_label_padding_len > 0:
+                    bridge_labels += [ignore_index] * bridge_label_padding_len
+                    bridge_loss_mask += [0] * bridge_label_padding_len
+            else:
+                bridge_input_ids = [pad_token_id] * mtp_num_layers
+                bridge_labels = [ignore_index] * mtp_num_layers
+                bridge_loss_mask = [0] * mtp_num_layers
+
+            chunk_input_ids = chunk_input_ids + bridge_input_ids
+            chunk_labels = chunk_labels + bridge_labels
+            chunk_loss_mask = chunk_loss_mask + bridge_loss_mask
+
+        chunks.append((chunk_input_ids, chunk_labels, chunk_loss_mask))
+
+    return chunks
+
+
 def _preprocess_supervised_dataset(
     samples: Dict[str, List[Any]],
     config: "SFTDatasetConfig",
@@ -195,6 +304,16 @@ def _preprocess_supervised_dataset(
         # the loss mask is generated here separately
         model_inputs["loss_mask"] = []
 
+    if config.enable_chunkpipe:
+        # Track how many consecutive chunks belong to the same source sequence,
+        # so that the sampler can keep them together and in order.
+        model_inputs["chunk_group_size"] = []
+        # Per-chunk N_g: total response tokens of the source sequence this chunk
+        # belongs to. All chunks from the same source sequence carry the same
+        # value; bin-packed short sequences store the bin's total response
+        # tokens. Consumed by the SFT chunkpipe per-sample loss path.
+        model_inputs["group_total_tokens"] = []
+
     pad_to_multiple_of = 1
     if config.packing:
         all_input_ids, all_labels, all_loss_mask = [], [], []
@@ -208,69 +327,209 @@ def _preprocess_supervised_dataset(
             else 1
         )
 
-    for i in range(len(samples["prompt"])):
-        if len(samples["prompt"][i]) % 2 != 1 or len(samples["response"][i]) != 1:
-            logger.warning(
-                f"Ignore invalid sample, prompt: {samples['prompt'][i]}, response: {samples['response'][i]}"
-            )
-            continue
+    if config.enable_chunkpipe:
+        chunksize = config.chunksize
+        mtp_num_layers = getattr(config, "mtp_num_layers", 0) or 0
+        # Buffers for long sequences (len > chunksize): will be split into chunks
+        long_input_ids, long_labels, long_loss_mask = [], [], []
+        # Buffers for short sequences (len <= chunksize): will be binpacked
+        short_input_ids, short_labels, short_loss_mask = [], [], []
+        short_sample_lens = []
+        short_len_to_sample_indexs = defaultdict(list)
+        short_index = 0
 
-        input_ids, labels, loss_mask, ori_total_len = _encode_supervised_example(
-            prompt=samples["prompt"][i],
-            response=samples["response"][i],
-            system=samples["system"][i],
-            images=samples["images"][i] or [],
-            videos=samples["videos"][i] or [],
-            config=config,
-        )
+    use_hf_chat_template = isinstance(config.chat_template, HFChatTemplate)
+    if use_hf_chat_template:
+        if "messages" not in samples:
+            raise ValueError(
+                "HFChatTemplate requires OpenAI Chat Completions-style "
+                "`messages` samples. Use dataset format "
+                "`openai_chat_completions` with a registered `*-hf` chat template."
+            )
+        sample_count = len(samples["messages"])
+    else:
+        if "prompt" not in samples or "response" not in samples:
+            raise ValueError(
+                "Legacy ChatTemplate preprocessing requires `prompt` and "
+                "`response` samples. Use a registered `*-hf` chat template for "
+                "OpenAI Chat Completions-style `messages` samples."
+            )
+        sample_count = len(samples["prompt"])
+
+    for i in range(sample_count):
+        if use_hf_chat_template:
+            input_ids, labels, loss_mask, ori_total_len = _encode_openai_example(
+                messages_json=samples["messages"][i],
+                tools_json=samples["tools"][i] if "tools" in samples else None,
+                config=config,
+            )
+        else:
+            if (
+                len(samples["prompt"][i]) % 2 != 1
+                or len(samples["response"][i]) != 1
+            ):
+                logger.warning(
+                    f"Ignore invalid sample, prompt: {samples['prompt'][i]}, "
+                    f"response: {samples['response'][i]}"
+                )
+                continue
+
+            input_ids, labels, loss_mask, ori_total_len = _encode_supervised_example(
+                prompt=samples["prompt"][i],
+                response=samples["response"][i],
+                system=samples["system"][i],
+                images=samples["images"][i] or [],
+                videos=samples["videos"][i] or [],
+                config=config,
+            )
+
+        if not input_ids:
+            logger.warning("Ignore sample with no tokens after preprocessing.")
+            continue
 
         if config.enable_discard_sample:
             if ori_total_len > config.sequence_length:
                 continue
 
-        if not config.packing:
-            model_inputs["input_ids"].append(input_ids)
-            model_inputs["labels"].append(labels)
-            model_inputs["attention_mask"].append([1] * len(input_ids))
-            model_inputs["images"].append(samples["images"][i])
-            model_inputs["videos"].append(samples["videos"][i])
-            if not config.eod_mask_loss:
-                model_inputs["loss_mask"].append(loss_mask)
+        if config.enable_chunkpipe:
+            _sample_len = len(input_ids)
+            if _sample_len > chunksize:
+                # Long sequence: collect for later splitting
+                long_input_ids.append(input_ids)
+                long_labels.append(labels)
+                long_loss_mask.append(loss_mask)
+            else:
+                # Short sequence: collect for later binpacking
+                short_input_ids.append(input_ids)
+                short_labels.append(labels)
+                short_loss_mask.append(loss_mask)
+                short_sample_lens.append(_sample_len)
+                short_len_to_sample_indexs[_sample_len].append(short_index)
+                short_index += 1
 
         else:
-            # TODO: support packing for images/videos
-            assert samples["images"][i] in [None, []] and samples["videos"][i] in [
-                None,
-                [],
-            ], "packing is not supported for images/videos yet."
+            if not config.packing:
+                model_inputs["input_ids"].append(input_ids)
+                model_inputs["labels"].append(labels)
+                model_inputs["attention_mask"].append([1] * len(input_ids))
+                model_inputs["images"].append(samples["images"][i])
+                model_inputs["videos"].append(samples["videos"][i])
+                if not config.eod_mask_loss:
+                    model_inputs["loss_mask"].append(loss_mask)
 
-            if pad_to_multiple_of > 1:
-                input_ids = _pad_sequence_to_multiple(
-                    config, input_ids, pad_to_multiple_of, config.tokenizer.pad
-                )
-                labels = _pad_sequence_to_multiple(
-                    config, labels, pad_to_multiple_of, constants.IGNORE_INDEX
-                )
-                loss_mask = _pad_sequence_to_multiple(
-                    config, loss_mask, pad_to_multiple_of, 0
-                )
+            else:
+                # TODO: support packing for images/videos
+                assert samples["images"][i] in [None, []] and samples["videos"][i] in [
+                    None,
+                    [],
+                ], "packing is not supported for images/videos yet."
 
-            # prepare for packing
-            _sample_len = len(input_ids)
-            if _sample_len > config.sequence_length:
-                logger.warning(
-                    f"Ignore too long sample with length {_sample_len} > {config.sequence_length}."
+                if pad_to_multiple_of > 1:
+                    input_ids = _pad_sequence_to_multiple(
+                        config, input_ids, pad_to_multiple_of, config.tokenizer.pad
+                    )
+                    labels = _pad_sequence_to_multiple(
+                        config, labels, pad_to_multiple_of, constants.IGNORE_INDEX
+                    )
+                    loss_mask = _pad_sequence_to_multiple(
+                        config, loss_mask, pad_to_multiple_of, 0
+                    )
+
+                # prepare for packing
+                _sample_len = len(input_ids)
+                if _sample_len > config.sequence_length:
+                    logger.warning(
+                        f"Ignore too long sample with length {_sample_len} > {config.sequence_length}."
+                    )
+                    continue
+
+                all_input_ids.append(input_ids)
+                all_labels.append(labels)
+                all_loss_mask.append(loss_mask)
+                all_sampel_lens.append(_sample_len)
+                len_to_sample_indexs[_sample_len].append(index)
+                index += 1
+
+    if not config.packing and not config.enable_chunkpipe:
+        return model_inputs
+
+    if config.enable_chunkpipe:
+        pad_token_id = config.tokenizer.pad
+        ignore_index = config.ignore_index
+
+        # (c) Long sequence splitting: split each long sequence into chunks of chunksize
+        for idx in range(len(long_input_ids)):
+            chunks = _split_long_sequence(
+                long_input_ids[idx],
+                long_labels[idx],
+                long_loss_mask[idx],
+                chunksize,
+                pad_token_id,
+                ignore_index,
+                mtp_num_layers,
+            )
+            num_chunks = len(chunks)
+            # N_g = total response tokens across all chunks of this source
+            # sequence (sum of per-chunk loss masks). Shared by every chunk.
+            group_total_tokens = sum(
+                sum(chunk_loss_mask[:chunksize]) for _, _, chunk_loss_mask in chunks
+            )
+            for chunk_input_ids, chunk_labels, chunk_loss_mask in chunks:
+                model_inputs["input_ids"].append(chunk_input_ids)
+                model_inputs["labels"].append(chunk_labels)
+                model_inputs["attention_mask"].append(
+                    [1] * chunksize + [0] * mtp_num_layers
                 )
-                continue
+                model_inputs["images"].append([])
+                model_inputs["videos"].append([])
+                model_inputs["chunk_group_size"].append(num_chunks)
+                model_inputs["group_total_tokens"].append(group_total_tokens)
+                if not config.eod_mask_loss:
+                    model_inputs["loss_mask"].append(chunk_loss_mask)
 
-            all_input_ids.append(input_ids)
-            all_labels.append(labels)
-            all_loss_mask.append(loss_mask)
-            all_sampel_lens.append(_sample_len)
-            len_to_sample_indexs[_sample_len].append(index)
-            index += 1
+        # (d) Short sequence binpacking: pack short sequences into bins of chunksize
+        knapsacks = _build_knapsacks(short_sample_lens, chunksize)
+        for knapsack in knapsacks:
+            packed_input_ids, packed_labels, packed_loss_mask, packed_attention_mask = (
+                [], [], [], [],
+            )
+            for i, length in enumerate(knapsack):
+                idx = short_len_to_sample_indexs[length].pop()
+                packed_input_ids += short_input_ids[idx]
+                # Pre-shift labels and loss_mask per sequence for next-token prediction:
+                # shift left by 1, last position set to IGNORE/0 (end of sequence)
+                packed_labels += short_labels[idx][1:] + [ignore_index]
+                packed_loss_mask += short_loss_mask[idx][1:] + [0]
+                packed_attention_mask += [i + 1] * len(short_input_ids[idx])  # start from 1
 
-    if not config.packing:
+            # Pad to chunksize
+            padding_len = chunksize - len(packed_input_ids)
+            if padding_len > 0:
+                packed_input_ids += [pad_token_id] * padding_len
+                packed_labels += [ignore_index] * padding_len
+                packed_loss_mask += [0] * padding_len
+                packed_attention_mask += [0] * padding_len
+
+            if mtp_num_layers > 0:
+                packed_input_ids += [pad_token_id] * mtp_num_layers
+                packed_labels += [ignore_index] * mtp_num_layers
+                packed_loss_mask += [0] * mtp_num_layers
+                packed_attention_mask += [0] * mtp_num_layers
+
+            model_inputs["input_ids"].append(packed_input_ids)
+            model_inputs["labels"].append(packed_labels)
+            model_inputs["attention_mask"].append(packed_attention_mask)
+            model_inputs["images"].append([])
+            model_inputs["videos"].append([])
+            model_inputs["chunk_group_size"].append(1)
+            # Bin-packed chunk is treated as a single sample; N_g = total
+            # response tokens of the base chunk, excluding MTP bridge padding.
+            model_inputs["group_total_tokens"].append(
+                sum(packed_loss_mask[:chunksize])
+            )
+            if not config.eod_mask_loss:
+                model_inputs["loss_mask"].append(packed_loss_mask)
+
         return model_inputs
 
     # build packing
@@ -356,7 +615,7 @@ def convert_to_tokenized_data(
             load_from_cache_file=load_from_cache_file,
             desc="Converting dataset to tokenized data",
         )
-        if config.sort_batch and not config.packing:
+        if config.sort_batch and not config.packing and not config.enable_chunkpipe:
             dataset_list = list(dataset)
             # Sort the dataset by length of samples
             sorted_dataset = _chunked_sort(dataset_list, chunk_size=100000)
@@ -385,6 +644,9 @@ def convert_to_tokenized_data(
     features["videos"] = datasets.Sequence(
         datasets.Value(dtype="string", id=None), length=-1, id=None
     )
+    if config.enable_chunkpipe:
+        features["chunk_group_size"] = datasets.Value(dtype="int64", id=None)
+        features["group_total_tokens"] = datasets.Value(dtype="int64", id=None)
 
     dataset = dataset.map(
         partial(_preprocess_supervised_dataset, config=config),

--- a/loongforge/train/pretrain/pretrain_vlm.py
+++ b/loongforge/train/pretrain/pretrain_vlm.py
@@ -32,6 +32,7 @@ from loongforge.utils import constants, get_args, get_model_config
 # from loongforge.models.qwen_vl.utils import get_inputs_on_this_cp_rank_by_tex # TODO:@yizhan
 from loongforge.train.megatron_trainer import MegatronTrainer
 from loongforge.train.trainer_builder import register_model_trainer
+from loongforge.train.training_utils import dump_model_input_example_once
 from loongforge.train.sft.utils import (
     build_sft_data_collator,
     build_sft_cyclic_iterators,
@@ -375,6 +376,10 @@ def forward_step(data_iterator, model, return_schedule_plan: bool = False):
             loss_mask,
             packed_seq_params,
         ) = batch_list[inner_group_id].values()
+
+        dump_model_input_example_once(
+            tokens, labels, attn_mask, cu_lengths, packed_seq_params,
+        )
 
         loss_func = getattr(model_config, "loss_func", default_loss_func)
 

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -2898,3 +2898,174 @@ def train(
         sys.exit(exit_code)
 
     return iteration, num_floating_point_operations_so_far
+
+
+_PRINTED_MODEL_INPUT_EXAMPLE = False
+
+_SAMPLE_DUMP_ANSI_COLOR = {
+    "T": "\033[92m",  # bright green — trainable (labels != IGNORE_INDEX)
+    "C": "\033[93m",  # yellow       — context (attended but not trained)
+    "P": "\033[90m",  # grey         — padded / masked
+}
+_SAMPLE_DUMP_ANSI_RESET = "\033[0m"
+
+
+def dump_model_input_example_once(
+    tokens, labels, attn_mask, cu_lengths=None, packed_seq_params=None
+):
+    """Dump the exact tensors flowing into ``model(...)``.
+
+    Runs once per process on (rank0, tp0, cp0). Decodes ``tokens`` with each
+    token segment colored by its role: green = trainable target (the model
+    is asked to predict this token), grey = padded (``attn_mask`` truthy),
+    yellow = context (attended but not trained). Consecutive same-role
+    tokens are decoded as one segment so multi-byte BPE pieces render
+    correctly. These are the same tensor objects the caller passes to
+    ``model(...)`` — any disalignment would mean someone mutated them in
+    between.
+
+    Labels here are already left-shifted by the collator for next-token
+    prediction (``labels[i]`` is the target the model produces from
+    ``tokens[:i+1]``, i.e. equal to ``tokens[i+1]``). So a token at
+    position ``i`` is trainable iff ``labels[i-1] != IGNORE_INDEX``;
+    position 0 is never a trainable target.
+
+    Pass ``cu_lengths`` / ``packed_seq_params`` only when the trainer packs
+    samples; for non-packed paths leave them as ``None``.
+    """
+    global _PRINTED_MODEL_INPUT_EXAMPLE
+    if _PRINTED_MODEL_INPUT_EXAMPLE:
+        return
+
+    if torch.distributed.is_available() and torch.distributed.is_initialized():
+        if torch.distributed.get_rank() != 0:
+            return
+    else:
+        if int(os.environ.get("RANK", "0")) != 0:
+            return
+
+    try:
+        if mpu.get_tensor_model_parallel_rank() != 0:
+            return
+        if mpu.get_context_parallel_rank() != 0:
+            return
+    except Exception:
+        pass
+
+    _PRINTED_MODEL_INPUT_EXAMPLE = True
+
+    from loongforge.utils.global_vars import get_tokenizer as get_loongforge_tokenizer
+    from loongforge.utils.constants import IGNORE_INDEX
+
+    tokenizer = get_loongforge_tokenizer()
+
+    def to_cpu_list(x):
+        if torch.is_tensor(x):
+            return x.detach().cpu().tolist()
+        if x is None:
+            return None
+        return list(x)
+
+    def decode(ids):
+        if not ids:
+            return ""
+        try:
+            return tokenizer.detokenize(ids, skip_special_tokens=False)
+        except TypeError:
+            return tokenizer.detokenize(ids)
+
+    tok = tokens[0] if tokens.dim() == 2 else tokens
+    lab = labels[0] if labels.dim() == 2 else labels
+
+    cu = cu_lengths
+    if torch.is_tensor(cu):
+        cu = cu[0] if cu.dim() == 2 else cu
+    cu_list = to_cpu_list(cu) or []
+
+    tok_list = to_cpu_list(tok)
+    lab_list = to_cpu_list(lab)
+
+    am = attn_mask
+    am_list = None
+    if torch.is_tensor(am):
+        if am.dim() == 4:
+            # Megatron sometimes hands a (1,1,seq,seq) causal-style mask; we
+            # only care about per-position padding here, so collapse it.
+            am_view = am[0, 0].diagonal()
+        elif am.dim() == 2:
+            am_view = am[0]
+        elif am.dim() == 1:
+            am_view = am
+        else:
+            am_view = None
+        if am_view is not None:
+            am_list = am_view.detach().cpu().to(torch.bool).tolist()
+
+    seq_len = len(tok_list)
+    # `labels` is the next-token-prediction target the collator produced,
+    # i.e. labels[i] is the target after consuming tokens[0..i]. So token
+    # position `i` is a trainable target iff labels[i-1] != IGNORE_INDEX.
+    # Position 0 has no predecessor and is never a target.
+    trainable_total = sum(
+        1 for v in lab_list[:-1] if v != IGNORE_INDEX
+    ) if lab_list else 0
+
+    def role_at(i):
+        if i > 0 and lab_list[i - 1] != IGNORE_INDEX:
+            return "T"
+        if am_list is not None and i < len(am_list) and am_list[i]:
+            return "P"
+        return "C"
+
+    header = [
+        "===== model-input example (forward_step entry, same tensor as model(...)) =====",
+        f"tokens.shape={tuple(tokens.shape)} labels.shape={tuple(labels.shape)} "
+        f"attn_mask.shape={tuple(attn_mask.shape) if torch.is_tensor(attn_mask) else None}",
+        f"local_seq_len={seq_len} trainable_tokens={trainable_total}",
+        f"cu_lengths={cu_list}",
+        f"packed_seq_params={packed_seq_params}",
+        f"tp_rank={mpu.get_tensor_model_parallel_rank()} "
+        f"cp_rank={mpu.get_context_parallel_rank()}/{mpu.get_context_parallel_world_size()} "
+        f"pp_rank={mpu.get_pipeline_model_parallel_rank()}",
+        f"[mask_legend] {_SAMPLE_DUMP_ANSI_COLOR['T']}T=trainable target{_SAMPLE_DUMP_ANSI_RESET} "
+        f"{_SAMPLE_DUMP_ANSI_COLOR['C']}C=context attended{_SAMPLE_DUMP_ANSI_RESET} "
+        f"{_SAMPLE_DUMP_ANSI_COLOR['P']}P=padded/masked{_SAMPLE_DUMP_ANSI_RESET}",
+    ]
+
+    trainable_ids = [v for v in lab_list if v != IGNORE_INDEX]
+
+    # Decode contiguous same-role runs as single segments so multi-byte BPE
+    # pieces render correctly. Splitting per-token would break UTF-8 mid-codepoint.
+    colored_segments = []
+    if seq_len:
+        run_start = 0
+        run_role = role_at(0)
+        for i in range(1, seq_len):
+            r = role_at(i)
+            if r != run_role:
+                colored_segments.append(
+                    f"{_SAMPLE_DUMP_ANSI_COLOR[run_role]}"
+                    f"{decode(tok_list[run_start:i])}"
+                    f"{_SAMPLE_DUMP_ANSI_RESET}"
+                )
+                run_start = i
+                run_role = r
+        colored_segments.append(
+            f"{_SAMPLE_DUMP_ANSI_COLOR[run_role]}"
+            f"{decode(tok_list[run_start:seq_len])}"
+            f"{_SAMPLE_DUMP_ANSI_RESET}"
+        )
+    colored_decoded = "".join(colored_segments)
+
+    body = [
+        "[input_ids]",
+        str(tok_list),
+        "[decoded_input | colored by role]",
+        colored_decoded,
+        "[decoded_trainable_labels]",
+        decode(trainable_ids),
+    ]
+
+    print("\n".join(header + body + [
+        "===== end model-input example =====",
+    ]), flush=True)

--- a/loongforge/utils/constants.py
+++ b/loongforge/utils/constants.py
@@ -27,6 +27,7 @@ class SFTDataFormats(object):
 
     ALPACA = "alpaca"
     SHAREGPT = "sharegpt"
+    OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
 
 
 class DataRoles(object):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -139,6 +139,7 @@ include = [
     "loongforge/data/*",
     "loongforge/**/*.yaml",
     "loongforge/**/*.json",
+    "loongforge/**/*.jinja",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/tools/data_preprocess/llm/preprocess_sft_data.py
+++ b/tools/data_preprocess/llm/preprocess_sft_data.py
@@ -4,6 +4,8 @@
 """preprocess sft data"""
 
 import argparse
+import json
+from pathlib import Path
 
 from transformers import AutoProcessor
 from datasets import DatasetDict
@@ -11,7 +13,11 @@ from datasets import DatasetDict
 from megatron.core.datasets.utils import get_blend_from_list, Split
 
 from loongforge.data.sft_dataset import SFTDatasetConfig, SFTDataset
-from loongforge.data import ChatTemplate, get_support_templates
+from loongforge.data import (
+    ChatTemplate,
+    HFChatTemplate,
+    get_support_templates,
+)
 from loongforge.tokenizer import build_tokenizer
 from loongforge.utils import constants
 from loongforge.utils.utils import get_default_sft_dataset_config
@@ -119,6 +125,10 @@ def _add_arguments(parser: argparse.ArgumentParser):
                        choices=get_support_templates(),
                        help='The template to apply to instruction data.')
 
+    group.add_argument('--chat-template-kwargs', type=str, default=None,
+                       help='Optional JSON object of extra kwargs for tokenizer.apply_chat_template. '
+                            'Only valid with HF chat templates.')
+
     group.add_argument('--sft-dataset-config', type=str, default=None,
                        help="A json file that contains the dataset configuration."
                             "default: configs/dataset_config.jsoin")
@@ -185,6 +195,20 @@ def parse_args():
     assert args.chat_template is not None, "chat_template not specified"
     template = ChatTemplate.from_name(args.chat_template)
     assert template is not None, f"chat_template {args.chat_template} not supported."
+
+    if args.chat_template_kwargs is not None:
+        if not isinstance(template, HFChatTemplate):
+            raise ValueError(
+                "--chat-template-kwargs is only supported with HF chat templates"
+            )
+        raw_kwargs = args.chat_template_kwargs
+        if not raw_kwargs.lstrip().startswith("{"):
+            kwargs_path = Path(raw_kwargs)
+            if kwargs_path.is_file():
+                raw_kwargs = kwargs_path.read_text(encoding="utf-8")
+        template.chat_template_kwargs = json.loads(raw_kwargs)
+        if not isinstance(template.chat_template_kwargs, dict):
+            raise ValueError("--chat-template-kwargs must be a JSON object")
     args.template = template
  
     args.variable_seq_lengths = True

--- a/tools/data_preprocess/vlm/convert_to_wds.sh
+++ b/tools/data_preprocess/vlm/convert_to_wds.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# messages_to_wds.sh : convert messages-format JSONL to WebDataset tar shards.
+set -euo pipefail
+
+INPUT="${INPUT:-/path/to/load/messages-format-jsonl}"   # messages-format JSONL
+OUTPUT_DIR="${OUTPUT_DIR:-/path/to/save/wds}"    # WDS output dir for kimi model
+LOONGFORGE_PATH="${LOONGFORGE_PATH:-/workspace/LoongForge}"
+MAXCOUNT="${MAXCOUNT:-10000}"
+MAXSIZE="${MAXSIZE:-3000000000}"
+
+CONVERT_SCRIPT="$LOONGFORGE_PATH/tools/data_preprocess/vlm/convert_to_webdataset.py"
+mkdir -p "$OUTPUT_DIR"
+
+python3 "$CONVERT_SCRIPT" \
+    --output_dir "$OUTPUT_DIR" \
+    --json_file  "$INPUT" \
+    --media mix \
+    --sample_type multi_mix_qa \
+    --columns_messages messages \
+    --maxcount "$MAXCOUNT" \
+    --maxsize  "$MAXSIZE"
+
+echo "[messages_to_wds] done -> $OUTPUT_DIR"

--- a/tools/data_preprocess/vlm/offline_packing/configs/config.yaml
+++ b/tools/data_preprocess/vlm/offline_packing/configs/config.yaml
@@ -34,7 +34,7 @@ sample:
   # Max length of training data tokens
   max_token_len: 131072
   # Determine parsing method
-  sample_type: packed_multi_mix_qa
+  sample_type: packed_chat_mix
 
 packing:
   # WDS-native production default. It keeps all valid samples and lets training

--- a/tools/data_preprocess/vlm/offline_packing/scripts/pack_wds.sh
+++ b/tools/data_preprocess/vlm/offline_packing/scripts/pack_wds.sh
@@ -7,18 +7,58 @@ cd "${BASE_DIR}"
 
 CONFIG="${1:-configs/config.yaml}"
 
-echo "=== [Step 1] Scan WDS Manifest and Compute Sample Length ==="
+format_elapsed() {
+    local total_seconds="$1"
+    local hours=$((total_seconds / 3600))
+    local minutes=$(((total_seconds % 3600) / 60))
+    local seconds=$((total_seconds % 60))
 
-python -m wds_pack.cli.scan_manifest --config "${CONFIG}"
+    printf "%02d:%02d:%02d" "${hours}" "${minutes}" "${seconds}"
+}
 
-echo "=== [Step 2] Hash-Bucket Split by Media Type ==="
+run_step() {
+    local step_name="$1"
+    shift
+    local start_time
+    local end_time
+    local elapsed
+    local status
 
-python -m wds_pack.cli.pack_bins --config "${CONFIG}"
+    echo "=== [${step_name}] START $(date '+%F %T') ==="
+    start_time=$(date +%s)
+    set +e
+    "$@"
+    status=$?
+    set -e
+    end_time=$(date +%s)
+    elapsed=$((end_time - start_time))
 
-echo "=== [Step 3] Build Pack Plan ==="
+    if [ "${status}" -eq 0 ]; then
+        echo "=== [${step_name}] DONE elapsed=$(format_elapsed "${elapsed}") (${elapsed}s) ==="
+    else
+        echo "=== [${step_name}] FAILED status=${status} elapsed=$(format_elapsed "${elapsed}") (${elapsed}s) ==="
+    fi
 
-python -m wds_pack.cli.build_plan --config "${CONFIG}"
+    return "${status}"
+}
 
-echo "=== [Step 4] Pack to WDS Format==="
+pipeline_start=$(date +%s)
 
-python -m wds_pack.cli.write_wds --config "${CONFIG}"
+echo "=== [Offline Packing] START $(date '+%F %T') config=${CONFIG} ==="
+
+run_step "Step 1: Scan WDS Manifest and Compute Sample Length" \
+    python -m wds_pack.cli.scan_manifest --config "${CONFIG}"
+
+run_step "Step 2: Hash-Bucket Split by Media Type" \
+    python -m wds_pack.cli.pack_bins --config "${CONFIG}"
+
+run_step "Step 3: Build Pack Plan" \
+    python -m wds_pack.cli.build_plan --config "${CONFIG}"
+
+run_step "Step 4: Pack to WDS Format" \
+    python -m wds_pack.cli.write_wds --config "${CONFIG}"
+
+pipeline_end=$(date +%s)
+pipeline_elapsed=$((pipeline_end - pipeline_start))
+
+echo "=== [Offline Packing] DONE elapsed=$(format_elapsed "${pipeline_elapsed}") (${pipeline_elapsed}s) ==="

--- a/tools/data_preprocess/vlm/offline_packing/wds_pack/core/types.py
+++ b/tools/data_preprocess/vlm/offline_packing/wds_pack/core/types.py
@@ -4,7 +4,7 @@
 """Typed records shared by the WDS-native offline packing stages."""
 
 from dataclasses import dataclass
-from typing import Tuple
+from typing import Any, Dict, Optional, Tuple
 
 HASH_BUCKET_WEIGHT_KEY = "w"
 HASH_BUCKET_TOKEN_LEN_KEY = "l"
@@ -65,6 +65,7 @@ class ManifestSample:
     prompt: str
     caption: str
     media_files: Tuple[str, ...]
+    raw_json: Optional[Dict[str, Any]] = None
 
     def pack_item(self) -> PackItem:
         return PackItem(sample_id=self.sample_id, token_len=self.token_len)

--- a/tools/data_preprocess/vlm/offline_packing/wds_pack/io/webdataset_writer.py
+++ b/tools/data_preprocess/vlm/offline_packing/wds_pack/io/webdataset_writer.py
@@ -404,6 +404,11 @@ def convert_to_wds(cfg: PackedWDSConfig):
     if cfg.sample_type == "packed_multi_mix_qa":
         stream_fn = stream_samples_packed_multi_mix_qa
         construct_fn = construct_sample_packed_multi_mix_qa
+    elif cfg.sample_type == "packed_chat_mix":
+        raise ValueError(
+            "packed_chat_mix is only supported by the WDS-native "
+            "offline packing path with data.input_format='wds'."
+        )
     else:
         stream_fn = stream_samples_caption
         construct_fn = lambda entry, roots: construct_sample(entry, roots)
@@ -441,7 +446,13 @@ def _safe_target_name(part: str, sample_index: int, used_names: set) -> str:
         counter += 1
 
 
-def construct_native_packed_sample(plan: dict, samples: dict, members: dict, reader: ShardReaderCache):
+def construct_native_packed_sample(
+    plan: dict,
+    samples: dict,
+    members: dict,
+    reader: ShardReaderCache,
+    sample_type: str,
+):
     media_type = plan["media_type"]
     sample_ids = plan["sample_ids"]
     packed = {"__key__": plan["pack_id"], "__restore_key__": plan["pack_id"]}
@@ -449,6 +460,7 @@ def construct_native_packed_sample(plan: dict, samples: dict, members: dict, rea
     captions = []
     token_lens = []
     packed_media_files = []
+    raw_samples = []
     used_names = set()
 
     for sample_index, sample_id in enumerate(sample_ids):
@@ -464,6 +476,13 @@ def construct_native_packed_sample(plan: dict, samples: dict, members: dict, rea
         prompts.append(sample.prompt)
         captions.append(sample.caption)
         token_lens.append(sample.token_len)
+        raw_sample = sample.raw_json or {}
+        if sample_type == "packed_chat_mix" and isinstance(raw_sample, dict):
+            raw_sample = dict(raw_sample)
+            texts = raw_sample.pop("texts", None)
+            if "messages" not in raw_sample and texts is not None:
+                raw_sample["messages"] = texts
+        raw_samples.append(raw_sample)
 
         if media_type == "text":
             packed_media_files.append([])
@@ -484,8 +503,20 @@ def construct_native_packed_sample(plan: dict, samples: dict, members: dict, rea
             current_media.append(target_name)
         packed_media_files.append(current_media)
 
-    packed["json"] = json.dumps(
-        {
+    if sample_type == "packed_chat_mix":
+        payload = {
+            "messages": raw_samples,
+            "media_files": packed_media_files,
+            "media_type": media_type,
+            "_meta": {
+                "pack_id": plan["pack_id"],
+                "sample_ids": sample_ids,
+                "token_lens": token_lens,
+                "total_token_len": sum(token_lens),
+            },
+        }
+    elif sample_type == "packed_multi_mix_qa":
+        payload = {
             "texts": {"prompts": prompts, "captions": captions},
             "media_files": packed_media_files,
             "media_type": media_type,
@@ -495,9 +526,13 @@ def construct_native_packed_sample(plan: dict, samples: dict, members: dict, rea
                 "token_lens": token_lens,
                 "total_token_len": sum(token_lens),
             },
-        },
-        ensure_ascii=False,
-    ).encode("utf-8")
+        }
+    else:
+        raise ValueError(
+            f"WDS-native packing writer does not support sample_type={sample_type!r}"
+        )
+
+    packed["json"] = json.dumps(payload, ensure_ascii=False).encode("utf-8")
     return packed
 
 
@@ -520,6 +555,7 @@ def convert_native_to_wds(cfg: dict):
         raise FileNotFoundError(f"Pack plan not found: {pack_plan}")
 
     samples, members = load_manifest_for_packing(manifest_sqlite)
+    sample_type = cfg.get("sample", {}).get("sample_type", "packed_multi_mix_qa")
     maxcount = int(cfg.get("packed_wds", {}).get("maxcount", 1000000))
     maxsize = int(cfg.get("packed_wds", {}).get("maxsize", 100000000))
     tar_pattern = output_dir / "pretrain-%06d.tar"
@@ -532,13 +568,15 @@ def convert_native_to_wds(cfg: dict):
             if not line.strip():
                 continue
             plan = json.loads(line)
-            sample = construct_native_packed_sample(plan, samples, members, reader)
+            sample = construct_native_packed_sample(
+                plan, samples, members, reader, sample_type
+            )
             _log_json_presence(plan["pack_id"], sample, idx)
             sink.write(sample)
 
     write_config(
         EPath(output_dir).absolute(),
-        sample_type=cfg.get("sample", {}).get("sample_type", "packed_multi_mix_qa"),
+        sample_type=sample_type,
     )
     print("WDS-native packed dataset successfully converted to wds")
 

--- a/tools/data_preprocess/vlm/offline_packing/wds_pack/manifest/scan.py
+++ b/tools/data_preprocess/vlm/offline_packing/wds_pack/manifest/scan.py
@@ -50,8 +50,10 @@ ROLE_ALIASES = {
     "bot": "assistant",
     "assistant": "assistant",
     "system": "system",
+    "tool": "tool",
+    "function": "tool",
 }
-FROM_ALIASES = {"user": "human", "assistant": "gpt"}
+FROM_ALIASES = {"user": "human", "assistant": "gpt", "tool": "tool"}
 MEDIA_CONTENT_ALIASES = {
     "image": {"image", "image_url"},
     "video": {"video", "video_url"},
@@ -433,6 +435,45 @@ def _count_media_placeholder_tokens(processor, model_inputs, placeholder_tokens:
     return sum(1 for token_id in input_ids if token_id in placeholder_ids)
 
 
+def _encode_text_input_ids(processor, text_input: str) -> Optional[List[int]]:
+    """Encode rendered chat text with the direct tokenizer API used at runtime."""
+    tokenizer = getattr(processor, "tokenizer", processor)
+    encode = getattr(tokenizer, "encode", None)
+    if encode is None:
+        return None
+
+    try:
+        input_ids = encode(text_input, add_special_tokens=False)
+    except TypeError:
+        input_ids = encode(text_input)
+
+    if hasattr(input_ids, "tolist"):
+        input_ids = input_ids.tolist()
+    if input_ids and isinstance(input_ids[0], list):
+        input_ids = input_ids[0]
+    return list(input_ids)
+
+
+def _count_media_placeholder_token_ids(
+    processor,
+    input_ids: Sequence[int],
+    placeholder_tokens: Sequence[str],
+) -> int:
+    tokenizer = getattr(processor, "tokenizer", processor)
+    convert_tokens_to_ids = getattr(tokenizer, "convert_tokens_to_ids", None)
+    if convert_tokens_to_ids is None:
+        return 0
+    placeholder_ids = {
+        convert_tokens_to_ids(token)
+        for token in placeholder_tokens
+        if token
+    }
+    placeholder_ids.discard(None)
+    if not placeholder_ids:
+        return 0
+    return sum(1 for token_id in input_ids if token_id in placeholder_ids)
+
+
 def _as_media_list(media_inputs: dict) -> List[dict]:
     medias = []
     for image in media_inputs.get("images", []):
@@ -480,16 +521,29 @@ def _compute_processor_token_len(
     media_inputs: dict,
     placeholder_tokens: Sequence[str] = DEFAULT_MEDIA_PLACEHOLDER_TOKENS,
 ) -> int:
+    direct_input_ids = _encode_text_input_ids(processor, text_input)
+    if not media_inputs and direct_input_ids is not None:
+        return len(direct_input_ids)
+
     model_inputs = _processor_model_inputs(processor, text_input, media_inputs)
-    token_len = _input_ids_len(model_inputs)
+    token_len = (
+        len(direct_input_ids)
+        if direct_input_ids is not None
+        else _input_ids_len(model_inputs)
+    )
 
     feature_lengths = _media_feature_lengths_from_grid(processor, model_inputs)
     if not feature_lengths:
         return token_len
 
-    placeholder_count = _count_media_placeholder_tokens(
-        processor, model_inputs, placeholder_tokens
-    )
+    if direct_input_ids is not None:
+        placeholder_count = _count_media_placeholder_token_ids(
+            processor, direct_input_ids, placeholder_tokens
+        )
+    else:
+        placeholder_count = _count_media_placeholder_tokens(
+            processor, model_inputs, placeholder_tokens
+        )
     replaced_tokens = min(placeholder_count, len(feature_lengths))
     return token_len - replaced_tokens + sum(feature_lengths)
 
@@ -569,7 +623,10 @@ def prepare_messages_for_hf_chat_template(messages: Sequence[dict], media_type: 
             else:
                 remaining_media -= count_structured_media_parts(content, media_type)
 
-        rendered_messages.append({"role": role, "content": content})
+        rendered_message = dict(message)
+        rendered_message["role"] = role
+        rendered_message["content"] = content
+        rendered_messages.append(rendered_message)
 
     if media_type in ("image", "video") and remaining_media != 0:
         raise ValueError(
@@ -587,9 +644,43 @@ def should_use_hf_chat_template(processor, cfg: dict) -> bool:
     return bool(model_cfg.get("chat_template_path"))
 
 
+def prepare_tools_for_hf_render(tokenizer, tools: Optional[Sequence[dict]], kwargs: dict):
+    if not tools:
+        return None, kwargs
+
+    tools = list(tools)
+    apply_chat_template = tokenizer.apply_chat_template
+    if hasattr(apply_chat_template, "__func__"):
+        apply_chat_template = apply_chat_template.__func__
+    apply_globals = getattr(apply_chat_template, "__globals__", {})
+    deep_sort_dict = apply_globals.get("deep_sort_dict")
+    encode_tools_to_typescript_style = apply_globals.get(
+        "encode_tools_to_typescript_style"
+    )
+
+    if deep_sort_dict is not None:
+        tools = deep_sort_dict(tools)
+
+    if (
+        "tools_ts_str" not in kwargs
+        and encode_tools_to_typescript_style is not None
+    ):
+        try:
+            kwargs["tools_ts_str"] = encode_tools_to_typescript_style(tools)
+        except Exception as exc:
+            LOG.warning(
+                "Failed to render tools_ts_str with HF tokenizer helper; "
+                "falling back to raw tools for chat template rendering: %s",
+                exc,
+            )
+
+    return tools, kwargs
+
+
 def render_chat_text(
     processor,
     messages: Sequence[dict],
+    tools: Optional[Sequence[dict]],
     cfg: dict,
     fallback_template: Optional[Template],
     media_type: str,
@@ -611,7 +702,11 @@ def render_chat_text(
         chat_kwargs = dict(cfg.get("model", {}).get("chat_template_kwargs", {}))
         chat_kwargs.pop("add_generation_prompt", None)
         chat_kwargs.pop("tokenize", None)
+        chat_kwargs.pop("tools", None)
         chat_kwargs.setdefault("thinking", False)
+        tools, chat_kwargs = prepare_tools_for_hf_render(tokenizer, tools, chat_kwargs)
+        if tools:
+            chat_kwargs["tools"] = tools
         return tokenizer.apply_chat_template(
             rendered_messages,
             tokenize=False,
@@ -622,7 +717,7 @@ def render_chat_text(
     if fallback_template is None:
         raise ValueError("No fallback chat template configured")
     template_text_key = cfg.get("data", {}).get("template_text_key", "messages")
-    render_payload = {template_text_key: messages, "messages": messages}
+    render_payload = {template_text_key: messages, "messages": messages, "tools": tools}
     return fallback_template.render(**render_payload)
 
 
@@ -714,6 +809,7 @@ def build_manifest_row(
     prompt: str,
     caption: str,
     media_files: Sequence[str],
+    raw_json: dict,
 ) -> dict:
     return {
         "sample_id": sample_id,
@@ -724,6 +820,7 @@ def build_manifest_row(
         "prompt": prompt,
         "caption": caption,
         "media_files": list(media_files),
+        "raw_json": raw_json,
         "members": manifest_member_rows(group, media_files),
     }
 
@@ -753,6 +850,7 @@ def process_group(
     messages, prompt, caption = load_messages_and_pair(json_data, template_text_key)
     if not messages:
         return None, skip_row("missing_messages", group.base_key)
+    tools = json_data.get("tools")
 
     media_files = resolve_media_files(json_data, group, media_type)
     missing_media = [part for part in media_files if part not in group.members]
@@ -774,6 +872,7 @@ def process_group(
         text_input = render_chat_text(
             processor,
             messages,
+            tools,
             cfg,
             chat_template,
             media_type,
@@ -822,6 +921,7 @@ def process_group(
         prompt=prompt,
         caption=caption,
         media_files=media_files,
+        raw_json=json_data,
     ), None
 
 
@@ -997,8 +1097,24 @@ def main() -> None:
     log_level = cfg.get("log", {}).get("level", "INFO")
     setup_logging(work_dir, log_level)
 
-    if cfg.get("sample", {}).get("sample_type") != "packed_multi_mix_qa":
-        raise ValueError("WDS-native V1 only supports sample.sample_type=packed_multi_mix_qa")
+    sample_type = cfg.get("sample", {}).get("sample_type")
+    supported_sample_types = {"packed_multi_mix_qa", "packed_chat_mix"}
+    if sample_type not in supported_sample_types:
+        raise ValueError(
+            "WDS-native V1 only supports sample.sample_type in "
+            f"{sorted(supported_sample_types)}, got {sample_type!r}"
+        )
+
+    model_cfg = cfg.get("model", {})
+    if (
+        sample_type == "packed_chat_mix"
+        and not model_cfg.get("use_hf_chat_template")
+        and not model_cfg.get("chat_template_path")
+    ):
+        raise ValueError(
+            "packed_chat_mix requires HF chat template rendering. "
+            "Set model.use_hf_chat_template=true or model.chat_template_path."
+        )
 
     wds_dir = Path(cfg["data"]["wds_dir"])
     shards = sorted(wds_dir.glob("*.tar"))

--- a/tools/data_preprocess/vlm/offline_packing/wds_pack/manifest/sqlite.py
+++ b/tools/data_preprocess/vlm/offline_packing/wds_pack/manifest/sqlite.py
@@ -32,7 +32,8 @@ def create_manifest(path: Path) -> sqlite3.Connection:
             base_key TEXT NOT NULL,
             prompt TEXT NOT NULL,
             caption TEXT NOT NULL,
-            media_files_json TEXT NOT NULL
+            media_files_json TEXT NOT NULL,
+            raw_json TEXT NOT NULL
         )
         """
     )
@@ -57,8 +58,8 @@ def insert_manifest_row(conn: sqlite3.Connection, row: Mapping[str, object]) -> 
     conn.execute(
         """
         INSERT INTO samples
-        (sample_id, media_type, token_len, shard, base_key, prompt, caption, media_files_json)
-        VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+        (sample_id, media_type, token_len, shard, base_key, prompt, caption, media_files_json, raw_json)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
         """,
         (
             row["sample_id"],
@@ -69,6 +70,7 @@ def insert_manifest_row(conn: sqlite3.Connection, row: Mapping[str, object]) -> 
             row["prompt"],
             row["caption"],
             json.dumps(row["media_files"], ensure_ascii=False),
+            json.dumps(row.get("raw_json") or {}, ensure_ascii=False),
         ),
     )
     for member in row["members"]:
@@ -89,6 +91,9 @@ def insert_manifest_row(conn: sqlite3.Connection, row: Mapping[str, object]) -> 
 
 
 def _sample_from_row(row: sqlite3.Row) -> ManifestSample:
+    raw_json = None
+    if "raw_json" in row.keys():
+        raw_json = json.loads(row["raw_json"]) if row["raw_json"] else None
     return ManifestSample(
         sample_id=row["sample_id"],
         media_type=row["media_type"],
@@ -98,6 +103,7 @@ def _sample_from_row(row: sqlite3.Row) -> ManifestSample:
         prompt=row["prompt"],
         caption=row["caption"],
         media_files=tuple(json.loads(row["media_files_json"])),
+        raw_json=raw_json,
     )
 
 


### PR DESCRIPTION
## Summary

Add Kimi K2.5 tool-calling SFT data support and use HF chat templates to build OpenAI Chat Completions-style samples.

## Changes

- add an HF-backed Kimi K2.5 training chat template and OpenAI Chat Completions dataset format handling
- extend SFT tokenization/format utilities for `messages`/`tools` samples and tool-call labels
- add multimodal chat-mix flavors and route chat/packed-chat-mix encoders through the dataloader provider
- update SFT/VLM preprocessing, training setup, and data preprocessing tools for tool-calling and WDS workflows

## Validation

- `git diff --check github/master...HEAD`
- `python -m py_compile $(git diff --name-only github/master...HEAD -- '*.py')`
