### PR TITLE
[data] feat: support assistant turn loss mask

### DIFF
--- a/loongforge/data/chat_template.py
+++ b/loongforge/data/chat_template.py
@@ -563,12 +563,62 @@ class HFChatTemplate(ChatTemplate):
             "or place `{% generation %}` boundaries exactly on tokenizer boundaries."
         )
 
+    @staticmethod
+    def _message_loss_mask_to_bool(value: Any) -> bool:
+        """Parse a per-message loss_mask value."""
+        if isinstance(value, bool):
+            return value
+        if isinstance(value, int) and value in (0, 1):
+            return bool(value)
+        if isinstance(value, str):
+            normalized = value.strip().lower()
+            if normalized in ("1", "true", "yes"):
+                return True
+            if normalized in ("0", "false", "no"):
+                return False
+
+        raise ValueError(
+            "message loss_mask must be one of 0/1, true/false, or yes/no; "
+            f"got {value!r}"
+        )
+
+    @classmethod
+    def _assistant_loss_flags_from_messages(
+        cls,
+        messages: Sequence[Dict[str, Any]],
+    ) -> Tuple[List[bool], bool]:
+        """Return assistant turn loss flags and whether any flag was explicit."""
+        assistant_loss_flags: List[bool] = []
+        has_explicit_loss_mask = False
+
+        for message_index, message in enumerate(messages):
+            role = message.get("role")
+            has_loss_mask = "loss_mask" in message
+            if has_loss_mask:
+                has_explicit_loss_mask = True
+                if role != DataRoles.ASSISTANT:
+                    raise ValueError(
+                        "message-level loss_mask is currently supported only for "
+                        f"assistant messages; got role {role!r} at message "
+                        f"index {message_index}"
+                    )
+
+            if role == DataRoles.ASSISTANT:
+                if has_loss_mask:
+                    assistant_loss_flags.append(
+                        cls._message_loss_mask_to_bool(message["loss_mask"])
+                    )
+                else:
+                    assistant_loss_flags.append(True)
+
+        return assistant_loss_flags, has_explicit_loss_mask
+
     def _tokenize_with_generation_indices(
         self,
         tokenizer: "AutoTokenizerFromHF",
         messages: Sequence[Dict[str, Any]],
         tools: Optional[Sequence[Dict[str, Any]]] = None,
-    ) -> Tuple[List[int], List[int]]:
+    ) -> Tuple[List[int], List[int], bool]:
         """Render OpenAI chat messages and build assistant-token masks."""
         hf_tokenizer = tokenizer.hf_tokenizer()
         rendered, generation_ranges = self._render_with_generation_indices(
@@ -576,6 +626,23 @@ class HFChatTemplate(ChatTemplate):
             messages=messages,
             tools=tools,
         )
+        assistant_loss_flags, has_explicit_loss_mask = (
+            self._assistant_loss_flags_from_messages(messages)
+        )
+        if has_explicit_loss_mask:
+            if len(assistant_loss_flags) != len(generation_ranges):
+                raise ValueError(
+                    "assistant loss_mask count does not match HuggingFace "
+                    "generation ranges: "
+                    f"{len(assistant_loss_flags)} assistant messages vs "
+                    f"{len(generation_ranges)} generation ranges"
+                )
+            generation_ranges = [
+                span
+                for span, keep_loss in zip(generation_ranges, assistant_loss_flags)
+                if keep_loss
+            ]
+
         input_ids = self._encode_text(hf_tokenizer, rendered)
         assistant_masks = self._assistant_mask_from_generation_ranges(
             hf_tokenizer=hf_tokenizer,
@@ -583,7 +650,7 @@ class HFChatTemplate(ChatTemplate):
             input_ids=input_ids,
             generation_ranges=generation_ranges,
         )
-        return input_ids, assistant_masks
+        return input_ids, assistant_masks, has_explicit_loss_mask
 
     @staticmethod
     def _mask_to_final_span(mask: List[int]) -> List[int]:
@@ -673,12 +740,23 @@ class HFChatTemplate(ChatTemplate):
         max_length: Optional[int] = None,
     ) -> Tuple[List[int], List[int], List[int], int]:
         """Encode OpenAI-style chat data into input ids, labels, and loss mask."""
