### PR TITLE
[data] feat: support HF chat Jinja templates

### DIFF
--- a/configs/data/sft_dataset_config.yaml
+++ b/configs/data/sft_dataset_config.yaml
@@ -32,8 +32,8 @@ sharegpt:
     assistant_tag: assistant
     system_tag: system
 
-openai_chat_completions:
-  format: openai_chat_completions
+openai:
+  format: openai
   columns:
     messages: messages
     tools: tools

--- a/loongforge/data/__init__.py
+++ b/loongforge/data/__init__.py
@@ -12,6 +12,7 @@ from .chat_template import (
     ChatTemplate,
     HFChatTemplate,
     get_support_templates,
+    load_chat_template_kwargs,
 )
 
 from .mm_plugin import MMPlugin
@@ -31,6 +32,7 @@ __all__ = [
     "ChatTemplate",
     "HFChatTemplate",
     "get_support_templates",
+    "load_chat_template_kwargs",
     "MMPlugin",
     "DataCollatorForSupervisedDataset",
     "MultiModalDataCollatorForSupervisedDataset",

--- a/loongforge/data/chat_template.py
+++ b/loongforge/data/chat_template.py
@@ -20,10 +20,12 @@
 """Chat templates"""
 
 import importlib.resources as resources
+import json
 import logging
 import re
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import (
     TYPE_CHECKING,
     Type,
@@ -275,6 +277,23 @@ class ChatTemplate:
     def from_name(cls, name: str) -> "ChatTemplate":
         """build template."""
         return MAPPING_NAME_TO_TEMPLATE.get(name, None)
+
+
+def load_chat_template_kwargs(raw_kwargs: Optional[str]) -> Dict[str, Any]:
+    """Load HF chat template kwargs from a JSON object string or JSON file path."""
+    if raw_kwargs is None:
+        return {}
+
+    kwargs_text = raw_kwargs
+    if not kwargs_text.lstrip().startswith("{"):
+        kwargs_path = Path(kwargs_text)
+        if kwargs_path.is_file():
+            kwargs_text = kwargs_path.read_text(encoding="utf-8")
+
+    chat_template_kwargs = json.loads(kwargs_text)
+    if not isinstance(chat_template_kwargs, dict):
+        raise ValueError("chat_template_kwargs must be a JSON object")
+    return chat_template_kwargs
 
 
 @dataclass
@@ -802,20 +821,147 @@ def get_support_templates() -> List[str]:
     return list(MAPPING_NAME_TO_TEMPLATE.keys())
 
 
+def _read_builtin_chat_template(filename: str) -> str:
+    """Read a packaged Jinja chat template."""
+    return (
+        resources.files("loongforge.data.chat_templates")
+        .joinpath(filename)
+        .read_text(encoding="utf-8")
+    )
+
+
 _register_chat_template(
     name="kimi-k2.5-hf",
     cls=HFChatTemplate,
-    chat_template=(
-        resources.files("loongforge.data.chat_templates")
-        .joinpath("kimi_k2_5_training.jinja")
-        .read_text(encoding="utf-8")
-    ),
+    chat_template=_read_builtin_chat_template("kimi_k2_5_training.jinja"),
     mm_plugin=KimiK25Plugin(
         image_token="<|media_content|>",
         video_token="<|media_content|>",
         merge_kernel_size=(2, 2),
         temporal_merge_kernel_size=4,
     ),
+)
+
+
+_register_chat_template(
+    name="kimi-k2.6-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("kimi_k2_5_training.jinja"),
+    mm_plugin=KimiK25Plugin(
+        image_token="<|media_content|>",
+        video_token="<|media_content|>",
+        merge_kernel_size=(2, 2),
+        temporal_merge_kernel_size=4,
+    ),
+)
+
+
+_register_chat_template(
+    name="qwen1.5-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen_chat_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen2-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen_chat_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen2.5-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen2_5_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen3-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen3-coder-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_coder_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen3-next-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_next_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="qwen3.5-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_5_think_hf_training.jinja"),
+    mm_plugin=Qwen3VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="qwen3.5-think-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_5_think_hf_training.jinja"),
+    mm_plugin=Qwen3VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="qwen3.5-nothink-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_5_nothink_hf_training.jinja"),
+    mm_plugin=Qwen3VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="qwen3.6-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_6_hf_training.jinja"),
+    mm_plugin=Qwen3VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="qwen2.5-vl-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen2_5_vl_hf_training.jinja"),
+    mm_plugin=Qwen2VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="qwen3-vl-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen3_vl_hf_training.jinja"),
+    mm_plugin=Qwen3VLPlugin(image_token="<|image_pad|>", video_token="<|video_pad|>"),
+)
+
+_register_chat_template(
+    name="llava-onevision-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("qwen_chat_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="deepseek-v2-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("deepseek_v2_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="deepseek-v3-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("deepseek_v3_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="internlm2.5-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("internlm2_5_hf_training.jinja"),
+)
+
+_register_chat_template(
+    name="mimo-v2-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("mimo_v2_hf_training.jinja"),
 )
 
 

--- a/loongforge/data/chat_templates/deepseek_v2_hf_training.jinja
+++ b/loongforge/data/chat_templates/deepseek_v2_hf_training.jinja
@@ -1,0 +1,23 @@
+{# Adapted from deepseek-ai/DeepSeek-V2-Chat tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if not add_generation_prompt is defined -%}
+    {%- set add_generation_prompt = false -%}
+{%- endif -%}
+{{- bos_token -}}
+{%- for message in messages -%}
+    {%- if message["role"] == "user" -%}
+        {{- "User: " + message["content"] + "\n\n" -}}
+    {%- elif message["role"] == "assistant" -%}
+        {{- "Assistant:" -}}
+        {%- generation -%}
+            {{- " " + message["content"] + eos_token -}}
+        {%- endgeneration -%}
+    {%- elif message["role"] == "system" -%}
+        {{- message["content"] + "\n\n" -}}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "Assistant:" -}}
+{%- endif -%}

