### PR TITLE
[docs] docs: update Docker installation guide

### DIFF
--- a/docs/source/get_started/installation.md
+++ b/docs/source/get_started/installation.md
@@ -83,17 +83,83 @@ After the build finishes, verify:
 docker images | grep loongforge
 ```
 
+### Pre-built Docker Images
+
+LoongForge Docker images are available on Docker Hub:
+[https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge).
+
+LoongForge publishes versioned pre-built Docker images. Select the desired tag
+from Docker Hub. LeRobot images use the same version tag with a `_lerobot` suffix
+when available.
+
+| Image | Tag Pattern | Description |
+|---|---|---|
+| `loongforge/loongforge` | `<version>` | Base image: LLM / VLM / Diffusion training only |
+| `loongforge/loongforge` | `<version>_lerobot` | Includes LeRobot dependencies for VLA training (Pi0.5 + GR00T) |
+
+```bash
+# Set the version tag you want to use, for example: 0.1.1
+LOONGFORGE_VERSION=<version>
+
+# Pull the base image
+docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
+
+# Pull the image with LeRobot support
+docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
+```
+
+#### Dual Python Environment in the LeRobot Image
+
+The LeRobot image (`<version>_lerobot`) uses a **dual virtual-environment** setup to resolve
+dependency conflicts between Pi0.5 and GR00T:
+
+| Environment | Path | Default? | Use Case |
+|---|---|---|---|
+| Base (Pi0.5) | System Python | Yes | Pi0.5 VLA training |
+| GR00T | `/opt/venvs/gr00t` | No | GR00T-N1.6 VLA training |
+
+**To activate the GR00T environment inside the container:**
+
+```bash
+source /opt/venvs/gr00t/bin/activate
+# or use the convenience alias:
+use-gr00t
+```
+
+**To return to the base (Pi0.5) environment:**
+
+```bash
+deactivate
+```
+
+**For distributed training, use the venv's torchrun:**
+
+```bash
+/opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
+```
+
 ### Run the container
 
 ```bash
+# Set the version tag you want to use, for example: 0.1.1
+LOONGFORGE_VERSION=<version>
+
+# Using the base image (LLM/VLM/Diffusion)
 docker run --runtime=nvidia --gpus all -itd --rm \
   -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
   -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge:latest /bin/bash
+  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
+
+# Using the LeRobot image (VLA: Pi0.5 + GR00T)
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
 ```
 
 Once inside the container, navigate to `/workspace/LoongForge/examples/` and
-launch the desired training script.
+launch the desired training script. For GR00T training, remember to activate
+the GR00T virtual environment first (see Dual Python Environment above).
 
 ---
 

--- a/docs/source_zh/get_started/installation.md
+++ b/docs/source_zh/get_started/installation.md
@@ -75,16 +75,80 @@ docker build --build-arg COMPILE_ENV=hopper --build-arg ENABLE_LEROBOT=false \
 docker images | grep loongforge
 ```
 
+### 预构建 Docker 镜像
+
+LoongForge Docker 镜像保存在 Docker Hub：
+[https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge)。
+
+LoongForge 发布带版本号的预构建 Docker 镜像。请在 Docker Hub 中选择需要的 tag。
+LeRobot 镜像在可用时使用相同版本号并追加 `_lerobot` 后缀。
+
+| 镜像 | 标签模式 | 描述 |
+|---|---|---|
+| `loongforge/loongforge` | `<version>` | 基础镜像：仅支持 LLM / VLM / Diffusion 训练 |
+| `loongforge/loongforge` | `<version>_lerobot` | 包含 VLA 训练（Pi0.5 + GR00T）的 LeRobot 依赖 |
+
+```bash
+# 设置需要使用的版本 tag，例如：0.1.1
+LOONGFORGE_VERSION=<version>
+
+# 拉取基础镜像
+docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
+
+# 拉取带 LeRobot 支持的镜像
+docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
+```
+
+#### LeRobot 镜像中的双 Python 环境
+
+LeRobot 镜像（`<version>_lerobot`）使用**双虚拟环境**方案解决 Pi0.5 和 GR00T 之间的依赖冲突：
+
+| 环境 | 路径 | 是否默认 | 用途 |
+|---|---|---|---|
+| 基础环境（Pi0.5） | 系统 Python | 是 | Pi0.5 VLA 训练 |
+| GR00T | `/opt/venvs/gr00t` | 否 | GR00T-N1.6 VLA 训练 |
+
+**在容器中激活 GR00T 环境：**
+
+```bash
+source /opt/venvs/gr00t/bin/activate
+# 或使用快捷命令：
+use-gr00t
+```
+
+**返回基础（Pi0.5）环境：**
+
+```bash
+deactivate
+```
+
+**分布式训练请使用虚拟环境内的 torchrun：**
+
+```bash
+/opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
+```
+
 ### 运行容器
 
 ```bash
+# 设置需要使用的版本 tag，例如：0.1.1
+LOONGFORGE_VERSION=<version>
+
+# 使用基础镜像（LLM/VLM/Diffusion）
 docker run --runtime=nvidia --gpus all -itd --rm \
   -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
   -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge:latest /bin/bash
+  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
+
+# 使用 LeRobot 镜像（VLA: Pi0.5 + GR00T）
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
 ```
 
 进入容器后，导航到 `/workspace/LoongForge/examples/` 并启动所需的训练脚本。
+对于 GR00T 训练，请先激活 GR00T 虚拟环境（参见上方双 Python 环境说明）。
 
 ---
 


### PR DESCRIPTION
## Summary
- Document where LoongForge Docker images are hosted on Docker Hub.
- Add general versioned tag guidance for base and LeRobot pre-built images.
- Clarify LeRobot image usage and dual Python environment setup in English and Chinese docs.

## Changes
- Added Docker Hub link for LoongForge images.
- Replaced fixed image tags with `<version>` and `<version>_lerobot` tag patterns.
- Updated `docker pull` and `docker run` examples to use `LOONGFORGE_VERSION`.
- Added GR00T environment activation, deactivation, and venv `torchrun` guidance.
- Kept English and Chinese installation docs aligned.