### PR TITLE
[docs] docs: promote pre-built docker images to top-level section

### DIFF
--- a/docs/source/get_started/installation.md
+++ b/docs/source/get_started/installation.md
@@ -83,7 +83,9 @@ After the build finishes, verify:
 docker images | grep loongforge
 ```
 
-### Pre-built Docker Images
+---
+
+## Pre-built Docker Images
 
 LoongForge Docker images are available on Docker Hub:
 [https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge).
@@ -108,7 +110,30 @@ docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
 docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 ```
 
-#### Dual Python Environment in the LeRobot Image
+### Run the container
+
+```bash
+# Set the version tag you want to use, for example: 0.1.1
+LOONGFORGE_VERSION=<version>
+
+# Using the base image (LLM/VLM/Diffusion)
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
+
+# Using the LeRobot image (VLA: Pi0.5 + GR00T)
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
+```
+
+Once inside the container, navigate to `/workspace/LoongForge/examples/` and
+launch the desired training script. For GR00T training, remember to activate
+the GR00T virtual environment first (see Dual Python Environment below).
+
+### Dual Python Environment in the LeRobot Image
 
 The LeRobot image (`<version>_lerobot`) uses a **dual virtual-environment** setup to resolve
 dependency conflicts between Pi0.5 and GR00T:
@@ -137,29 +162,6 @@ deactivate
 ```bash
 /opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
 ```
-
-### Run the container
-
-```bash
-# Set the version tag you want to use, for example: 0.1.1
-LOONGFORGE_VERSION=<version>
-
-# Using the base image (LLM/VLM/Diffusion)
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
-
-# Using the LeRobot image (VLA: Pi0.5 + GR00T)
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
-```
-
-Once inside the container, navigate to `/workspace/LoongForge/examples/` and
-launch the desired training script. For GR00T training, remember to activate
-the GR00T virtual environment first (see Dual Python Environment above).
 
 ---
 

--- a/docs/source_zh/get_started/installation.md
+++ b/docs/source_zh/get_started/installation.md
@@ -75,7 +75,9 @@ docker build --build-arg COMPILE_ENV=hopper --build-arg ENABLE_LEROBOT=false \
 docker images | grep loongforge
 ```
 
-### 预构建 Docker 镜像
+---
+
+## 预构建 Docker 镜像
 
 LoongForge Docker 镜像保存在 Docker Hub：
 [https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge)。
@@ -99,7 +101,29 @@ docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
 docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 ```
 
-#### LeRobot 镜像中的双 Python 环境
+### 运行容器
+
+```bash
+# 设置需要使用的版本 tag，例如：0.1.1
+LOONGFORGE_VERSION=<version>
+
+# 使用基础镜像（LLM/VLM/Diffusion）
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
+
+# 使用 LeRobot 镜像（VLA: Pi0.5 + GR00T）
+docker run --runtime=nvidia --gpus all -itd --rm \
+  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
+  -v /path/to/data:/mnt/cluster/LoongForge/ \
+  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
+```
+
+进入容器后，导航到 `/workspace/LoongForge/examples/` 并启动所需的训练脚本。
+对于 GR00T 训练，请先激活 GR00T 虚拟环境（参见下方双 Python 环境说明）。
+
+### LeRobot 镜像中的双 Python 环境
 
 LeRobot 镜像（`<version>_lerobot`）使用**双虚拟环境**方案解决 Pi0.5 和 GR00T 之间的依赖冲突：
 
@@ -127,28 +151,6 @@ deactivate
 ```bash
 /opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
 ```
-
-### 运行容器
-
-```bash
-# 设置需要使用的版本 tag，例如：0.1.1
-LOONGFORGE_VERSION=<version>
-
-# 使用基础镜像（LLM/VLM/Diffusion）
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
-
-# 使用 LeRobot 镜像（VLA: Pi0.5 + GR00T）
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
-```
-
-进入容器后，导航到 `/workspace/LoongForge/examples/` 并启动所需的训练脚本。
-对于 GR00T 训练，请先激活 GR00T 虚拟环境（参见上方双 Python 环境说明）。
 
 ---
 


### PR DESCRIPTION
## Summary
- Surface the **Pre-built Docker Images** section in the installation page TOC by lifting it from a `###` subsection of *Option A: Docker Image* to a top-level `##` section, alongside *Option A* and *Option B*.
- Fix an internal inconsistency: the previous **Run the container** snippet sat under *Option A* (which only documents `docker build -t loongforge:latest`) but actually used the pre-built image tags `loongforge/loongforge:${LOONGFORGE_VERSION}[_lerobot]`. It now lives directly under **Pre-built Docker Images**, paired with the matching `docker pull` commands.
- Mirror the exact same restructuring in the Chinese translation so the EN/ZH TOCs stay aligned.

## Changes
- `docs/source/get_started/installation.md`
  - Promote `### Pre-built Docker Images` → `## Pre-built Docker Images`.
  - Move `### Run the container` from under *Option A* to under *Pre-built Docker Images* (right after the `docker pull` block).
  - Demote `#### Dual Python Environment in the LeRobot Image` to `### Dual Python Environment in the LeRobot Image` so it nests correctly under the new top-level section.
  - Update cross-reference: *"see Dual Python Environment above"* → *"below"* to match the new ordering.
- `docs/source_zh/get_started/installation.md`
  - Same restructuring applied to the Chinese version (`预构建 Docker 镜像` / `运行容器` / `LeRobot 镜像中的双 Python 环境`).

No content / commands were rewritten — this PR is purely a heading-level and ordering change so the *Pre-built Docker Images* path stands as a first-class peer of the build-from-source path.