--- a/loongforge/data/chat_templates/deepseek_v3_hf_training.jinja
+++ b/loongforge/data/chat_templates/deepseek_v3_hf_training.jinja
@@ -1,0 +1,75 @@
+{# Adapted from deepseek-ai/DeepSeek-V3 tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if not add_generation_prompt is defined -%}
+    {%- set add_generation_prompt = false -%}
+{%- endif -%}
+{%- set ns = namespace(is_first=false, is_tool=false, is_output_first=true, system_prompt="", is_first_sp=true) -%}
+{%- for message in messages -%}
+    {%- if message["role"] == "system" -%}
+        {%- if ns.is_first_sp -%}
+            {%- set ns.system_prompt = ns.system_prompt + message["content"] -%}
+            {%- set ns.is_first_sp = false -%}
+        {%- else -%}
+            {%- set ns.system_prompt = ns.system_prompt + "\n\n" + message["content"] -%}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+{{- bos_token -}}
+{{- ns.system_prompt -}}
+{%- for message in messages -%}
+    {%- if message["role"] == "user" -%}
+        {%- set ns.is_tool = false -%}
+        {{- "<｜User｜>" + message["content"] -}}
+    {%- endif -%}
+    {%- if message["role"] == "assistant" and "tool_calls" in message -%}
+        {%- set ns.is_tool = false -%}
+        {%- generation -%}
+            {%- for tool in message["tool_calls"] -%}
+                {%- if not ns.is_first -%}
+                    {%- if message["content"] is none -%}
+                        {{- "<｜Assistant｜><｜tool▁calls▁begin｜><｜tool▁call▁begin｜>" + tool["type"] + "<｜tool▁sep｜>" + tool["function"]["name"] + "\n" + "```json" + "\n" + (tool["function"]["arguments"] | tojson) + "\n" + "```" + "<｜tool▁call▁end｜>" -}}
+                    {%- else -%}
+                        {{- "<｜Assistant｜>" + message["content"] + "<｜tool▁calls▁begin｜><｜tool▁call▁begin｜>" + tool["type"] + "<｜tool▁sep｜>" + tool["function"]["name"] + "\n" + "```json" + "\n" + (tool["function"]["arguments"] | tojson) + "\n" + "```" + "<｜tool▁call▁end｜>" -}}
+                    {%- endif -%}
+                    {%- set ns.is_first = true -%}
+                {%- else -%}
+                    {{- "\n" + "<｜tool▁call▁begin｜>" + tool["type"] + "<｜tool▁sep｜>" + tool["function"]["name"] + "\n" + "```json" + "\n" + (tool["function"]["arguments"] | tojson) + "\n" + "```" + "<｜tool▁call▁end｜>" -}}
+                {%- endif -%}
+            {%- endfor -%}
+            {{- "<｜tool▁calls▁end｜><｜end▁of▁sentence｜>" -}}
+        {%- endgeneration -%}
+    {%- endif -%}
+    {%- if message["role"] == "assistant" and "tool_calls" not in message -%}
+        {%- if ns.is_tool -%}
+            {%- generation -%}
+                {{- "<｜tool▁outputs▁end｜>" + message["content"] + "<｜end▁of▁sentence｜>" -}}
+            {%- endgeneration -%}
+            {%- set ns.is_tool = false -%}
+        {%- else -%}
+            {%- generation -%}
+                {%- set content = message["content"] -%}
+                {%- if "</think>" in content -%}
+                    {%- set content = content.split("</think>")[-1] -%}
+                {%- endif -%}
+                {{- "<｜Assistant｜>" + content + "<｜end▁of▁sentence｜>" -}}
+            {%- endgeneration -%}
+        {%- endif -%}
+    {%- endif -%}
+    {%- if message["role"] == "tool" -%}
+        {%- set ns.is_tool = true -%}
+        {%- if ns.is_output_first -%}
+            {{- "<｜tool▁outputs▁begin｜><｜tool▁output▁begin｜>" + message["content"] + "<｜tool▁output▁end｜>" -}}
+            {%- set ns.is_output_first = false -%}
+        {%- else -%}
+            {{- "\n<｜tool▁output▁begin｜>" + message["content"] + "<｜tool▁output▁end｜>" -}}
+        {%- endif -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- if ns.is_tool -%}
+    {{- "<｜tool▁outputs▁end｜>" -}}
+{%- endif -%}
+{%- if add_generation_prompt and not ns.is_tool -%}
+    {{- "<｜Assistant｜><think>\n" -}}
+{%- endif -%}

--- a/loongforge/data/chat_templates/internlm2_5_hf_training.jinja
+++ b/loongforge/data/chat_templates/internlm2_5_hf_training.jinja
@@ -1,0 +1,18 @@
+{# Adapted from internlm/internlm2_5-7b-chat tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{{- bos_token -}}
+{%- for message in messages -%}
+    {%- if message["role"] == "assistant" -%}
+        {{- "<|im_start|>" + message["role"] + "\n" -}}
+        {%- generation -%}
+            {{- message["content"] + "<|im_end|>" + "\n" -}}
+        {%- endgeneration -%}
+    {%- else -%}
+        {{- "<|im_start|>" + message["role"] + "\n" + message["content"] + "<|im_end|>" + "\n" -}}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/loongforge/data/chat_templates/mimo_v2_hf_training.jinja
+++ b/loongforge/data/chat_templates/mimo_v2_hf_training.jinja
@@ -1,0 +1,150 @@
+{# Adapted from XiaomiMiMo/MiMo-V2-Flash-Base?chat_template=default.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if not add_generation_prompt is defined -%}
+    {%- set add_generation_prompt = false -%}
+{%- endif -%}
+{%- if not enable_thinking is defined -%}
+    {%- set enable_thinking = false -%}
+{%- endif -%}
+{%- if not keep_all_reasoning is defined -%}
+    {%- set keep_all_reasoning = false -%}
+{%- endif -%}
+{%- macro render_extra_keys(json_dict, handled_keys) -%}
+    {%- if json_dict is mapping -%}
+        {%- for json_key in json_dict if json_key not in handled_keys -%}
+            {%- if json_dict[json_key] is mapping or json_dict[json_key] is sequence and json_dict[json_key] is not string -%}
+                {{- "\n<" ~ json_key ~ ">" ~ json_dict[json_key] | tojson | safe ~ "</" ~ json_key ~ ">" -}}
+            {%- else -%}
+                {{- "\n<" ~ json_key ~ ">" ~ json_dict[json_key] | string ~ "</" ~ json_key ~ ">" -}}
+            {%- endif -%}
+        {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{%- if messages[0]["role"] == "system" -%}
+    {%- set system_message = messages[0]["content"] -%}
+    {%- set loop_messages = messages[1:] -%}
+{%- else -%}
+    {%- set loop_messages = messages -%}
+{%- endif -%}
+{%- set ns = namespace(last_user_index=-1) -%}
+{%- for m in loop_messages -%}
+    {%- if m.role == "user" -%}
+        {%- set ns.last_user_index = loop.index0 -%}
+    {%- endif -%}
+{%- endfor -%}
+{%- if not tools is defined -%}
+    {%- set tools = [] -%}
+{%- endif -%}
+{%- if system_message is defined -%}
+    {{- "<|im_start|>system\n" + system_message -}}
+{%- else -%}
+    {{- "<|im_start|>system\nYou are MiMo, a helpful AI assistant engineered by Xiaomi." -}}
+{%- endif -%}
+{%- if tools is iterable and tools | length > 0 -%}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou have access to the following functions:\n\n" -}}
+    {{- "<tools>" -}}
+    {%- for tool in tools -%}
+        {%- if tool.function is defined -%}
+            {%- set tool = tool.function -%}
+        {%- endif -%}
+        {{- "\n<function>\n<name>" ~ tool.name ~ "</name>" -}}
+        {%- if tool.description is defined -%}
+            {{- "\n<description>" ~ tool.description | trim ~ "</description>" -}}
+        {%- endif -%}
+        {{- "\n<parameters>" -}}
+        {%- if tool.parameters is defined and tool.parameters is mapping and tool.parameters.properties is defined and tool.parameters.properties is mapping -%}
+            {%- for (param_name, param_fields) in tool.parameters.properties | items -%}
+                {{- "\n<parameter>" -}}
+                {{- "\n<name>" ~ param_name ~ "</name>" -}}
+                {%- if param_fields.type is defined -%}
+                    {{- "\n<type>" ~ param_fields.type | string ~ "</type>" -}}
+                {%- endif -%}
+                {%- if param_fields.description is defined -%}
+                    {{- "\n<description>" ~ param_fields.description | trim ~ "</description>" -}}
+                {%- endif -%}
+                {%- set handled_keys = ["name", "type", "description"] -%}
+                {{- render_extra_keys(param_fields, handled_keys) -}}
+                {{- "\n</parameter>" -}}
+            {%- endfor -%}
+        {%- endif -%}
+        {%- set handled_keys = ["type", "properties"] -%}
+        {{- render_extra_keys(tool.parameters, handled_keys) -}}
+        {{- "\n</parameters>" -}}
+        {%- set handled_keys = ["type", "name", "description", "parameters"] -%}
+        {{- render_extra_keys(tool, handled_keys) -}}
+        {{- "\n</function>" -}}
+    {%- endfor -%}
+    {{- "\n</tools>" -}}
+    {{- "\n\nFor each function call, output the function name and arguments in the following format:\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>value_1</parameter>\n<parameter=example_parameter_2>This is the value for the second parameter\nthat can span\nmultiple lines</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- DO NOT use function calls inside <think></think> tags.\n- The value enclosed between parameter tags is preserved exactly as-is, including newlines and spaces.\n</IMPORTANT>" -}}
+{%- endif -%}
+{{- "<|im_end|>" -}}
+{%- for message in loop_messages -%}
+    {%- if message.content is string -%}
+        {%- set content = message.content -%}
+    {%- else -%}
+        {%- set content = "" -%}
+    {%- endif -%}
+    {%- if message.role == "assistant" -%}
+        {%- if message.reasoning_content is string -%}
+            {%- set reasoning_content = message.reasoning_content -%}
+        {%- else -%}
+            {%- set reasoning_content = "" -%}
+            {%- if "</think>" in content -%}
+                {%- set reasoning_content = content.split("</think>")[0].split("<think>")[-1] -%}
+                {%- set content = content.split("</think>")[-1] -%}
+            {%- endif -%}
+        {%- endif -%}
+        {{- "<|im_start|>" + message.role + "\n" -}}
+        {%- generation -%}
+            {%- if (keep_all_reasoning or loop.index0 > ns.last_user_index) and reasoning_content -%}
+                {{- "<think>" + reasoning_content + "</think>" + content -}}
+            {%- else -%}
+                {{- "<think></think>" + content -}}
+            {%- endif -%}
+            {%- if message.tool_calls is defined and message.tool_calls is iterable and message.tool_calls | length > 0 -%}
+                {%- for tool_call in message.tool_calls -%}
+                    {%- if tool_call.function is defined -%}
+                        {%- set tool_call = tool_call.function -%}
+                    {%- endif -%}
+                    {{- "<tool_call>\n<function=" + tool_call.name + ">\n" -}}
+                    {%- if tool_call.arguments is defined -%}
+                        {%- for (args_name, args_value) in tool_call.arguments | items -%}
+                            {{- "<parameter=" + args_name + ">" -}}
+                            {%- set args_value = args_value | tojson | safe if args_value is mapping or args_value is sequence and args_value is not string else args_value | string -%}
+                            {{- args_value -}}
+                            {{- "</parameter>\n" -}}
+                        {%- endfor -%}
+                    {%- endif -%}
+                    {{- "</function>\n</tool_call>" -}}
+                {%- endfor -%}
+            {%- endif -%}
+            {{- "<|im_end|>" -}}
+        {%- endgeneration -%}
+    {%- elif message.role == "user" or message.role == "system" -%}
+        {{- "<|im_start|>" + message.role + "\n" + message.content + "<|im_end|>" -}}
+    {%- elif message.role == "tool" -%}
+        {%- if loop.previtem and loop.previtem.role != "tool" -%}
+            {{- "<|im_start|>tool\n" -}}
+        {%- endif -%}
+        {{- "<tool_response>\n" -}}
+        {{- message.content -}}
+        {{- "\n</tool_response>\n" -}}
+        {%- if not loop.last and loop.nextitem.role != "tool" -%}
+            {{- "<|im_end|>" -}}
+        {%- elif loop.last -%}
+            {{- "<|im_end|>" -}}
+        {%- endif -%}
+    {%- else -%}
+        {{- "<|im_start|>" + message.role + "\n" + message.content + "<|im_end|>" -}}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+    {%- if not enable_thinking -%}
+        {{- "<think></think>" -}}
+    {%- else -%}
+        {{- "" -}}
+    {%- endif -%}
+{%- endif -%}

--- a/loongforge/data/chat_templates/qwen2_5_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen2_5_hf_training.jinja
@@ -1,0 +1,64 @@
+{# Adapted from Qwen/Qwen2.5-7B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- messages[0]['content'] }}
+    {%- else %}
+        {{- 'You are Qwen, created by Alibaba Cloud. You are a helpful assistant.' }}
+    {%- endif %}
+    {{- "\n\n# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0]['role'] == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0]['content'] + '<|im_end|>\n' }}
+    {%- else %}
+        {{- '<|im_start|>system\nYou are Qwen, created by Alibaba Cloud. You are a helpful assistant.<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>assistant' }}
+        {%- generation %}
+        {%- if not message.tool_calls %}
+            {{- '\n' + message.content + '<|im_end|>\n' }}
+        {%- else %}
+            {%- if message.content %}
+                {{- '\n' + message.content }}
+            {%- endif %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '\n<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {{- tool_call.arguments | tojson }}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if (loop.index0 == 0) or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen2_5_vl_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen2_5_vl_hf_training.jinja
@@ -1,0 +1,74 @@
+{# Adapted from Qwen/Qwen2.5-VL-7B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- set image_count = namespace(value=0) -%}
+{%- set video_count = namespace(value=0) -%}
+{%- for message in messages -%}
+    {%- if loop.first and message["role"] != "system" -%}
+        {{- "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" -}}
+    {%- endif -%}
+    {{- "<|im_start|>" -}}
+    {{- message["role"] -}}
+    {{- "\n" -}}
+    {%- if message["role"] == "assistant" -%}
+        {%- generation -%}
+            {%- if message["content"] is string -%}
+                {{- message["content"] -}}
+                {{- "<|im_end|>\n" -}}
+            {%- else -%}
+                {%- for content in message["content"] -%}
+                    {%- if content["type"] == "image" or "image" in content or "image_url" in content -%}
+                        {%- set image_count.value = image_count.value + 1 -%}
+                        {%- if add_vision_id -%}
+                            {{- "Picture " -}}
+                            {{- image_count.value -}}
+                            {{- ": " -}}
+                        {%- endif -%}
+                        {{- "<|vision_start|><|image_pad|><|vision_end|>" -}}
+                    {%- elif content["type"] == "video" or "video" in content -%}
+                        {%- set video_count.value = video_count.value + 1 -%}
+                        {%- if add_vision_id -%}
+                            {{- "Video " -}}
+                            {{- video_count.value -}}
+                            {{- ": " -}}
+                        {%- endif -%}
+                        {{- "<|vision_start|><|video_pad|><|vision_end|>" -}}
+                    {%- elif "text" in content -%}
+                        {{- content["text"] -}}
+                    {%- endif -%}
+                {%- endfor -%}
+                {{- "<|im_end|>\n" -}}
+            {%- endif -%}
+        {%- endgeneration -%}
+    {%- elif message["content"] is string -%}
+        {{- message["content"] -}}
+        {{- "<|im_end|>\n" -}}
+    {%- else -%}
+        {%- for content in message["content"] -%}
+            {%- if content["type"] == "image" or "image" in content or "image_url" in content -%}
+                {%- set image_count.value = image_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{- "Picture " -}}
+                    {{- image_count.value -}}
+                    {{- ": " -}}
+                {%- endif -%}
+                {{- "<|vision_start|><|image_pad|><|vision_end|>" -}}
+            {%- elif content["type"] == "video" or "video" in content -%}
+                {%- set video_count.value = video_count.value + 1 -%}
+                {%- if add_vision_id -%}
+                    {{- "Video " -}}
+                    {{- video_count.value -}}
+                    {{- ": " -}}
+                {%- endif -%}
+                {{- "<|vision_start|><|video_pad|><|vision_end|>" -}}
+            {%- elif "text" in content -%}
+                {{- content["text"] -}}
+            {%- endif -%}
+        {%- endfor -%}
+        {{- "<|im_end|>\n" -}}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/loongforge/data/chat_templates/qwen3_5_nothink_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_5_nothink_hf_training.jinja
@@ -1,0 +1,157 @@
+{# Adapted from Hugging Face TRL qwen3_5_nothink_training.jinja.
+   LoongForge keeps the training variant prefix-preserving by always rendering
+   the assistant thinking block inside assistant generation spans. -#}
+
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '<think>' in content and '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- '<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is true %}
+        {{- '<think>\n' }}
+    {%- else %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_5_think_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_5_think_hf_training.jinja
@@ -1,0 +1,157 @@
+{# Adapted from Hugging Face TRL qwen3_5_think_training.jinja.
+   LoongForge keeps the training variant prefix-preserving by always rendering
+   the assistant thinking block inside assistant generation spans. -#}
+
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '<think>' in content and '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- '<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_6_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_6_hf_training.jinja
@@ -1,0 +1,157 @@
+{# Adapted from Qwen/Qwen3.6-27B tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- macro render_content(content, do_vision_count, is_system_content=false) %}
+    {%- if content is string %}
+        {{- content }}
+    {%- elif content is iterable and content is not mapping %}
+        {%- for item in content %}
+            {%- if 'image' in item or 'image_url' in item or item.type == 'image' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain images.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Picture ' ~ image_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|image_pad|><|vision_end|>' }}
+            {%- elif 'video' in item or item.type == 'video' %}
+                {%- if is_system_content %}
+                    {{- raise_exception('System message cannot contain videos.') }}
+                {%- endif %}
+                {%- if do_vision_count %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                {%- endif %}
+                {%- if add_vision_id %}
+                    {{- 'Video ' ~ video_count.value ~ ': ' }}
+                {%- endif %}
+                {{- '<|vision_start|><|video_pad|><|vision_end|>' }}
+            {%- elif 'text' in item %}
+                {{- item.text }}
+            {%- else %}
+                {{- raise_exception('Unexpected item type in content.') }}
+            {%- endif %}
+        {%- endfor %}
+    {%- elif content is none or content is undefined %}
+        {{- '' }}
+    {%- else %}
+        {{- raise_exception('Unexpected content type.') }}
+    {%- endif %}
+{%- endmacro %}
+{%- if not messages %}
+    {{- raise_exception('No messages provided.') }}
+{%- endif %}
+{%- if tools and tools is iterable and tools is not mapping %}
+    {{- '<|im_start|>system\n' }}
+    {{- "# Tools\n\nYou have access to the following functions:\n\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {%- if content %}
+            {{- '\n\n' + content }}
+        {%- endif %}
+    {%- endif %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {%- set content = render_content(messages[0].content, false, true)|trim %}
+        {{- '<|im_start|>system\n' + content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" %}
+        {%- set content = render_content(message.content, false)|trim %}
+        {%- if not(content.startswith('<tool_response>') and content.endswith('</tool_response>')) %}
+            {%- set ns.multi_step_tool = false %}
+            {%- set ns.last_query_index = index %}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if ns.multi_step_tool %}
+    {{- raise_exception('No user query found in messages.') }}
+{%- endif %}
+{%- for message in messages %}
+    {%- set content = render_content(message.content, true)|trim %}
+    {%- if message.role == "system" %}
+        {%- if not loop.first %}
+            {{- raise_exception('System message must be at the beginning.') }}
+        {%- endif %}
+    {%- elif message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '<think>' in content and '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {%- set reasoning_content = reasoning_content|trim %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- '<think>\n' + reasoning_content + '\n</think>\n\n' + content }}
+        {%- if message.tool_calls and message.tool_calls is iterable and message.tool_calls is not mapping %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if tool_call.function is defined %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {%- if loop.first %}
+                    {%- if content|trim %}
+                        {{- '\n\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- else %}
+                        {{- '<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                    {%- endif %}
+                {%- else %}
+                    {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+                {%- endif %}
+                {%- if tool_call.arguments is defined %}
+                    {%- for args_name, args_value in tool_call.arguments|items %}
+                        {{- '<parameter=' + args_name + '>\n' }}
+                        {%- set args_value = args_value | string if args_value is string else args_value | tojson | safe %}
+                        {{- args_value }}
+                        {{- '\n</parameter>\n' }}
+                    {%- endfor %}
+                {%- endif %}
+                {{- '</function>\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- raise_exception('Unexpected message role.') }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- else %}
+        {{- '<think>\n' }}
+    {%- endif %}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_coder_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_coder_hf_training.jinja
@@ -1,0 +1,128 @@
+{# Adapted from Qwen/Qwen3-Coder-30B-A3B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{% macro render_extra_keys(json_dict, handled_keys) %}
+    {%- if json_dict is mapping %}
+        {%- for json_key in json_dict if json_key not in handled_keys %}
+            {%- if json_dict[json_key] is mapping or (json_dict[json_key] is sequence and json_dict[json_key] is not string) %}
+                {{- '\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | tojson | safe) ~ '</' ~ json_key ~ '>' }}
+            {%- else %}
+                {{-'\n<' ~ json_key ~ '>' ~ (json_dict[json_key] | string) ~ '</' ~ json_key ~ '>' }}
+            {%- endif %}
+        {%- endfor %}
+    {%- endif %}
+{% endmacro %}
+
+{%- if messages[0]["role"] == "system" %}
+    {%- set system_message = messages[0]["content"] %}
+    {%- set loop_messages = messages[1:] %}
+{%- else %}
+    {%- set loop_messages = messages %}
+{%- endif %}
+
+{%- if not tools is defined %}
+    {%- set tools = [] %}
+{%- endif %}
+
+{%- if system_message is defined %}
+    {{- "<|im_start|>system\n" + system_message }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- "<|im_start|>system\nYou are Qwen, a helpful AI assistant that can interact with a computer to solve tasks." }}
+    {%- endif %}
+{%- endif %}
+{%- if tools is iterable and tools | length > 0 %}
+    {{- "\n\n# Tools\n\nYou have access to the following functions:\n\n" }}
+    {{- "<tools>" }}
+    {%- for tool in tools %}
+        {%- if tool.function is defined %}
+            {%- set tool = tool.function %}
+        {%- endif %}
+        {{- "\n<function>\n<name>" ~ tool.name ~ "</name>" }}
+        {%- if tool.description is defined %}
+            {{- '\n<description>' ~ (tool.description | trim) ~ '</description>' }}
+        {%- endif %}
+        {{- '\n<parameters>' }}
+        {%- if tool.parameters is defined and tool.parameters is mapping and tool.parameters.properties is defined and tool.parameters.properties is mapping %}
+            {%- for param_name, param_fields in tool.parameters.properties|items %}
+                {{- '\n<parameter>' }}
+                {{- '\n<name>' ~ param_name ~ '</name>' }}
+                {%- if param_fields.type is defined %}
+                    {{- '\n<type>' ~ (param_fields.type | string) ~ '</type>' }}
+                {%- endif %}
+                {%- if param_fields.description is defined %}
+                    {{- '\n<description>' ~ (param_fields.description | trim) ~ '</description>' }}
+                {%- endif %}
+                {%- set handled_keys = ['name', 'type', 'description'] %}
+                {{- render_extra_keys(param_fields, handled_keys) }}
+                {{- '\n</parameter>' }}
+            {%- endfor %}
+        {%- endif %}
+        {% set handled_keys = ['type', 'properties'] %}
+        {{- render_extra_keys(tool.parameters, handled_keys) }}
+        {{- '\n</parameters>' }}
+        {%- set handled_keys = ['type', 'name', 'description', 'parameters'] %}
+        {{- render_extra_keys(tool, handled_keys) }}
+        {{- '\n</function>' }}
+    {%- endfor %}
+    {{- "\n</tools>" }}
+    {{- '\n\nIf you choose to call a function ONLY reply in the following format with NO suffix:\n\n<tool_call>\n<function=example_function_name>\n<parameter=example_parameter_1>\nvalue_1\n</parameter>\n<parameter=example_parameter_2>\nThis is the value for the second parameter\nthat can span\nmultiple lines\n</parameter>\n</function>\n</tool_call>\n\n<IMPORTANT>\nReminder:\n- Function calls MUST follow the specified format: an inner <function=...></function> block must be nested within <tool_call></tool_call> XML tags\n- Required parameters MUST be specified\n- You may provide optional reasoning for your function call in natural language BEFORE the function call, but NOT after\n- If there is no function call available, answer the question like normal with your current knowledge and do not tell the user about function calls\n</IMPORTANT>' }}
+{%- endif %}
+{%- if system_message is defined %}
+    {{- '<|im_end|>\n' }}
+{%- else %}
+    {%- if tools is iterable and tools | length > 0 %}
+        {{- '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in loop_messages %}
+    {%- if message.role == "assistant" and message.tool_calls is defined and message.tool_calls is iterable and message.tool_calls | length > 0 %}
+        {{- '<|im_start|>' + message.role }}
+        {%- generation %}
+        {%- if message.content is defined and message.content is string and message.content | trim | length > 0 %}
+            {{- '\n' + message.content | trim + '\n' }}
+        {%- endif %}
+        {%- for tool_call in message.tool_calls %}
+            {%- if tool_call.function is defined %}
+                {%- set tool_call = tool_call.function %}
+            {%- endif %}
+            {{- '\n<tool_call>\n<function=' + tool_call.name + '>\n' }}
+            {%- if tool_call.arguments is defined %}
+                {%- for args_name, args_value in tool_call.arguments|items %}
+                    {{- '<parameter=' + args_name + '>\n' }}
+                    {%- set args_value = args_value | tojson | safe if args_value is mapping or (args_value is sequence and args_value is not string) else args_value | string %}
+                    {{- args_value }}
+                    {{- '\n</parameter>\n' }}
+                {%- endfor %}
+            {%- endif %}
+            {{- '</function>\n</tool_call>' }}
+        {%- endfor %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "user" or message.role == "system" %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- message.content + '<|im_end|>' + '\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.previtem and loop.previtem.role != "tool" %}
+            {{- '<|im_start|>user\n' }}
+        {%- endif %}
+        {{- '<tool_response>\n' }}
+        {{- message.content }}
+        {{- '\n</tool_response>\n' }}
+        {%- if not loop.last and loop.nextitem.role != "tool" %}
+            {{- '<|im_end|>\n' }}
+        {%- elif loop.last %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- else %}
+        {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_hf_training.jinja
@@ -1,0 +1,88 @@
+{# Adapted from Qwen/Qwen3-8B and Qwen/Qwen3-30B-A3B tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set ns = namespace(multi_step_tool=true, last_query_index=messages|length - 1) %}
+{%- for message in messages[::-1] %}
+    {%- set index = (messages|length - 1) - loop.index0 %}
+    {%- if ns.multi_step_tool and message.role == "user" and message.content is string and not(message.content.startswith('<tool_response>') and message.content.endswith('</tool_response>')) %}
+        {%- set ns.multi_step_tool = false %}
+        {%- set ns.last_query_index = index %}
+    {%- endif %}
+{%- endfor %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {%- set reasoning_content = '' %}
+        {%- if message.reasoning_content is string %}
+            {%- set reasoning_content = message.reasoning_content %}
+        {%- else %}
+            {%- if '<think>' in content and '</think>' in content %}
+                {%- set reasoning_content = content.split('</think>')[0].rstrip('\n').split('<think>')[-1].lstrip('\n') %}
+                {%- set content = content.split('</think>')[-1].lstrip('\n') %}
+            {%- endif %}
+        {%- endif %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- '<think>\n' + reasoning_content.strip('\n') + '\n</think>\n\n' + content.lstrip('\n') }}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+    {%- if enable_thinking is defined and enable_thinking is false %}
+        {{- '<think>\n\n</think>\n\n' }}
+    {%- endif %}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_next_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_next_hf_training.jinja
@@ -1,0 +1,68 @@
+{# Adapted from Qwen/Qwen3-Next-80B-A3B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {{- messages[0].content + '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' + messages[0].content + '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- for message in messages %}
+    {%- if message.content is string %}
+        {%- set content = message.content %}
+    {%- else %}
+        {%- set content = '' %}
+    {%- endif %}
+    {%- if (message.role == "user") or (message.role == "system" and not loop.first) %}
+        {{- '<|im_start|>' + message.role + '\n' + content + '<|im_end|>' + '\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {{- content }}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {{- content }}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen3_vl_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen3_vl_hf_training.jinja
@@ -1,0 +1,126 @@
+{# Adapted from Qwen/Qwen3-VL-30B-A3B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- if tools %}
+    {{- '<|im_start|>system\n' }}
+    {%- if messages[0].role == 'system' %}
+        {%- if messages[0].content is string %}
+            {{- messages[0].content }}
+        {%- else %}
+            {%- for content in messages[0].content %}
+                {%- if 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '\n\n' }}
+    {%- endif %}
+    {{- "# Tools\n\nYou may call one or more functions to assist with the user query.\n\nYou are provided with function signatures within <tools></tools> XML tags:\n<tools>" }}
+    {%- for tool in tools %}
+        {{- "\n" }}
+        {{- tool | tojson }}
+    {%- endfor %}
+    {{- "\n</tools>\n\nFor each function call, return a json object with function name and arguments within <tool_call></tool_call> XML tags:\n<tool_call>\n{\"name\": <function-name>, \"arguments\": <args-json-object>}\n</tool_call><|im_end|>\n" }}
+{%- else %}
+    {%- if messages[0].role == 'system' %}
+        {{- '<|im_start|>system\n' }}
+        {%- if messages[0].content is string %}
+            {{- messages[0].content }}
+        {%- else %}
+            {%- for content in messages[0].content %}
+                {%- if 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- endif %}
+{%- endif %}
+{%- set image_count = namespace(value=0) %}
+{%- set video_count = namespace(value=0) %}
+{%- for message in messages %}
+    {%- if message.role == "user" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- if message.content is string %}
+            {{- message.content }}
+        {%- else %}
+            {%- for content in message.content %}
+                {%- if content.type == 'image' or 'image' in content or 'image_url' in content %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                    {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                    <|vision_start|><|image_pad|><|vision_end|>
+                {%- elif content.type == 'video' or 'video' in content %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                    {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                    <|vision_start|><|video_pad|><|vision_end|>
+                {%- elif 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+    {%- elif message.role == "assistant" %}
+        {{- '<|im_start|>' + message.role + '\n' }}
+        {%- generation %}
+        {%- if message.content is string %}
+            {{- message.content }}
+        {%- else %}
+            {%- for content_item in message.content %}
+                {%- if 'text' in content_item %}
+                    {{- content_item.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {%- if message.tool_calls %}
+            {%- for tool_call in message.tool_calls %}
+                {%- if (loop.first and message.content) or (not loop.first) %}
+                    {{- '\n' }}
+                {%- endif %}
+                {%- if tool_call.function %}
+                    {%- set tool_call = tool_call.function %}
+                {%- endif %}
+                {{- '<tool_call>\n{"name": "' }}
+                {{- tool_call.name }}
+                {{- '", "arguments": ' }}
+                {%- if tool_call.arguments is string %}
+                    {{- tool_call.arguments }}
+                {%- else %}
+                    {{- tool_call.arguments | tojson }}
+                {%- endif %}
+                {{- '}\n</tool_call>' }}
+            {%- endfor %}
+        {%- endif %}
+        {{- '<|im_end|>\n' }}
+        {%- endgeneration %}
+    {%- elif message.role == "tool" %}
+        {%- if loop.first or (messages[loop.index0 - 1].role != "tool") %}
+            {{- '<|im_start|>user' }}
+        {%- endif %}
+        {{- '\n<tool_response>\n' }}
+        {%- if message.content is string %}
+            {{- message.content }}
+        {%- else %}
+            {%- for content in message.content %}
+                {%- if content.type == 'image' or 'image' in content or 'image_url' in content %}
+                    {%- set image_count.value = image_count.value + 1 %}
+                    {%- if add_vision_id %}Picture {{ image_count.value }}: {% endif -%}
+                    <|vision_start|><|image_pad|><|vision_end|>
+                {%- elif content.type == 'video' or 'video' in content %}
+                    {%- set video_count.value = video_count.value + 1 %}
+                    {%- if add_vision_id %}Video {{ video_count.value }}: {% endif -%}
+                    <|vision_start|><|video_pad|><|vision_end|>
+                {%- elif 'text' in content %}
+                    {{- content.text }}
+                {%- endif %}
+            {%- endfor %}
+        {%- endif %}
+        {{- '\n</tool_response>' }}
+        {%- if loop.last or (messages[loop.index0 + 1].role != "tool") %}
+            {{- '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endif %}
+{%- endfor %}
+{%- if add_generation_prompt %}
+    {{- '<|im_start|>assistant\n' }}
+{%- endif %}

--- a/loongforge/data/chat_templates/qwen_chat_hf_training.jinja
+++ b/loongforge/data/chat_templates/qwen_chat_hf_training.jinja
@@ -1,0 +1,20 @@
+{# Adapted from Qwen/Qwen1.5-7B-Chat and Qwen/Qwen2-7B-Instruct tokenizer_config.json.
+   LoongForge adds Hugging Face generation blocks around assistant answer spans
+   so OpenAI-style SFT can build assistant-only loss masks. -#}
+
+{%- for message in messages -%}
+    {%- if loop.first and messages[0]["role"] != "system" -%}
+        {{- "<|im_start|>system\nYou are a helpful assistant.<|im_end|>\n" -}}
+    {%- endif -%}
+    {%- if message["role"] == "assistant" -%}
+        {{- "<|im_start|>" + message["role"] + "\n" -}}
+        {%- generation -%}
+            {{- message["content"] + "<|im_end|>" + "\n" -}}
+        {%- endgeneration -%}
+    {%- else -%}
+        {{- "<|im_start|>" + message["role"] + "\n" + message["content"] + "<|im_end|>" + "\n" -}}
+    {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+    {{- "<|im_start|>assistant\n" -}}
+{%- endif -%}

--- a/loongforge/data/sft_dataset.py
+++ b/loongforge/data/sft_dataset.py
@@ -405,7 +405,7 @@ class SFTDataset(HuggingFaceDataset):
                 )
                 sft_format.tags.function_tag = _desc_tags.get("function_tag", None)
                 sft_format.tags.system_tag = _desc_tags.get("system_tag", None)
-        elif sft_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+        elif sft_format.format == SFTDataFormats.OPENAI:
             sft_format.columns = OpenAIChatColumns()
             if _desc_columns is not None:
                 sft_format.columns.messages = _desc_columns.get("messages", "messages")

--- a/loongforge/data/sft_format_utils.py
+++ b/loongforge/data/sft_format_utils.py
@@ -267,7 +267,7 @@ def _normalize_openai_chat_message(
     return normalized
 
 
-def _convert_openai_chat_completions(
+def _convert_openai(
     samples: Dict[str, Any],
     openai_columns: "OpenAIChatColumns",
     dataset_dir: str,
@@ -347,9 +347,9 @@ def convert_to_unified_format(
             sharegpt_tags=data_format.tags,
             dataset_dir=os.path.dirname(dataset_path),
         )
-    elif data_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+    elif data_format.format == SFTDataFormats.OPENAI:
         convert_func = partial(
-            _convert_openai_chat_completions,
+            _convert_openai,
             openai_columns=data_format.columns,
             dataset_dir=os.path.dirname(dataset_path),
         )
@@ -360,7 +360,7 @@ def convert_to_unified_format(
         col for col in next(iter(dataset)).keys() if col not in ["images", "videos"]
     ]
 
-    if data_format.format == SFTDataFormats.OPENAI_CHAT_COMPLETIONS:
+    if data_format.format == SFTDataFormats.OPENAI:
         features = Features(
             {
                 "messages": Value(dtype="string"),

--- a/loongforge/data/sft_supervised_utils.py
+++ b/loongforge/data/sft_supervised_utils.py
@@ -344,7 +344,7 @@ def _preprocess_supervised_dataset(
             raise ValueError(
                 "HFChatTemplate requires OpenAI Chat Completions-style "
                 "`messages` samples. Use dataset format "
-                "`openai_chat_completions` with a registered `*-hf` chat template."
+                "`openai` with a registered `*-hf` chat template."
             )
         sample_count = len(samples["messages"])
     else:

--- a/loongforge/train/arguments.py
+++ b/loongforge/train/arguments.py
@@ -428,6 +428,16 @@ def _add_extra_sft_args(parser: argparse.ArgumentParser):
     )
 
     group.add_argument(
+        "--chat-template-kwargs",
+        type=str,
+        default=None,
+        help="Optional JSON object or path to a JSON file containing extra kwargs "
+             "for Hugging Face chat templates. Only valid with registered "
+             "`*-hf` chat templates. Example: '{\"enable_thinking\": false}'. "
+             "Default: None"
+    )
+
+    group.add_argument(
         "--sft-dataset-config",
         type=str,
         default=None,

--- a/loongforge/utils/constants.py
+++ b/loongforge/utils/constants.py
@@ -27,7 +27,7 @@ class SFTDataFormats(object):
 
     ALPACA = "alpaca"
     SHAREGPT = "sharegpt"
-    OPENAI_CHAT_COMPLETIONS = "openai_chat_completions"
+    OPENAI = "openai"
 
 
 class DataRoles(object):

--- a/loongforge/utils/global_vars.py
+++ b/loongforge/utils/global_vars.py
@@ -12,7 +12,11 @@ from megatron.training.global_vars import (
 )
 
 from loongforge.tokenizer import build_tokenizer
-from loongforge.data import ChatTemplate
+from loongforge.data import (
+    ChatTemplate,
+    HFChatTemplate,
+    load_chat_template_kwargs,
+)
 
 from .constants import TrainingPhase
 
@@ -94,6 +98,15 @@ def _build_chat_template(args) -> Optional["ChatTemplate"]:
         assert (
             _GLOBAL_CHAT_TEMPLATE is not None
         ), f"chat_template {args.chat_template} not supported."
+        raw_kwargs = getattr(args, "chat_template_kwargs", None)
+        if raw_kwargs is not None:
+            if not isinstance(_GLOBAL_CHAT_TEMPLATE, HFChatTemplate):
+                raise ValueError(
+                    "--chat-template-kwargs is only supported with HF chat templates"
+                )
+            _GLOBAL_CHAT_TEMPLATE.chat_template_kwargs = load_chat_template_kwargs(
+                raw_kwargs
+            )
         return _GLOBAL_CHAT_TEMPLATE
 
     return None

--- a/tools/data_preprocess/llm/preprocess_sft_data.py
+++ b/tools/data_preprocess/llm/preprocess_sft_data.py
@@ -4,8 +4,6 @@
 """preprocess sft data"""
 
 import argparse
-import json
-from pathlib import Path
 
 from transformers import AutoProcessor
 from datasets import DatasetDict
@@ -17,6 +15,7 @@ from loongforge.data import (
     ChatTemplate,
     HFChatTemplate,
     get_support_templates,
+    load_chat_template_kwargs,
 )
 from loongforge.tokenizer import build_tokenizer
 from loongforge.utils import constants
@@ -201,14 +200,9 @@ def parse_args():
             raise ValueError(
                 "--chat-template-kwargs is only supported with HF chat templates"
             )
-        raw_kwargs = args.chat_template_kwargs
-        if not raw_kwargs.lstrip().startswith("{"):
-            kwargs_path = Path(raw_kwargs)
-            if kwargs_path.is_file():
-                raw_kwargs = kwargs_path.read_text(encoding="utf-8")
-        template.chat_template_kwargs = json.loads(raw_kwargs)
-        if not isinstance(template.chat_template_kwargs, dict):
-            raise ValueError("--chat-template-kwargs must be a JSON object")
+        template.chat_template_kwargs = load_chat_template_kwargs(
+            args.chat_template_kwargs
+        )
     args.template = template
  
     args.variable_seq_lengths = True


### PR DESCRIPTION
## Summary

Add built-in HF/Jinja chat templates for common LLM/VLM families and wire template kwargs through SFT training and offline preprocessing.

## Changes

- add HF training Jinja templates for Qwen, Qwen-VL, DeepSeek, InternLM, MiMo, and related model families
- register `*-hf` chat template names that load packaged Jinja templates via `HFChatTemplate`
- add `--chat-template-kwargs` support for SFT training and `tools/data_preprocess/llm/preprocess_sft_data.py`
- simplify OpenAI-style SFT dataset naming from `openai_chat_completions` to `openai`

## Usage

- Use `--chat-template <model>-hf` to select a built-in HF/Jinja template, for example `qwen3-hf`, `qwen2.5-vl-hf`, `deepseek-v3-hf`, `internlm2.5-hf`, or `mimo-v2-hf`.
- Pass optional template kwargs with `--chat-template-kwargs` as a JSON object or a path to a JSON file, for example `--chat-template-kwargs '{"enable_thinking": false}'`.
- Use the `openai` dataset format for OpenAI Chat Completions-style SFT data with `messages` and optional `tools` columns.

Example dataset config section:

```yaml
openai:
  format: openai
  columns:
    messages: messages
    tools: tools
```

## Validation

- `git diff --check github/master...HEAD`
- `python -m py_compile $(git diff --name-only github/master...HEAD -- '*.py')`
