### PR TITLE
[ci] ci: add issue notification workflow

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -12,6 +12,7 @@ This directory contains the CI/CD workflows for LoongForge.
 | `build.yml` | PR + push to master | Build sdist + wheel on Python 3.10 / 3.12 |
 | `submodule-sync.yml` | repository dispatch / workflow dispatch + manual | Sync `third_party/Loong-Megatron` to its tracked branch and push the submodule pointer update |
 | `auto-label.yml` | Issue/PR open/edit | Auto-label issues and PRs by keyword matching |
+| `issue-notify.yml` | Issue opened | Notify Ruliu group when a new issue is opened |
 
 All workflows support `workflow_dispatch` for manual re-runs from the Actions UI (except `auto-label.yml`).
 
@@ -46,3 +47,11 @@ Required secrets:
 - `SUBMODULE_SYNC_APP_PRIVATE_KEY`
 
 The GitHub App behind those secrets must be able to push to the configured target branch.
+
+## Ruliu Issue Notifications
+
+`issue-notify.yml` sends a Markdown message to a Ruliu group when a new GitHub Issue is opened. It runs on the self-hosted Linux runner because the Ruliu webhook host is only reachable from the internal network.
+
+Required secret:
+
+- `RULIU_ISSUE_WEBHOOK`: Ruliu group robot webhook URL for issue notifications.

--- a/.github/workflows/issue-notify.yml
+++ b/.github/workflows/issue-notify.yml
@@ -1,0 +1,41 @@
+name: Issue Notify
+
+on:
+  issues:
+    types: [opened]
+
+permissions:
+  contents: read
+
+jobs:
+  issue-notify:
+    name: Notify Ruliu on new issue
+    runs-on: [self-hosted, Linux, X64]
+    env:
+      RULIU_ISSUE_WEBHOOK: ${{ secrets.RULIU_ISSUE_WEBHOOK }}
+      ISSUE_TITLE: ${{ github.event.issue.title }}
+      ISSUE_NUMBER: ${{ github.event.issue.number }}
+      ISSUE_AUTHOR: ${{ github.event.issue.user.login }}
+      ISSUE_URL: ${{ github.event.issue.html_url }}
+      REPOSITORY: ${{ github.repository }}
+    steps:
+      - name: Notify via Ruliu group
+        run: |
+          if [ -z "${RULIU_ISSUE_WEBHOOK:-}" ]; then
+            echo "RULIU_ISSUE_WEBHOOK 未配置，跳过通知"
+            exit 0
+          fi
+
+          CONTENT=$(cat <<EOF
+          ##### LoongForge Issue 通知
+          **Repo**: ${REPOSITORY}
+          **Issue**: #${ISSUE_NUMBER} ${ISSUE_TITLE}
+          **Author**: ${ISSUE_AUTHOR}
+          **Link**: ${ISSUE_URL}
+          EOF
+          )
+          PAYLOAD=$(jq -n --arg content "$CONTENT" '{message:{body:[{type:"MD",content:$content}]}}')
+
+          curl -sS -X POST "$RULIU_ISSUE_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "$PAYLOAD" || echo "如流 Issue 通知发送失败（不影响主流程）"


### PR DESCRIPTION
## Summary
- Add a dedicated GitHub Actions workflow to notify Ruliu when a new GitHub Issue is opened.
- Use `RULIU_ISSUE_WEBHOOK` as the repository secret so the webhook URL is not committed.
- Run the notification job on the self-hosted Linux runner because the Ruliu webhook host is only reachable from the internal network.

## Changes
- Added `.github/workflows/issue-notify.yml` to listen for `issues.opened` events and send a Markdown notification with repo, issue, author, and link.
- Updated `.github/workflows/README.md` to document the new workflow and required secret.