### PR TITLE
[diffusion, data] fix: sample latent files across the full dataset

### DIFF
--- a/loongforge/data/video/latent_dataset.py
+++ b/loongforge/data/video/latent_dataset.py
@@ -4,9 +4,7 @@
 """latent dataset"""
 
 import numpy as np
-import pandas as pd
 import torch
-import json
 from pathlib import Path
 class TensorDataset(torch.utils.data.Dataset):
     def __init__(self, data_path, steps_per_epoch=0, seed=0, keep_keys=None, data_parallel_size=1):

--- a/loongforge/data/video/latent_dataset.py
+++ b/loongforge/data/video/latent_dataset.py
@@ -1,23 +1,39 @@
 # Copyright 2026 The LoongForge Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""latent dataset"""
+"""Latent dataset used by diffusion training."""
+
+from pathlib import Path
 
 import numpy as np
-import pandas as pd
 import torch
-import json
-from pathlib import Path
+
+
 class TensorDataset(torch.utils.data.Dataset):
-    def __init__(self, data_path, steps_per_epoch=0, seed=0, keep_keys=None):
+    def __init__(
+        self,
+        data_path,
+        steps_per_epoch=0,
+        seed=0,
+        keep_keys=None,
+        data_parallel_size=1,
+    ):
         self.data_paths = []
         self.load_data(data_path)
         self.steps_per_epoch = steps_per_epoch
+        self.data_parallel_size = data_parallel_size
+        if not 0 < self.data_parallel_size <= len(self.data_paths):
+            raise ValueError("Need at least one physical file per DP rank")
+        self.samples_per_rank = len(self.data_paths) // self.data_parallel_size
+
         print(
-            f"self.steps_per_epoch: {self.steps_per_epoch}, total_samples: {len(self.data_paths)}"
+            f"self.steps_per_epoch: {self.steps_per_epoch}, "
+            f"total_samples: {len(self.data_paths)}, "
+            f"dropped_samples: {len(self.data_paths) % self.data_parallel_size}"
         )
-        assert len(self.data_paths) > 0
         self.manual_seed = seed
+        self._shuffle_epoch = None
+        self._shuffle_order = None
         # Optional whitelist of keys to keep from each loaded sample. Caller decides
         # the policy (e.g. wan2-1-i2v) so this dataset stays decoupled from global state.
         self.keep_keys = set(keep_keys) if keep_keys else None
@@ -29,15 +45,27 @@ class TensorDataset(torch.utils.data.Dataset):
         self.data_paths = sorted([str(p) for p in base_path.rglob("*") if p.is_file()])
 
     def __getitem__(self, index):
-        seed = (self.manual_seed + index) % 2**32
-        numpy_random_state = np.random.RandomState(seed=seed)
-        data_id = numpy_random_state.randint(0, len(self.data_paths))
+        index = int(index)
+        logical_rank = index % self.data_parallel_size
+        shuffle_epoch, shard_offset = divmod(
+            index // self.data_parallel_size, self.samples_per_rank
+        )
+
+        if shuffle_epoch != self._shuffle_epoch:
+            rng = np.random.RandomState((self.manual_seed + shuffle_epoch) % 2**32)
+            self._shuffle_order = rng.permutation(self.samples_per_rank)
+            self._shuffle_epoch = shuffle_epoch
+
+        data_id = logical_rank * self.samples_per_rank + int(
+            self._shuffle_order[shard_offset]
+        )
         path = self.data_paths[data_id]
         data = torch.load(path, weights_only=False, map_location="cpu")
         if self.keep_keys is not None:
             data = {k: v for k, v in data.items() if k in self.keep_keys}
         data = {k: v for k, v in data.items() if v is not None}
         # used for generate timestep
+        seed = (self.manual_seed + index) % 2**32
         data["seed"] = seed
         return data
 

--- a/loongforge/data/video/latent_dataset.py
+++ b/loongforge/data/video/latent_dataset.py
@@ -1,37 +1,26 @@
 # Copyright 2026 The LoongForge Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""Latent dataset used by diffusion training."""
-
-from pathlib import Path
+"""latent dataset"""
 
 import numpy as np
+import pandas as pd
 import torch
-
-
+import json
+from pathlib import Path
 class TensorDataset(torch.utils.data.Dataset):
-    def __init__(
-        self,
-        data_path,
-        steps_per_epoch=0,
-        seed=0,
-        keep_keys=None,
-        data_parallel_size=1,
-    ):
+    def __init__(self, data_path, steps_per_epoch=0, seed=0, keep_keys=None, data_parallel_size=1):
         self.data_paths = []
         self.load_data(data_path)
         self.steps_per_epoch = steps_per_epoch