-        input_ids, assistant_masks = self._tokenize_with_generation_indices(
-            tokenizer=tokenizer,
-            messages=messages,
-            tools=tools,
+        input_ids, assistant_masks, has_explicit_loss_mask = (
+            self._tokenize_with_generation_indices(
+                tokenizer=tokenizer,
+                messages=messages,
+                tools=tools,
+            )
         )
         ori_total_len = len(input_ids)
+        if has_explicit_loss_mask and train_on_prompt:
+            raise ValueError(
+                "message-level loss_mask conflicts with train_on_prompt=True"
+            )
+        if has_explicit_loss_mask and history_mask_loss:
+            raise ValueError(
+                "message-level loss_mask conflicts with history_mask_loss=True"
+            )
+
         input_ids, assistant_masks = self._truncate_to_assistant_boundary(
             input_ids=input_ids,
             assistant_masks=assistant_masks,

--- a/loongforge/data/chat_template.py
+++ b/loongforge/data/chat_template.py
@@ -565,7 +565,11 @@ class HFChatTemplate(ChatTemplate):
 
     @staticmethod
     def _message_loss_mask_to_bool(value: Any) -> bool:
-        """Parse a per-message loss_mask value."""
+        """Parse an assistant message loss_mask value.
+
+        ``1``/``true``/``yes`` means this assistant turn contributes loss;
+        ``0``/``false``/``no`` means this assistant turn is masked out.
+        """
         if isinstance(value, bool):
             return value
         if isinstance(value, int) and value in (0, 1):
@@ -587,31 +591,31 @@ class HFChatTemplate(ChatTemplate):
         cls,
         messages: Sequence[Dict[str, Any]],
     ) -> Tuple[List[bool], bool]:
-        """Return assistant turn loss flags and whether any flag was explicit."""
-        assistant_loss_flags: List[bool] = []
-        has_explicit_loss_mask = False
+        """Return assistant turn loss flags and whether any assistant flag was explicit.
 
-        for message_index, message in enumerate(messages):
+        Input files may include a ``loss_mask`` field on every message for a
+        uniform schema. Only assistant messages map to HuggingFace generation
+        ranges, so non-assistant ``loss_mask`` fields are ignored. Assistant
+        messages without ``loss_mask`` keep the previous behavior and train on
+        that turn.
+        """
+        assistant_loss_flags: List[bool] = []
+        has_explicit_assistant_loss_mask = False
+
+        for message in messages:
             role = message.get("role")
             has_loss_mask = "loss_mask" in message
-            if has_loss_mask:
-                has_explicit_loss_mask = True
-                if role != DataRoles.ASSISTANT:
-                    raise ValueError(
-                        "message-level loss_mask is currently supported only for "
-                        f"assistant messages; got role {role!r} at message "
-                        f"index {message_index}"
-                    )
 
             if role == DataRoles.ASSISTANT:
                 if has_loss_mask:
+                    has_explicit_assistant_loss_mask = True
                     assistant_loss_flags.append(
                         cls._message_loss_mask_to_bool(message["loss_mask"])
                     )
                 else:
                     assistant_loss_flags.append(True)
 
-        return assistant_loss_flags, has_explicit_loss_mask
+        return assistant_loss_flags, has_explicit_assistant_loss_mask
 
     def _tokenize_with_generation_indices(
         self,


### PR DESCRIPTION
## Summary
- Add assistant message-level `loss_mask` support in `HFChatTemplate.encode_openai()`
- Define assistant semantics: `loss_mask=1` keeps that assistant turn trainable, `loss_mask=0` masks it out
- Preserve existing behavior when no assistant message has explicit `loss_mask`
- Allow `loss_mask` on non-assistant messages for uniform input schemas; these fields are ignored because only assistant messages map to HF generation ranges
- Validate explicit assistant masks against HuggingFace generation ranges to avoid silent turn/span misalignment
- Reject conflicts between explicit assistant masks and `train_on_prompt` / `history_mask_loss`

## Validation
- `compile(..., "loongforge/data/chat_template.py", "exec")`
- CPU helper checks for default assistant behavior, explicit 0/1/string mask parsing, invalid assistant values, ignored non-assistant masks, and alternating generation-span filtering
- Local CPU tokenizer validation on a ReAct/tool-calling sample confirmed only the final assistant answer remains trainable (`assistant_flags=[False, False, True]`)