-        self.data_parallel_size = data_parallel_size
-        if not 0 < self.data_parallel_size <= len(self.data_paths):
-            raise ValueError("Need at least one physical file per DP rank")
-        self.samples_per_rank = len(self.data_paths) // self.data_parallel_size
-
         print(
-            f"self.steps_per_epoch: {self.steps_per_epoch}, "
-            f"total_samples: {len(self.data_paths)}, "
-            f"dropped_samples: {len(self.data_paths) % self.data_parallel_size}"
+            f"self.steps_per_epoch: {self.steps_per_epoch}, total_samples: {len(self.data_paths)}"
         )
+        assert len(self.data_paths) > 0
         self.manual_seed = seed
+        self.data_parallel_size = data_parallel_size
+        assert 0 < self.data_parallel_size <= len(self.data_paths)
+        self.samples_per_rank = len(self.data_paths) // self.data_parallel_size
         self._shuffle_epoch = None
         self._shuffle_order = None
         # Optional whitelist of keys to keep from each loaded sample. Caller decides
@@ -45,7 +34,7 @@ class TensorDataset(torch.utils.data.Dataset):
         self.data_paths = sorted([str(p) for p in base_path.rglob("*") if p.is_file()])
 
     def __getitem__(self, index):
-        index = int(index)
+        seed = (self.manual_seed + index) % 2**32
         logical_rank = index % self.data_parallel_size
         shuffle_epoch, shard_offset = divmod(
             index // self.data_parallel_size, self.samples_per_rank
@@ -65,7 +54,6 @@ class TensorDataset(torch.utils.data.Dataset):
             data = {k: v for k, v in data.items() if k in self.keep_keys}
         data = {k: v for k, v in data.items() if v is not None}
         # used for generate timestep
-        seed = (self.manual_seed + index) % 2**32
         data["seed"] = seed
         return data
 

--- a/loongforge/data/video/latent_dataset.py
+++ b/loongforge/data/video/latent_dataset.py
@@ -31,8 +31,7 @@ class TensorDataset(torch.utils.data.Dataset):
     def __getitem__(self, index):
         seed = (self.manual_seed + index) % 2**32
         numpy_random_state = np.random.RandomState(seed=seed)
-        data_id = numpy_random_state.randint(0, self.steps_per_epoch)
-        data_id = data_id % len(self.data_paths)
+        data_id = numpy_random_state.randint(0, len(self.data_paths))
         path = self.data_paths[data_id]
         data = torch.load(path, weights_only=False, map_location="cpu")
         if self.keep_keys is not None:

--- a/loongforge/data/video/packed_dataset.py
+++ b/loongforge/data/video/packed_dataset.py
@@ -15,7 +15,6 @@ import torch.nn.functional as F
 from torch.utils.data import IterableDataset
 from megatron.core import parallel_state
 
-from loongforge.utils import get_args, print_rank_0
 from loongforge.data.video.latent_dataset import TensorDataset
 from loongforge.data.video.sequence_packing_utils import first_fit
 

--- a/loongforge/data/video/packed_dataset.py
+++ b/loongforge/data/video/packed_dataset.py
@@ -15,7 +15,6 @@ import torch.nn.functional as F
 from torch.utils.data import IterableDataset
 from megatron.core import parallel_state
 
-from loongforge.utils import get_args, print_rank_0
 from loongforge.data.video.latent_dataset import TensorDataset
 from loongforge.data.video.sequence_packing_utils import first_fit
 
@@ -102,6 +101,8 @@ class PackedDataset(IterableDataset):
         self.seq_length = seq_length
         self.dp_rank = dp_rank
         self.dp_world_size = dp_world_size
+        if self.packing_buffer_size <= 0:
+            raise ValueError("packing_buffer_size must be positive")
 
         self.context_max_len = getattr(args, "context_max_len", 512)
 
@@ -119,7 +120,8 @@ class PackedDataset(IterableDataset):
                 "max_timestep_boundary", "min_timestep_boundary",
             }
         self.base_dataset = TensorDataset(
-            data_path, steps_per_epoch, seed=args.seed, keep_keys=keep_keys,
+            data_path, self.steps_per_epoch, seed=args.seed, keep_keys=keep_keys,
+            data_parallel_size=self.dp_world_size,
         )
 
         # Validate timestep boundaries
@@ -168,10 +170,10 @@ class PackedDataset(IterableDataset):
     # ------------------------------------------------------------------
 
     def __iter__(self):
-        from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
-
         scheduler = self.scheduler
         if scheduler is None:
+            from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
+
             scheduler = FlowMatchScheduler(shift=5, sigma_min=0.0, extra_one_step=True)
             scheduler.set_timesteps(1000, training=True)
 
@@ -181,10 +183,15 @@ class PackedDataset(IterableDataset):
         batch_count = 0
 
         while batch_count < required_bins:
-            # Fill buffer
-            while len(buffer) < self.packing_buffer_size:
-                wrapped_idx = sample_idx % len(self.base_dataset)
-                buffer.append(self.base_dataset[wrapped_idx])
+            # Keep a packed bin inside one no-replacement physical epoch.
+            shard_size = self.base_dataset.samples_per_rank
+            shard_offset = (sample_idx // self.dp_world_size) % shard_size
+            buffer_target_size = min(
+                self.packing_buffer_size, shard_size - shard_offset
+            )
+            while len(buffer) < buffer_target_size:
+                # Rank-strided logical indices map to a fixed physical DP shard.
+                buffer.append(self.base_dataset[sample_idx])
                 sample_idx += self.dp_world_size
 
             bins = self._pack_samples(buffer)

--- a/loongforge/data/video/packed_dataset.py
+++ b/loongforge/data/video/packed_dataset.py
@@ -15,6 +15,7 @@ import torch.nn.functional as F
 from torch.utils.data import IterableDataset
 from megatron.core import parallel_state
 
+from loongforge.utils import get_args, print_rank_0
 from loongforge.data.video.latent_dataset import TensorDataset
 from loongforge.data.video.sequence_packing_utils import first_fit
 
@@ -101,8 +102,6 @@ class PackedDataset(IterableDataset):
         self.seq_length = seq_length
         self.dp_rank = dp_rank
         self.dp_world_size = dp_world_size
-        if self.packing_buffer_size <= 0:
-            raise ValueError("packing_buffer_size must be positive")
 
         self.context_max_len = getattr(args, "context_max_len", 512)
 
@@ -120,7 +119,7 @@ class PackedDataset(IterableDataset):
                 "max_timestep_boundary", "min_timestep_boundary",
             }
         self.base_dataset = TensorDataset(
-            data_path, self.steps_per_epoch, seed=args.seed, keep_keys=keep_keys,
+            data_path, steps_per_epoch, seed=args.seed, keep_keys=keep_keys,
             data_parallel_size=self.dp_world_size,
         )
 
@@ -170,10 +169,10 @@ class PackedDataset(IterableDataset):
     # ------------------------------------------------------------------
 
     def __iter__(self):
+        from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
+
         scheduler = self.scheduler
         if scheduler is None:
-            from loongforge.models.diffusion.wan.wan_flow_match import FlowMatchScheduler
-
             scheduler = FlowMatchScheduler(shift=5, sigma_min=0.0, extra_one_step=True)
             scheduler.set_timesteps(1000, training=True)
 

--- a/loongforge/train/diffusion/pretrain_qwen_image.py
+++ b/loongforge/train/diffusion/pretrain_qwen_image.py
@@ -317,12 +317,14 @@ def train_valid_test_datasets_provider(diffusion, train_val_test_num_samples, vp
         args.train_iters * args.global_batch_size,
         seed=args.seed,
         keep_keys=keep_keys,
+        data_parallel_size=parallel_state.get_data_parallel_world_size(),
     )
     sampler = torch.utils.data.DistributedSampler(
         dataset,
         shuffle=False,
         num_replicas=parallel_state.get_data_parallel_world_size(),
         rank=parallel_state.get_data_parallel_rank(),
+        drop_last=True,
     )
     dataloader = DataLoader(dataset, batch_size=1, num_workers=args.num_workers, sampler=sampler, pin_memory=True)
     print_rank_0(f"> finished creating {args.model_name} datasets ...")

--- a/loongforge/train/diffusion/pretrain_wan.py
+++ b/loongforge/train/diffusion/pretrain_wan.py
@@ -507,9 +507,11 @@ def train_valid_test_datasets_provider(diffusion, train_val_test_num_samples, vp
             args.train_iters * args.global_batch_size,
             seed=args.seed,
             keep_keys=keep_keys,
+            data_parallel_size=dp_world_size,
         )
         sampler = torch.utils.data.DistributedSampler(
-            dataset, shuffle=False, num_replicas=dp_world_size, rank=dp_rank
+            dataset, shuffle=False, num_replicas=dp_world_size,
+            rank=dp_rank, drop_last=True,
         )
         dataloader = torch.utils.data.DataLoader(
             dataset,


### PR DESCRIPTION
Use the number of latent files as the random sampling bound.

This keeps every cached sample reachable regardless of steps_per_epoch.