### PR TITLE
[ckpt, train] feat: support packed INT4/MXFP4 HF checkpoint bridge loading with memory optimizations

### DIFF
--- a/configs/models/kimi_k2.6/kimi_k2_6_bf16.yaml
+++ b/configs/models/kimi_k2.6/kimi_k2_6_bf16.yaml
@@ -1,0 +1,27 @@
+# Kimi K2.6 Model Config — bf16 training variant.
+#
+# Identical to kimi_k2_6.yaml except it points model.foundation.convert_file at
+# the bf16 ckpt convert config. With that, bridge online HF-load dequantizes
+# INT4 weights to bf16 and STOPS there — it does not requantize bf16 back to
+# FP8 (the FP8 requant crashes on Blackwell with pow_2_scale when FP8 training
+# is off and --force_pow_2_scales is unset). Use this for bf16-only training;
+# use kimi_k2_6.yaml for FP8 training.
+
+defaults:
+  - ../../models/image_encoder@model.image_encoder: moon_vit_3d
+  - ../../models/image_projector@model.image_projector: patch_merger_adapter
+  - ../../models/kimi_k2@model.foundation: kimi_k2
+  - _self_
+
+model:
+  model_type: kimi_k2_6
+  loss_func: ${loss_func:default}
+  image_encoder:
+    model_spec: ["loongforge.models.encoder.moon_vision_models.moon_vision_layer_spec",
+                 "get_moon_vision_model_layer_with_te_spec"]
+  image_projector:
+    model_spec: ["loongforge.models.encoder.moon_vision_models.moon_vision_layer_spec",
+     "get_adapeter_layer_with_te_spec"]
+  vision_token_id: 163603
+  foundation:
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/kimi_k2/ckpt_convert/kimi_k2_convert_bf16.yaml

--- a/configs/models/kimi_k2/ckpt_convert/kimi_k2_convert_bf16.yaml
+++ b/configs/models/kimi_k2/ckpt_convert/kimi_k2_convert_bf16.yaml
@@ -1,0 +1,119 @@
+# Kimi K2 checkpoint convert config — bf16 training variant.
+#
+# Mirrors kimi_k2_convert.yaml (the FP8 variant) but drops every `fp8: true`,
+# `fp8_ignore_tp: true`, and `dtype: fp8` marker on the mcore attention/expert
+# linears. With those removed, mcore_base.common_to_mcore sees mcore_dtype=None,
+# so it does NOT trigger QUANT_HF_BF16_AND_MCORE_FP8 — i.e. bridge online HF-load
+# stops at the INT4->bf16 dequant and does NOT requantize bf16 weights back to
+# FP8. That requant path crashes on Blackwell (pow_2_scale assertion) when FP8
+# training is off and --force_pow_2_scales is therefore unset.
+#
+# `extra: true` is kept (same as the bf16 qwen3_moe convert config): it selects
+# the TE extra_state weight path, which is dtype-agnostic. Use this config for
+# bf16-only training; use kimi_k2_convert.yaml for FP8 training.
+hydra:
+  searchpath:
+    - file://${oc.env:LOONGFORGE_PATH}/configs/models/
+
+defaults:
+  - kimi_k2@module: ???
+  - _self_
+
+
+args:
+  common:
+    num_layers: ${module.num_layers}
+    hidden_size: ${module.hidden_size}
+    ffn_hidden_size: ${module.ffn_hidden_size}
+    num_attention_heads: ${module.num_attention_heads}
+    num_key_value_heads: ${module.num_query_groups}
+    vocab_size: ${module.vocab_size_in_config_file}
+    num_experts: ${module.num_experts}
+  mcore:
+    untie_embeddings_and_output_weights: true
+    add_embedding_padding: true
+    transpose_mlp_dense: true
+    transpose_query_key_value: true
+name_map:
+  huggingface:
+    weight_scale_key: weight_scale
+    word_embeddings: language_model.model.embed_tokens
+    transformer: language_model.model
+    layer_prefix: layers
+    input_layernorm: input_layernorm
+    attention.q_down:
+      name: self_attn.q_a_proj
+      dtype: bf16
+    attention.q_up: self_attn.q_b_proj
+    attention.q_up_layernorm: self_attn.q_a_layernorm
+    attention.kv_down:
+      name: self_attn.kv_a_proj_with_mqa
+      dtype: bf16
+    attention.kv_up: self_attn.kv_b_proj
+    attention.kv_up_layernorm: self_attn.kv_a_layernorm
+    attention.dense: self_attn.o_proj
+    post_attention_layernorm: post_attention_layernorm
+    moe.gate: mlp.gate
+    moe.gate.bias: mlp.gate.e_score_correction_bias
+    moe.expert: mlp.experts
+    moe.shared_expert: mlp.shared_experts
+    moe.expert_h_to_4h:
+    - gate_proj
+    - up_proj
+    mlp.dense_h_to_4h:
+    - mlp.gate_proj
+    - mlp.up_proj
+    moe.expert_4h_to_h: down_proj
+    mlp.dense_4h_to_h: mlp.down_proj
+    final_layernorm: language_model.model.norm
+    word_embeddings_for_head: language_model.lm_head
+  mcore:
+    word_embeddings: language_model.embedding.word_embeddings
+    transformer: model
+    layer_prefix: language_model.decoder.layers
+    input_layernorm: input_layernorm
+    attention.q_down:
+      name: self_attention.linear_q_down_proj
+      extra: true
+    attention.q_up:
+      name: self_attention.linear_q_up_proj
+      extra: true
+    attention.q_up_layernorm:
+      name: self_attention.linear_q_up_proj
+      is_layernorm: true
+    attention.kv_down:
+      name: self_attention.linear_kv_down_proj
+      extra: true
+    attention.kv_up:
+      name: self_attention.linear_kv_up_proj
+      extra: true
+    attention.kv_up_layernorm:
+      name: self_attention.linear_kv_up_proj
+      is_layernorm: true
+    attention.dense:
+      name: self_attention.linear_proj
+      extra: true
+    post_attention_layernorm: pre_mlp_layernorm
+    moe.gate: mlp.router
+    moe.gate.bias: mlp.router.expert_bias
+    moe.expert: mlp.experts.local_experts
+    moe.groupedgemm.expert: mlp.experts
+    moe.shared_expert: mlp.shared_experts
+    moe.expert_h_to_4h:
+      name: linear_fc1
+      extra: true
+    mlp.dense_h_to_4h:
+      name: mlp.linear_fc1
+      extra: true
+    moe.expert_4h_to_h:
+      name: linear_fc2
+      extra: true
+    mlp.dense_4h_to_h:
+      name: mlp.linear_fc2
+      extra: true
+    final_layernorm:
+      name: language_model.decoder.final_layernorm
+      extra: true
+    word_embeddings_for_head: language_model.output_layer
+    transformer_tpl: model%d
+torch_dtype: bfloat16

--- a/loongforge/data/chat_template.py
+++ b/loongforge/data/chat_template.py
@@ -857,6 +857,19 @@ _register_chat_template(
 
 
 _register_chat_template(
+    name="kimi-k2.7-code-hf",
+    cls=HFChatTemplate,
+    chat_template=_read_builtin_chat_template("kimi_k2_7_code_training.jinja"),
+    mm_plugin=KimiK25Plugin(
+        image_token="<|media_content|>",
+        video_token="<|media_content|>",
+        merge_kernel_size=(2, 2),
+        temporal_merge_kernel_size=4,
+    ),
+)
+
+
+_register_chat_template(
     name="qwen1.5-hf",
     cls=HFChatTemplate,
     chat_template=_read_builtin_chat_template("qwen_chat_hf_training.jinja"),

--- a/loongforge/data/chat_templates/kimi_k2_7_code_training.jinja
+++ b/loongforge/data/chat_templates/kimi_k2_7_code_training.jinja
@@ -1,0 +1,75 @@
+{# LoongForge Kimi K2.7-Code SFT training template.
+   Derived from checkpoints/Kimi-K2.7-Code/chat_template.jinja (the inference
+   template the offline packer rendered with) so packed boundary lengths match
+   what training sees. The ONLY change vs the inference template is that each
+   assistant turn's body plus its <|im_end|> terminator is wrapped in a
+   {% generation %} / {% endgeneration %} block, which HFChatTemplate needs to
+   build the assistant-only loss mask. Generation markers emit no text, so the
+   rendered string is byte-identical to the inference template. #}
+{%- macro render_content(msg) -%}
+    {%- set c = msg.get('content') -%}
+    {%- if c is string -%}
+      {{ c }}
+    {%- elif c is not none -%}
+      {% for content in c -%}
+        {% if content['type'] == 'image' or content['type'] == 'image_url' -%}
+          <|media_begin|>image<|media_content|><|media_pad|><|media_end|>
+        {% elif content['type'] == 'video' or content['type']== 'video_url'-%}
+          <|kimi_k25_video_placeholder|>
+        {% else -%}
+          {{ content['text'] }}
+        {%- endif -%}
+      {%- endfor -%}
+    {%- endif -%}
+{%- endmacro -%}
+{% macro set_roles(message) -%}
+  {%- set role_name =  message.get('name') or  message['role'] -%}
+  {%- if message['role'] == 'user' -%}
+    <|im_user|>{{role_name}}<|im_middle|>
+  {%- elif message['role'] == 'assistant' -%}
+    <|im_assistant|>{{role_name}}<|im_middle|>
+  {%- else -%}
+    <|im_system|>{{role_name}}<|im_middle|>
+  {%- endif -%}
+{%- endmacro -%}
+{%- macro render_toolcalls(message) -%}
+  <|tool_calls_section_begin|>
+  {%- for tool_call in message['tool_calls'] -%}
+    {%- set formatted_id = tool_call['id'] -%}
+    <|tool_call_begin|>{{ formatted_id }}<|tool_call_argument_begin|>{% if tool_call['function']['arguments'] is string %}{{ tool_call['function']['arguments'] }}{% else %}{{ tool_call['function']['arguments'] | tojson }}{% endif %}<|tool_call_end|>
+  {%- endfor -%}
+  <|tool_calls_section_end|>
+{%- endmacro -%}
+{%- if tools -%}
+  {%- if tools_ts_str -%}
+    <|im_system|>tool_declare<|im_middle|>{{ tools_ts_str }}<|im_end|>
+  {%- else -%}
+    <|im_system|>tool_declare<|im_middle|>{{ tools | tojson(separators=(',', ':')) }}<|im_end|>
+  {%- endif -%}
+{%- endif -%}
+{%- for message in messages -%}
+  {{set_roles(message)}}
+  {%- if message['role'] == 'assistant' -%}
+    {%- generation -%}
+    {%- set rc = message.get('reasoning', message.get('reasoning_content', '')) -%}
+    <think>{{rc}}</think>{{render_content(message)}}
+    {%- if message.get('tool_calls') -%}
+      {{render_toolcalls(message)}}
+    {%- endif -%}
+    {{- '<|im_end|>' -}}
+    {%- endgeneration -%}
+  {%- elif message['role'] == 'tool' -%}
+    {%- set tool_call_id = message.tool_call_id -%}
+    ## Return of {{ tool_call_id }}
+{{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- elif message['content'] is not none -%}
+    {{render_content(message)}}
+    {{- '<|im_end|>' -}}
+  {%- else -%}
+    {{- '<|im_end|>' -}}
+  {%- endif -%}
+{%- endfor -%}
+{%- if add_generation_prompt -%}
+  <|im_assistant|>assistant<|im_middle|><think>
+{%- endif -%}

--- a/loongforge/models/omni_models/omni_combination_model.py
+++ b/loongforge/models/omni_models/omni_combination_model.py
@@ -298,6 +298,12 @@ class OmniCombinationModel(BaseMegatronModule):
 
                 if self.config.sequence_parallel:
                     combined_embeddings = tensor_parallel.scatter_to_sequence_parallel_region(combined_embeddings)
+                    # `scatter_to_sequence_parallel_region` returns a view into
+                    # `combined_embeddings`, which keeps the full-seq tensor (and the
+                    # text/vision embeddings merged into it) alive until the view is
+                    # freed. Clone to let the full-seq tensor be garbage collected.
+                    if self.config.clone_scatter_output_in_embedding:
+                        combined_embeddings = combined_embeddings.clone()
             elif enable_encoder_hetero_dp and inner_group_id == 0:
                 batch_id = mpu.get_tensor_model_parallel_rank()
 
@@ -405,6 +411,10 @@ class OmniCombinationModel(BaseMegatronModule):
 
             if self.config.sequence_parallel:
                 combined_embeddings = tensor_parallel.scatter_to_sequence_parallel_region(combined_embeddings)
+                # See the comment at the primary-path scatter call above: clone to
+                # break the view so the full-seq tensor can be garbage collected.
+                if self.config.clone_scatter_output_in_embedding:
+                    combined_embeddings = combined_embeddings.clone()
 
             # visual positional encoding communication
             if self.vit_contexts[forward_group_id]["local_visual_pos_masks"] is not None:
@@ -509,6 +519,10 @@ class OmniCombinationModel(BaseMegatronModule):
 
             if self.config.sequence_parallel:
                 combined_embeddings = tensor_parallel.scatter_to_sequence_parallel_region(combined_embeddings)
+                # See the comment at the primary-path scatter call above: clone to
+                # break the view so the full-seq tensor can be garbage collected.
+                if self.config.clone_scatter_output_in_embedding:
+                    combined_embeddings = combined_embeddings.clone()
 
             if self.vit_contexts[round_num]["local_visual_pos_masks"] is not None:
                 # Reload visual_pos_masks from CPU if offloaded

--- a/loongforge/models/omni_models/omni_encoder_model.py
+++ b/loongforge/models/omni_models/omni_encoder_model.py
@@ -28,6 +28,41 @@ from loongforge.train.initialize import change_parallel_state
 from loongforge.data.dp_balance.vit_balance import dp_balance_vit_encoder
 from loongforge.utils import get_args
 
+
+class _DummyEncoderPassthrough(torch.autograd.Function):
+    """Ties encoder/projector params into the autograd graph without paying
+    the cost of an out-of-place op on the full [seq, hidden] input_embeds.
+
+    Forward is a pure passthrough of input_embeds (no computation touching
+    encoder_output — avoids the `.sum()` reduction and the O(seq*hidden)
+    broadcast-add that `input_embeds + encoder_output.sum() * 0.0` incurred,
+    which allocated a full-size copy of input_embeds per call — ~3.5GB at
+    seq_length=262144, hidden_size=7168, and PP warm-up keeps ~PP_size of
+    these in flight simultaneously). Backward routes the real gradient to
+    input_embeds unchanged and zeros out encoder_output's gradient, matching
+    the original semantics (encoder/projector params get a real zero grad
+    for DDP sync, contributing nothing to the loss). Works whether or not
+    the encoder/projector are frozen.
+    """
+
+    @staticmethod
+    def forward(ctx, input_embeds, encoder_output):
+        """forward."""
+        ctx.encoder_output_shape = encoder_output.shape
+        ctx.encoder_output_dtype = encoder_output.dtype
+        return input_embeds
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """backward"""
+        grad_encoder_output = torch.zeros(
+            ctx.encoder_output_shape,
+            dtype=ctx.encoder_output_dtype,
+            device=grad_output.device,
+        )
+        return grad_output, grad_encoder_output
+
+
 def make_encoder_forward_pre_hook(module_name):
     """
     Create a forward pre-hook function that switches the tensor-parallel
@@ -534,8 +569,7 @@ class OmniEncoderModel(torch.nn.Module):
             encoder_output = projector_model(encoder_output, window_index)
         if isinstance(encoder_output, (tuple, list)):
             encoder_output = encoder_output[0]
-        input_embeds = input_embeds + encoder_output.sum() * 0.0
-        return input_embeds
+        return _DummyEncoderPassthrough.apply(input_embeds, encoder_output)
 
 
 def _load_state_dict_hook_ignore_param_names(

--- a/loongforge/tokenizer/tokenization_hf.py
+++ b/loongforge/tokenizer/tokenization_hf.py
@@ -3,6 +3,7 @@
 
 """auto tokenizer"""
 
+import logging
 from typing import Dict, List, Union, Optional
 
 from transformers import AutoTokenizer
@@ -40,6 +41,16 @@ class AutoTokenizerFromHF(MegatronLegacyTokenizer):
             trust_remote_code=True,
             **kwargs,
         )
+        # Some trust_remote_code tokenizers (e.g. Kimi K2.6) emit a logger.warning
+        # on every encode() call that passes kwargs (add_special_tokens=False, ...).
+        # The HFChatTemplate chunk-tokenization fallback invokes encode() once per
+        # chunk, which on packed multi-turn data floods the log with thousands of
+        # identical warnings and slows I/O. The fallback itself works correctly, so
+        # silence that module's logger. Only acts when no explicit level was set
+        # upstream (so debug overrides still win).
+        _mod_logger = logging.getLogger(self.tokenizer.__class__.__module__)
+        if _mod_logger.level == logging.NOTSET:
+            _mod_logger.setLevel(logging.ERROR)
 
     def tokenize(self, text: str, **kwargs) -> List[int]:
         """tokenize text

--- a/loongforge/train/arguments.py
+++ b/loongforge/train/arguments.py
@@ -213,18 +213,62 @@ def _add_extra_bridge_args(parser):
     """Add bridge arguments"""
     group = parser.add_argument_group(title='extra-bridge')
 
-    # Arguments for defining manner of converting FP8 checkpoint
-    group.add_argument('--fp8_force_no_requant', action='store_true',
+    # Arguments for defining manner of converting FP8 checkpoint.
+    # Both kebab-case and snake_case option strings are registered so callers
+    # may use either convention (Megatron args are typically kebab, convert-tool
+    # args are snake_case).
+    group.add_argument('--fp8-force-no-requant', '--fp8_force_no_requant', dest='fp8_force_no_requant',
+                       action='store_true',
                        help=("If enabled, in converting FP8 checkpoint, skip the `dequantize + re-quantize`, "
                              "directly chunk/concate the quantized data.")
     )
-    group.add_argument('--force_pow_2_scales', action='store_true',
+    group.add_argument('--force-pow-2-scales', '--force_pow_2_scales', dest='force_pow_2_scales',
+                       action='store_true',
                        help=("Define whether to force destination checkpoint's scale to be power-of-two.")
     )
-    group.add_argument('--amax_epsilon', type=float, default=0.0,
+    group.add_argument('--amax-epsilon', '--amax_epsilon', dest='amax_epsilon',
+                       type=float, default=0.0,
                        help=("Epsilon value added to the amax calculation to avoid divised by zero "
                              "when converting to FP8. Only used in Transformer Engine FP8 conversion.")
     )
+
+    # Arguments for online dequantization of compressed-tensors INT4 HF checkpoints
+    # during Bridge online loading (load_hf_checkpoint_online). Mirrors the offline
+    # convert-tool flags in tools/convert_checkpoint/arguments.py so that INT4-quantized
+    # HF weights (e.g. Kimi K2.6) can be loaded directly without offline conversion.
+    group.add_argument('--hf-dequantize-int4', '--hf_dequantize_int4', dest='hf_dequantize_int4',
+                       action='store_true',
+                       help=("If enabled, on-the-fly dequantize compressed-tensors packed INT4 "
+                             "weights to bf16/fp32 during HF checkpoint online loading.")
+    )
+    group.add_argument('--hf-dequantize-mxfp4', '--hf_dequantize_mxfp4', dest='hf_dequantize_mxfp4',
+                       action='store_true',
+                       help=("If enabled, on-the-fly dequantize MXFP4 packed FP4 weights "
+                             "(E2M1 two-per-byte in uint8 + per-block E8M0 scale, block_size=32, "
+                             "e.g. DeepSeek-V4 routed experts) to bf16/fp32 during HF checkpoint "
+                             "online loading.")
+    )
+    group.add_argument('--hf-dequantize-dtype', '--hf_dequantize_dtype', dest='hf_dequantize_dtype',
+                       default='bfloat16',
+                       help=("Target dtype for INT4 dequantization (bfloat16 or float32). "
+                             "Default: bfloat16")
+    )
+    group.add_argument('--hf-quant-config-file', '--hf_quant_config_file', dest='hf_quant_config_file',
+                       default=None,
+                       help=("Path to config.json carrying the compressed-tensors quantization_config; "
+                             "used to locate the INT4-packed weight keys. Default: None")
+    )
+    # fp8 conversion args used by the mcore converter during Bridge online loading
+    # (bf16->fp8 when training is fp8). Mirrors tools/convert_checkpoint/arguments.py.
+    # Defaults match TransformerEngine-based training; no need to pass explicitly.
+    group.add_argument('--quant-method', '--quant_method', dest='quant_method',
+                       default='te', choices=['te', 'pt'],
+                       help="fp8 quantization backend for bf16->fp8 conversion during bridge load. "
+                            "Default: te (TransformerEngine)")
+    group.add_argument('--pretrain-as-fp8', '--pretrain_as_fp8', dest='pretrain_as_fp8',
+                       action='store_true',
+                       help="Treat the loaded checkpoint as fp8 for pretrain (bf16 saved ckpt + pretrain fp8). "
+                            "Default: False")
     return parser
 
 

--- a/loongforge/train/training_utils.py
+++ b/loongforge/train/training_utils.py
@@ -210,6 +210,29 @@ def is_hf_checkpoint(load_path):
             os.path.exists(bin_index_path) or os.path.exists(bin_path)
 
 
+def _resolve_convert_pp_layout(model_config):
+    """Resolve ``pipeline_model_parallel_layout`` for the Bridge converter.
+
+    For pure-LLM configs the layout lives on ``model_config`` itself. For VLM
+    (OmniCombinationModel / VLMModelConfig) configs it lives on the foundation
+    sub-config, because VLMModelConfig does not carry the field at the top
+    level. Returning None here makes the converter fall back to a balanced VPP
+    partition, which disagrees with the model's custom layout and breaks
+    ``load_state_dict(strict=True)`` during bridge online loading.
+    """
+    layout = getattr(model_config, 'pipeline_model_parallel_layout', None)
+    if layout is None:
+        foundation = getattr(model_config, 'foundation', None)
+        if foundation is not None:
+            layout = getattr(foundation, 'pipeline_model_parallel_layout', None)
+    if layout is None:
+        return None
+    # Parser._build_param_dict requires convert_pp_layout.layout to be populated.
+    if getattr(layout, 'layout', None) is None:
+        return None
+    return layout
+
+
 @torch.no_grad()
 def update_ema(ema_model, model, rate=0.9999):
     """
@@ -225,8 +248,11 @@ def enable_memory_history_record(memory_snapshot_path):
     """Enable memory history record"""
     torch.cuda.memory._record_memory_history(
         True,
-        # keep 100,000 alloc/free events from before the snapshot
-        trace_alloc_max_entries=100000,
+        # keep 500,000 alloc/free events from before the snapshot (5x the old
+        # 100k) so the trace covers the full PP warmup + steady-state window;
+        # 100k was truncating early events, leaving only the tail in the pickle.
+        # ~500k events lands the dump around 60-75 MB, still cheap to move.
+        trace_alloc_max_entries=500000,
         # record stack information for the trace events
         trace_alloc_record_context=True,
     )
@@ -775,8 +801,9 @@ def get_model(
             # Temporarily set args.load for load_hf_checkpoint_online
             orig_load = args.load
             args.load = args.pretrained_checkpoint
-            if hasattr(model_config, 'pipeline_model_parallel_layout'):
-                args.convert_pp_layout = model_config.pipeline_model_parallel_layout
+            _pp_layout = _resolve_convert_pp_layout(model_config)
+            if _pp_layout is not None:
+                args.convert_pp_layout = _pp_layout
 
             # Load HF checkpoint online
             iteration, num_fp_ops = load_hf_checkpoint_online(
@@ -1159,8 +1186,14 @@ def setup_model_and_optimizer(
         assert (not args.use_megatron_fsdp), "Megatron FSDP and HF checkpoint loading cannot be used together. " \
             "Please set --use-megatron-fsdp to False."
         timers("load-checkpoint", log_level=0).start(barrier=True)
-        if hasattr(model_config, 'pipeline_model_parallel_layout'):
-            args.convert_pp_layout = model_config.pipeline_model_parallel_layout
+        _pp_layout = _resolve_convert_pp_layout(model_config)
+        if _pp_layout is not None:
+            args.convert_pp_layout = _pp_layout
+            print_rank_0("[bridge] convert_pp_layout resolved (foundation-aware for VLM); "
+                         "converter will use the model's custom VPP layer layout.")
+        else:
+            print_rank_0("[bridge] WARNING: no pipeline_model_parallel_layout on model_config or its "
+                         "foundation; converter falls back to balanced VPP (likely wrong for custom layouts).")
         args.iteration, args.num_floating_point_operations_so_far = load_hf_checkpoint_online(
             model,
             optimizer,
@@ -2575,7 +2608,7 @@ def train(
         and args.use_pytorch_profiler
     ):
         if getattr(args, 'record_memory_history', False):
-            torch.cuda.memory._record_memory_history(max_entries=100000)
+            torch.cuda.memory._record_memory_history(max_entries=500000)
         prof = torch.profiler.profile(
             schedule=torch.profiler.schedule(
                 wait=max(args.profile_step_start - 1, 0),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,7 @@ gpu = [
     "accelerate==1.12.0",
     "tokenizers==0.22.2",
     "sentencepiece>=0.2.0",
-    "safetensors==0.4.5",
+    "safetensors>=0.5.0,<1.0",  # >=0.5 required for F8_E8M0 dtype (DSV4 MXFP4 expert dequant)
     "compressed-tensors==0.15.0.1",
     "huggingface_hub==1.5.0",
     "tiktoken==0.5.2",

--- a/tools/convert_checkpoint/arguments.py
+++ b/tools/convert_checkpoint/arguments.py
@@ -95,7 +95,15 @@ def _add_checkpoint_args(parser):
     group.add_argument('--hf-dequantize-dtype', '--hf_dequantize_dtype', dest='hf_dequantize_dtype',
                        type=str, default='bfloat16',
                        choices=['bf16', 'bfloat16', 'fp16', 'float16', 'fp32', 'float32'],
-                       help='Floating dtype used for on-the-fly HF INT4 dequantization.')
+                       help='Floating dtype used for on-the-fly HF INT4/MXFP4 dequantization.')
+    group.add_argument('--hf-dequantize-mxfp4', '--hf_dequantize_mxfp4', dest='hf_dequantize_mxfp4',
+                       action='store_true',
+                       help=('When loading a HuggingFace checkpoint, materialize MXFP4 packed '
+                             'FP4 weights (E2M1 two-per-byte in uint8 + per-block E8M0 scale, '
+                             'block_size=32, e.g. DeepSeek-V4 routed experts) into floating-point '
+                             '.weight tensors before the common/mcore conversion. Only acts on '
+                             'uint8/int8 .weight tensors that have a paired .scale. Uses '
+                             '--hf-dequantize-dtype for the output dtype.'))
     group.add_argument('--hf-quant-config-file', '--hf_quant_config_file', dest='hf_quant_config_file',
                        type=str, default=None,
                        help='Optional HF config.json path for compressed-tensors quantization_config.')

--- a/tools/convert_checkpoint/huggingface/huggingface_checkpoint.py
+++ b/tools/convert_checkpoint/huggingface/huggingface_checkpoint.py
@@ -39,10 +39,18 @@ from convert_checkpoint.huggingface.compressed_tensors_dequant import (
 from convert_checkpoint.huggingface.compressed_tensors_quant import (
     pack_state_dict_from_official_config,
 )
+from convert_checkpoint.huggingface.mxfp4_dequant import (
+    dequantize_mxfp4_state_dict,
+    progress_print,
+)
 
 
 def _hf_dequantize_int4_enabled(args):
     return bool(args is not None and getattr(args, "hf_dequantize_int4", False))
+
+
+def _hf_dequantize_mxfp4_enabled(args):
+    return bool(args is not None and getattr(args, "hf_dequantize_mxfp4", False))
 
 
 def _packed_to_weight_key(key):
@@ -219,14 +227,22 @@ def merge_transformers_sharded_states(path, checkpoint_names, load_safe=False, m
     """
     if load_safe:
         from safetensors.torch import load_file
+    import time
     state_dict = {}
     current_chunks = [None] * len(checkpoint_names)
+    n_total = len(checkpoint_names)
+    done = []  # list.append is atomic under the GIL — safe as a thread counter
     def load_files(checkpoint_path, i):
+        t0 = time.perf_counter()
         if load_safe:
             current_chunks[i] = load_file(checkpoint_path, device=hf_checkpoint_device)
         else:
             current_chunks[i] = torch.load(checkpoint_path, map_location=hf_checkpoint_device, weights_only=False)
-        logging.info(f"Loaded huggingface checkpoint: {checkpoint_path}")
+        done.append(1)
+        progress_print(
+            f"[hf-load] {len(done)}/{n_total} {os.path.basename(checkpoint_path)} "
+            f"({time.perf_counter() - t0:.1f}s)"
+        )
     if max_workers is None:
         for i in range(len(checkpoint_names)):
             load_files(os.path.join(path, checkpoint_names[i]), i)
@@ -471,6 +487,57 @@ class HuggingFaceCheckpoint(AbstractCheckpoint):
             dtype_name,
         )
 
+    def _drop_unowned_expert_tensors(self, c_config, expert_ids):
+        """Drop routed-expert tensors this rank does not own.
+
+        ``expert_ids`` narrows which shard FILES are read, but shards are read
+        whole and mix all experts, so after the merge the state_dict still
+        holds every expert of the loaded layers. Under expert parallelism a
+        rank only consumes its own ``expert_ids`` (the rest are re-read by
+        their owning ranks), so drop the others right away: host memory and
+        MXFP4 dequant then scale with 1/EP instead of the full expert count
+        (DSV4-Flash: 8 ranks x full PP-stage experts dequantized to BF16
+        OOM-killed the node at ~1.7TB).
+        """
+        if expert_ids is None or c_config is None or not self.state_dict:
+            return
+        name_map = c_config.get("name_map")["huggingface"]
+        moe_expert = name_map.get(MOE_EXPERT)
+        if not moe_expert:
+            return
+        keep = {str(e) for e in expert_ids}
+        pattern = re.compile(rf"(?:^|\.){re.escape(moe_expert)}\.([0-9]+)\.")
+        dropped = 0
+        for key in list(self.state_dict.keys()):
+            m = pattern.search(key)
+            if m and m.group(1) not in keep:
+                del self.state_dict[key]
+                dropped += 1
+        if dropped:
+            progress_print(
+                f"[hf-load] EP filter: dropped {dropped} expert tensor(s) not owned "
+                f"by this rank, kept experts {min(map(int, keep))}..{max(map(int, keep))}"
+            )
+
+    def dequantize_mxfp4_if_needed(self, target_weight_keys=None):
+        """On-the-fly MXFP4 (E2M1 + E8M0) packed FP4 -> floating-point materialization."""
+        if not _hf_dequantize_mxfp4_enabled(self.args):
+            return
+
+        dtype_name = getattr(self.args, "hf_dequantize_dtype", "bfloat16")
+        try:
+            output_dtype = HF_DEQUANT_DTYPE_MAP[dtype_name.lower()]
+        except KeyError as exc:
+            raise ValueError(f"Unsupported --hf-dequantize-dtype: {dtype_name}") from exc
+
+        converted = dequantize_mxfp4_state_dict(
+            self.state_dict,
+            output_dtype=output_dtype,
+            target_weight_keys=target_weight_keys,
+        )
+        progress_print(
+            f"[mxfp4-dequant] done: materialized {converted} packed FP4 weight(s) to {dtype_name}."
+        )
 
     def load(self, load_path, load_safe=False, c_config=None, layer_ids=[], expert_ids=None, mtp_num_layers=0):
         """ load ckpt """
@@ -523,6 +590,18 @@ class HuggingFaceCheckpoint(AbstractCheckpoint):
                 logging.info(f"merge_transformers_sharded_states: {load_path}")
 
 
+        # EP filter must run before the dequant hooks so per-rank memory and
+        # dequant work scale with 1/EP.
+        self._drop_unowned_expert_tensors(c_config, expert_ids)
+
+        self.dequantize_compressed_tensors_if_needed(load_path, target_weight_keys=dequant_weight_keys)
+        # MXFP4 dequant must run before the DSV4 `.scale` -> `.weight_scale_inv`
+        # rename below: it matches routed-expert scale companions by the raw
+        # `.scale` suffix and pops them once consumed. If the rename ran first,
+        # the pairing key would already be gone and the packed MXFP4 weights
+        # would reach mcore conversion still as int8 with a stale scale.
+        self.dequantize_mxfp4_if_needed()
+
         # DeepSeek-V4 key preprocessing: add model. prefix, rename FP8 scales,
         # restructure MTP keys, split hyper-connection scale into alpha_pre/alpha_post/alpha_res
         if (is_dsv4_hybrid_config(c_config) and self.state_dict
@@ -558,8 +637,6 @@ class HuggingFaceCheckpoint(AbstractCheckpoint):
                 new_sd[new_key] = value
             # MTP e_proj and h_proj kept separate for mcore (upstream uses them independently)
             self.state_dict = new_sd
-
-        self.dequantize_compressed_tensors_if_needed(load_path, target_weight_keys=dequant_weight_keys)
 
     def print_memory_usage(self, desc):
         import psutil

--- a/tools/convert_checkpoint/huggingface/mxfp4_dequant.py
+++ b/tools/convert_checkpoint/huggingface/mxfp4_dequant.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-the-fly MXFP4 (OCP Microscaling FP4) dequantization for HuggingFace checkpoints.
+
+DeepSeek-V4 (and similar) ship routed-expert weights as packed MXFP4:
+
+  * weight: E2M1 4-bit values, two packed per byte (safetensors dtype ``I8``).
+  * scale:  per-block E8M0 factor, one per ``block_size=32`` consecutive E2M1
+            values (safetensors dtype ``F8_E8M0``).
+
+This module materializes such weights into ordinary floating-point ``.weight``
+tensors so the downstream common/mcore conversion can treat experts as plain
+BF16/FP16 linears. It is intentionally a pure-PyTorch, element-wise + gather
+implementation — it only runs once during checkpoint bridging, so kernel-level
+throughput is not a concern.
+
+Ported from ModelOpt's ``MXFP4QTensor.dequantize``
+(``modelopt.torch.quantization.qtensor.mxfp4_tensor``), flattened to stateless
+functions and inlined here to avoid pulling ModelOpt in as a LoongForge dep.
+"""
+
+import logging
+import time
+from typing import Iterable, Optional
+
+import torch
+
+__all__ = ["dequantize_mxfp4", "dequantize_mxfp4_state_dict", "progress_print"]
+
+LOGGER = logging.getLogger(__name__)
+
+
+def progress_print(message: str) -> None:
+    """Progress line visible in training logs: rank 0 only under
+    torch.distributed (all ranks print when it is not initialized, e.g. the
+    offline conversion tools). ``logging.info`` is swallowed by the default
+    WARNING threshold in the training entrypoints, so progress must use print.
+    """
+    try:
+        import torch.distributed as dist
+
+        if dist.is_available() and dist.is_initialized() and dist.get_rank() != 0:
+            return
+    except Exception:
+        pass
+    print(message, flush=True)
+
+# OCP MXFP4: 32 E2M1 values share one E8M0 block scale.
+DEFAULT_MXFP4_BLOCK_SIZE = 32
+
+# E2M1 representable magnitudes indexed by the 3 magnitude bits (bit2..0).
+_E2M1_MAGNITUDES = (0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0)
+
+# E8M0 is exponent-only with bias 127: effective scale = 2 ** (raw_uint - 127).
+_E8M0_BIAS = 127
+
+# 8-bit signed/unsigned integer dtypes whose raw bytes can be reinterpreted as
+# uint8 for nibble / bit operations. safetensors ``I8`` loads as torch.int8.
+_UINT8_VIEW_COMPATIBLE = (torch.uint8, torch.int8)
+
+# Float8 dtypes safetensors may hand us for E8M0 / E4M3 scales (torch >= 2.1).
+try:
+    _FLOAT8_DTYPES = (torch.float8_e8m0fnu, torch.float8_e4m3fn, torch.float8_e5m2)
+except AttributeError:  # torch < 2.1 has no float8 dtypes
+    _FLOAT8_DTYPES = ()
+
+
+def _as_uint8(tensor: torch.Tensor, name: str) -> torch.Tensor:
+    """Reinterpret an 8-bit tensor's raw bytes as uint8 without copying.
+
+    Accepts uint8/int8 (safetensors ``I8``) and the float8 dtypes safetensors may
+    use for E8M0 scales. The bit-level unpack below is defined on the unsigned
+    byte, so we view rather than cast — no values are rounded or sign-extended.
+    """
+    if tensor.dtype == torch.uint8:
+        return tensor
+    if tensor.dtype in _UINT8_VIEW_COMPATIBLE or tensor.dtype in _FLOAT8_DTYPES:
+        return tensor.view(torch.uint8)
+    raise TypeError(
+        f"{name}: expected an 8-bit packed/scale dtype "
+        f"(uint8/int8/float8_e8m0fnu/e4m3fn/e5m2), got {tensor.dtype}."
+    )
+
+
+def dequantize_mxfp4(
+    weight: torch.Tensor,
+    scale: torch.Tensor,
+    block_size: int = DEFAULT_MXFP4_BLOCK_SIZE,
+    dtype: torch.dtype = torch.bfloat16,
+    compute_device: Optional[str] = None,
+) -> torch.Tensor:
+    """Dequantize a single MXFP4 packed tensor (E2M1 in uint8 + E8M0 block scale).
+
+    Args:
+        weight: packed E2M1 weights, two values per byte. Any leading dims; the
+            last dim is the contraction (in_features) axis stored as
+            ``in_features // 2`` bytes. Accepted as uint8/int8 (safetensors ``I8``)
+            — reinterpreted, not rounded.
+        scale: per-block E8M0 scale of shape ``... x (in_features // block_size)``.
+            Accepted as uint8/int8/float8_e8m0fnu (safetensors ``F8_E8M0``).
+        block_size: E2M1 values covered by one block scale. OCP MXFP4 = 32.
+        dtype: output dtype (bf16/fp16/fp32).
+        compute_device: optional device to route the computation through (e.g.
+            ``"cuda"``). The packed tensors are copied there, dequantized, and
+            the result is copied back to the input device — the state dict
+            stays host-resident, only ~a few tens of MB transit the GPU at a
+            time. All ops involved (bit masks, LUT gather, exp2, mul, bf16
+            round) are exact/IEEE, so the result is bit-identical to the CPU
+            path. None = compute in place on the input device.
+
+    Returns:
+        Dequantized tensor of shape ``... x in_features`` in ``dtype``, on the
+        input's original device.
+    """
+    out_device = weight.device
+    weight = _as_uint8(weight.contiguous(), "weight")
+    scale = _as_uint8(scale.contiguous(), "scale")
+    if compute_device is not None and torch.device(compute_device) != out_device:
+        weight = weight.to(compute_device)
+        scale = scale.to(compute_device)
+
+    out_last = weight.shape[-1] * 2
+    scale_last = scale.shape[-1]
+    if out_last != scale_last * block_size:
+        raise ValueError(
+            f"MXFP4 shape mismatch: weight unpacked last dim {out_last} != "
+            f"scale last dim {scale_last} * block_size {block_size}."
+        )
+    if list(weight.shape[:-1]) != list(scale.shape[:-1]):
+        raise ValueError(
+            f"MXFP4 shape mismatch: weight leading dims {list(weight.shape[:-1])} "
+            f"!= scale leading dims {list(scale.shape[:-1])}."
+        )
+
+    # 1) Split each byte into its two E2M1 nibbles -> uint4 indices (last dim x2).
+    low_nibble = weight & 0x0F
+    high_nibble = (weight >> 4) & 0x0F
+    idx = torch.empty(
+        weight.shape[:-1] + (out_last,), dtype=torch.uint8, device=weight.device
+    )
+    idx[..., 0::2] = low_nibble
+    idx[..., 1::2] = high_nibble
+
+    # 2) Map each 4-bit pattern (sign | 3 magnitude bits) -> float via E2M1 LUT.
+    lut = torch.tensor(_E2M1_MAGNITUDES, device=weight.device, dtype=torch.float32)
+    magnitude_bits = (idx & 0b0111).to(torch.long)
+    values = lut[magnitude_bits]
+    sign = 1.0 - 2.0 * ((idx & 0b1000) >> 3).to(torch.float32)
+    x = sign * values
+
+    # 3) Apply per-block E8M0 scale: effective = 2 ** (raw_uint - 127).
+    sf = torch.exp2(scale.to(torch.float32) - _E8M0_BIAS)
+    x = x.reshape(-1, block_size) * sf.reshape(-1, 1)
+    # Cast to the target dtype before the device copy-back so only half the
+    # bytes cross PCIe when routed through a GPU.
+    return x.reshape(idx.shape).to(dtype).to(out_device)
+
+
+def dequantize_mxfp4_state_dict(
+    state_dict: dict,
+    output_dtype: torch.dtype = torch.bfloat16,
+    target_weight_keys: Optional[Iterable[str]] = None,
+    block_size: int = DEFAULT_MXFP4_BLOCK_SIZE,
+    compute_device: Optional[str] = "auto",
+) -> int:
+    """Materialize MXFP4 (E2M1 + E8M0) expert weights in-place into ``output_dtype``.
+
+    A key pair matches when ``<base>.weight`` is an 8-bit int dtype (uint8/int8)
+    AND a companion ``<base>.scale`` exists. On match the dequantized tensor
+    replaces ``<base>.weight`` and ``<base>.scale`` is dropped, so downstream
+    conversion sees a plain floating-point linear. BF16/FP8 weights and any
+    tensor without a paired ``.scale`` are left untouched.
+
+    Args:
+        state_dict: HF state dict to mutate in place.
+        output_dtype: target dtype for the materialized weight.
+        target_weight_keys: optional allow-list of ``<base>.weight`` keys to
+            convert (e.g. only routed-expert weights). Entries that are not
+            8-bit or lack a ``.scale`` are silently skipped. If None, every
+            matching uint8/int8 ``.weight`` + ``.scale`` pair is converted.
+        block_size: MXFP4 block size (default 32).
+        compute_device: device to route per-tensor dequant math through.
+            ``"auto"`` (default) uses the current CUDA device when available —
+            ~200x faster than CPU at DSV4 expert sizes — falling back to the
+            tensors' own device otherwise. Results are bit-identical either
+            way; the state dict itself stays on its original (host) device.
+
+    Returns:
+        Number of tensors dequantized.
+    """
+    if compute_device == "auto":
+        compute_device = "cuda" if torch.cuda.is_available() else None
+    if target_weight_keys is None:
+        weight_keys = sorted(
+            k
+            for k in state_dict
+            if k.endswith(".weight")
+            and state_dict[k].dtype in _UINT8_VIEW_COMPATIBLE
+            and f"{k[:-len('.weight')]}.scale" in state_dict
+        )
+    else:
+        weight_keys = []
+        missing = []
+        for weight_key in sorted(target_weight_keys):
+            if not weight_key.endswith(".weight"):
+                raise ValueError(
+                    f"MXFP4 dequant target must end with '.weight', got: {weight_key}"
+                )
+            if weight_key not in state_dict:
+                missing.append(weight_key)
+                continue
+            if state_dict[weight_key].dtype not in _UINT8_VIEW_COMPATIBLE:
+                continue  # not MXFP4 (already float / FP8) — skip silently
+            scale_key = f"{weight_key[:-len('.weight')]}.scale"
+            if scale_key not in state_dict:
+                continue
+            weight_keys.append(weight_key)
+        if missing:
+            preview = ", ".join(missing[:5])
+            suffix = "" if len(missing) <= 5 else f", ... ({len(missing)} total)"
+            raise KeyError(
+                "MXFP4 dequant targeted weight(s) not loaded in state_dict: "
+                f"{preview}{suffix}"
+            )
+
+    if not weight_keys:
+        return 0
+
+    total = len(weight_keys)
+    progress_interval = max(1, total // 20)
+    start = time.perf_counter()
+    progress_print(
+        f"[mxfp4-dequant] start: {total} packed weight(s) -> {output_dtype} "
+        f"(compute on {compute_device or 'input device'})"
+    )
+
+    converted = 0
+    for weight_key in weight_keys:
+        base = weight_key[: -len(".weight")]
+        scale_key = f"{base}.scale"
+        tensor = dequantize_mxfp4(
+            state_dict[weight_key],
+            state_dict[scale_key],
+            block_size=block_size,
+            dtype=output_dtype,
+            compute_device=compute_device,
+        )
+        state_dict[weight_key] = tensor.contiguous()
+        state_dict.pop(scale_key, None)
+        converted += 1
+        if converted == total or converted % progress_interval == 0:
+            elapsed = time.perf_counter() - start
+            eta = elapsed / converted * (total - converted)
+            progress_print(
+                f"[mxfp4-dequant] {converted}/{total} ({converted / total:.0%}), "
+                f"elapsed {elapsed / 60:.1f}m, ETA {eta / 60:.1f}m"
+            )
+
+    if converted and compute_device is not None and str(compute_device).startswith("cuda"):
+        # Return the transient dequant buffers to the allocator pool before
+        # training-time allocations begin.
+        torch.cuda.empty_cache()
+
+    return converted

--- a/tools/convert_checkpoint/utils/utils.py
+++ b/tools/convert_checkpoint/utils/utils.py
@@ -579,7 +579,9 @@ def get_etp_map(tp, ep, etp):
     return etp_to_tp_mapping, tp_to_ep
 
 def is_power_of_two(x):
-    return bool(((x.view(torch.int32) & 0x007FFFFF) == 0).all())
+    x = x.float()
+    mantissa, _ = torch.frexp(x)
+    return bool(((x > 0) & (mantissa == 0.5)).all())
 
 def get_quantizer_with_weight_scale_inv(weight, weight_scale_inv, dtype, amax_epsilon=False):
     from transformer_engine.pytorch.tensor.float8_blockwise_tensor import Float8BlockQuantizer

--- a/tools/data_preprocess/vlm/offline_packing/configs/config_256k.yaml
+++ b/tools/data_preprocess/vlm/offline_packing/configs/config_256k.yaml
@@ -1,0 +1,71 @@
+
+# Data path configuration
+data:
+  # WDS-native input. The directory must contain uncompressed pretrain-*.tar shards.
+  input_format: "wds"
+  wds_dir: "/path/to/wds"
+  # Text field name
+  template_text_key: "texts"
+  # Packed wds dataset
+  packed_wds_dir: "/path/to/save/packed_wds"
+  # Directory for manifest, token reports, bins and pack_plan
+  work_dir: "/path/to/save/packed_wds/logs"
+
+model:
+  model_type: "kimi-k2.5"
+  # Use auto_processor for VLM datasets. auto_tokenizer is useful for text-only smoke tests.
+  processor_loader: "auto_tokenizer"
+  use_hf_chat_template: true
+  chat_template_path: "/path/to/chat_template.jinja"
+  chat_template_kwargs:
+    thinking: false
+  processor_kwargs:
+    pretrained_model_name_or_path: "/path/to/official/huggingface_checkpoint/Kimi-k25"
+    min_pixels: 3136   # 4*28*28
+    max_pixels: 4014080 # 5120*28*28(4014080,8192)
+    trust_remote_code: True
+    use_fast: False
+
+# Media file preprocessing configuration, optional preprocessing functions are defined in wds_pack/media/preprocess.py
+media_preprocess:
+  image: custom_image_preprocess
+
+sample:
+  # Max length of training data tokens (256k)
+  max_token_len: 262144
+  # Determine parsing method
+  sample_type: packed_chat_mix
+
+packing:
+  # WDS-native production default. It keeps all valid samples and lets training
+  # pad non-exact bins instead of spending hours searching for exact 64k fills.
+  algorithm: "best_fit_decreasing"
+  # BFD compact plans are generated from the manifest and are re-checked when
+  # WDS is written, so Step 3 does not need another expensive manifest scan.
+  validate_pack_plan: false
+
+artifacts:
+  # Production keeps only artifacts required to resume/audit the packed dataset.
+  debug_artifacts: false
+  keep_intermediate: false
+
+packed_wds:
+  maxsize: 2000000000
+  maxcount: 1000000000
+
+# Parallel processing parameters
+process:
+  # Number of source tar shards scanned in parallel. Keep low when the processor is memory-heavy.
+  workers: 8
+  # Optional smoke-test limit for source shards; 0 means all shards.
+  max_shards: 0
+  # Chunk size for samples processed by each process
+  chunk_size: 5000
+  # Batch size for merge parameters (sorting)
+  merge_batch_size: 20
+  # Timeout setting (estimated based on data volume, 1M data ~ 45 minutes / 2700s)
+  time_out: 2000
+
+# Logging and temporary files
+log:
+  level: "INFO"

--- a/tools/dist_checkpoint/checkpoint/hf_checkpoint_converter.py
+++ b/tools/dist_checkpoint/checkpoint/hf_checkpoint_converter.py
@@ -41,7 +41,10 @@ class HfCheckpointConverter:
         self.args.fp8_force_no_requant = parallel_config.fp8_force_no_requant
         self.args.force_pow_2_scales = parallel_config.force_pow_2_scales
         self.args.amax_epsilon = parallel_config.amax_epsilon
+        self.args.quant_method = parallel_config.quant_method
+        self.args.pretrain_as_fp8 = parallel_config.pretrain_as_fp8
         self.args.hf_dequantize_int4 = parallel_config.hf_dequantize_int4
+        self.args.hf_dequantize_mxfp4 = parallel_config.hf_dequantize_mxfp4
         self.args.hf_dequantize_dtype = parallel_config.hf_dequantize_dtype
         self.args.hf_quant_config_file = parallel_config.hf_quant_config_file
         self.args.mtp_num_layers = parallel_config.mtp_num_layers
@@ -98,6 +101,10 @@ class HfCheckpointConverter:
             self.hf_ckpt.load(ckpt_path, self.args.safetensors, self.config, self.layer_ids, expert_ids=expert_ids,
                          mtp_num_layers=self.args.mtp_num_layers)
             c_ckpt = self.hf_ckpt.convert_to_common(cur_layer_dict, expert_dict=self.expert_dict)
+            # HF-format tensors are no longer needed once converted to common;
+            # drop the dict entries so anything not aliased by c_ckpt is freed
+            # before the mcore sharding allocates its output copies.
+            self.hf_ckpt.state_dict = {}
             no_encoder: bool = self.vision_patch_config is None or (not self.args.enable_full_hetero_dp and p > 0)
             if no_encoder:
                 mcore_dict[p] = self.m_ckpt.convert_from_common(

--- a/tools/dist_checkpoint/checkpoint/hf_checkpoint_loader.py
+++ b/tools/dist_checkpoint/checkpoint/hf_checkpoint_loader.py
@@ -174,18 +174,10 @@ def load_hf_checkpoint_online(
 
     print_rank_0("Processing HF checkpoint...")
 
-    # Load HF checkpoint
-    print_rank_0(f"Loading HF checkpoint from {args.load}...")
-    mem_before = 0.0
-    if torch.cuda.is_available():
-        mem_before = torch.cuda.memory_allocated() / (1024 ** 3)
-        torch.cuda.reset_peak_memory_stats()
-    if torch.cuda.is_available():
-        peak_mem_gb = torch.cuda.max_memory_allocated() / (1024 ** 3)
-        mem_after = torch.cuda.memory_allocated() / (1024 ** 3)
-        print_rank_0(f"HF checkpoint loaded successfully. Memory: Before={mem_before:.2f}GB → Peak={peak_mem_gb:.2f}GB → After={mem_after:.2f}GB, Change={mem_after-mem_before:+.2f}GB")
-    else:
-        print_rank_0("HF checkpoint loaded successfully")
+    # All real work (safetensors shard reads, MXFP4 dequant, HF->Mcore
+    # sharding) happens inside get_mcore_ckpt below; rank 0 emits
+    # [hf-load] / [mxfp4-dequant] progress lines during it.
+    print_rank_0(f"Converting HF checkpoint from {args.load} (shard reads + dequant + Mcore sharding)...")
 
     # Convert to Mcore format
     mem_before = 0.0
@@ -258,6 +250,21 @@ def load_hf_checkpoint_online(
 
     if optimizer is not None:
         optimizer.reload_model_params()
+
+    # Free the bridge-time host copies now that the weights live in the model:
+    # the HF state_dict (~40GB/rank after MXFP4 dequant), the common/mcore
+    # intermediate dicts, and the per-rank shard. With 8 ranks per node these
+    # add up to hundreds of GB that would otherwise stay resident through
+    # training — and get COW-materialized by forked dataloader workers
+    # (rank got SIGKILLed by the host OOM killer during step 0 before this).
+    import gc
+    hf_converter.hf_ckpt.state_dict = {}
+    del model_state_dict
+    del current_rank_state_dict
+    del mcore_dict
+    del hf_converter
+    gc.collect()
+    print_rank_0("Bridge-time host buffers released.")
 
     # Step 8: Synchronize all ranks
     print_rank_0("Synchronizing all ranks...")

--- a/tools/dist_checkpoint/config/parallel_config.py
+++ b/tools/dist_checkpoint/config/parallel_config.py
@@ -29,7 +29,10 @@ class ParallelConfig:
     fp8_force_no_requant: bool = False
     force_pow_2_scales: bool = False
     amax_epsilon: float = 0.0
+    quant_method: str = "te"
+    pretrain_as_fp8: bool = False
     hf_dequantize_int4: bool = False
+    hf_dequantize_mxfp4: bool = False
     hf_dequantize_dtype: str = "bfloat16"
     hf_quant_config_file: Optional[str] = None
     mtp_num_layers: int = 0

--- a/tools/dist_checkpoint/core/parser.py
+++ b/tools/dist_checkpoint/core/parser.py
@@ -138,8 +138,19 @@ class Parser:
         param_dict['max_workers'] = getattr(args, 'max_workers', 1) #
         param_dict['fp8_force_no_requant'] = getattr(args, 'fp8_force_no_requant', False) # 
         param_dict['force_pow_2_scales'] = getattr(args, 'force_pow_2_scales', False) # 
-        param_dict['amax_epsilon'] = getattr(args, 'amax_epsilon', 0.0) # 
+        param_dict['amax_epsilon'] = getattr(args, 'amax_epsilon', 0.0) #
         # ============================================================================
+
+        # INT4 dequantization for Bridge online HF loading (also defined as training
+        # CLI args in loongforge/train/arguments.py::_add_extra_bridge_args).
+        param_dict['hf_dequantize_int4'] = getattr(args, 'hf_dequantize_int4', False)
+        param_dict['hf_dequantize_mxfp4'] = getattr(args, 'hf_dequantize_mxfp4', False)
+        param_dict['hf_dequantize_dtype'] = getattr(args, 'hf_dequantize_dtype', 'bfloat16')
+        param_dict['hf_quant_config_file'] = getattr(args, 'hf_quant_config_file', None)
+        # fp8 conversion method used by mcore converter (bf16->fp8 during bridge load
+        # when training is fp8). Default 'te' matches TransformerEngine-based training.
+        param_dict['quant_method'] = getattr(args, 'quant_method', 'te')
+        param_dict['pretrain_as_fp8'] = getattr(args, 'pretrain_as_fp8', False)
 
         param_dict['mtp_num_layers'] = getattr(args, 'mtp_num_layers', None)
 
@@ -157,7 +168,9 @@ class Parser:
             'moe_grouped_gemm', 'vpp_scheduler', 'tp_ranks', 'pp_ranks', 'ep_ranks',
             'etp_ranks', 'safetensors', 'custom_pipeline_layers',
             'max_workers', 'fp8_force_no_requant', 'force_pow_2_scales',
-            'amax_epsilon', 'mtp_num_layers', 'lora_alpha', 'lora_dim', 'enable_full_hetero_dp'
+            'amax_epsilon', 'mtp_num_layers', 'lora_alpha', 'lora_dim', 'enable_full_hetero_dp',
+            'hf_dequantize_int4', 'hf_dequantize_mxfp4', 'hf_dequantize_dtype', 'hf_quant_config_file',
+            'quant_method', 'pretrain_as_fp8',
         ]
 
         for field in parallel_fields:


### PR DESCRIPTION
## Summary
- Add on-the-fly dequantization for packed INT4 (compressed-tensors) and MXFP4
  (OCP E2M1+E8M0) HuggingFace checkpoint weights during Bridge online loading,
  so quantized checkpoints (e.g. Kimi K2.6, DeepSeek-V4 routed experts) load
  directly without an offline conversion step.
- Add several host-memory optimizations to the Bridge/HF checkpoint path
  (drop EP-unowned expert tensors early, free intermediate state dicts once
  consumed, clone scattered sequence-parallel embeddings) that were causing
  OOM kills on large MoE models.
- Add Kimi K2.6 bf16 training config + SFT chat template, plus a couple of
  correctness fixes found along the way.

## Changes
- `tools/convert_checkpoint/huggingface/mxfp4_dequant.py` (new): standalone
  MXFP4 (E2M1 nibble-packed weight + E8M0 block scale) dequantization,
  inlined from ModelOpt's `MXFP4QTensor.dequantize` to avoid a new dependency.
- `tools/convert_checkpoint/huggingface/huggingface_checkpoint.py`: wires up
  `dequantize_mxfp4_if_needed`, drops experts not owned by the current EP
  rank before dequant/conversion, adds shard-load progress logging.
- `tools/dist_checkpoint/checkpoint/{hf_checkpoint_loader,hf_checkpoint_converter}.py`,
  `config/parallel_config.py`, `core/parser.py`: plumb new
  `hf_dequantize_mxfp4` / `quant_method` / `pretrain_as_fp8` options through
  the Bridge config/parser; free host-side HF/common/mcore intermediate
  state dicts right after use to cut peak host memory.
- `loongforge/train/arguments.py`, `tools/convert_checkpoint/arguments.py`:
  new `--hf-dequantize-mxfp4`, `--quant-method`, `--pretrain-as-fp8` args
  (kebab-case + legacy snake_case both accepted).
- `loongforge/train/training_utils.py`: resolve `pipeline_model_parallel_layout`
  from the VLM foundation sub-config too, so Bridge loading uses the model's
  real custom VPP layout instead of silently falling back to a balanced one;
  bump memory-history trace buffer 100k → 500k entries.
- `loongforge/models/omni_models/omni_combination_model.py`: clone the
  sequence-parallel scatter output (guarded by
  `clone_scatter_output_in_embedding`) so the full-sequence embedding tensor
  can be freed instead of kept alive by a view.
- `loongforge/models/omni_models/omni_encoder_model.py`: replace a
  `.sum() * 0.0` zero-grad trick (allocated a full `[seq, hidden]` copy per
  call, ~3.5GB at 256k seq length) with an autograd `Function` passthrough.
- `tools/convert_checkpoint/utils/utils.py`: `is_power_of_two` now uses
  `torch.frexp` instead of reinterpreting float32 bits, so it's correct for
  bf16/fp16 tensors too.
- `loongforge/tokenizer/tokenization_hf.py`: silence a `trust_remote_code`
  tokenizer's per-call logging warning that floods logs on packed
  multi-turn data.
- `configs/models/kimi_k2.6/kimi_k2_6_bf16.yaml`,
  `configs/models/kimi_k2/ckpt_convert/kimi_k2_convert_bf16.yaml` (new):
  Kimi K2.6 bf16 training config + a bf16 (non-FP8-requant) checkpoint
  convert variant — the FP8 requant path hits a `pow_2_scale` assertion on
  Blackwell when FP8 training is off.
- `loongforge/data/chat_template.py`,
  `loongforge/data/chat_templates/kimi_k2_7_code_training.jinja` (new):
  registers a Kimi K2.7-Code SFT template with `{% generation %}` markers
  for assistant-only loss masking.
- `tools/data_preprocess/vlm/offline_packing/configs/config_256k.yaml` (new):
  256k-context offline packing example config for Kimi K2.5-style data.
- `pyproject.toml`: bump `safetensors` to `>=0.5.0,<1.0` (required for the
  `F8_E8M0` dtype used by MXFP4 scales).

## Test Plan
- Ported as-is from internal CR aiak-train-2213, which was already reviewed,
  passed internal CI (pipeline: SUCCESS), and merged internally.
- No additional local testing performed as part of this port — recommend
  running the relevant Kimi K2.6 / checkpoint-conversion E2E config(s) from
  `tests/` before merging, since internal CI covers the internal repo's
  matrix, not this one.

## Model Info
- **Model family:** kimi_k2 (K2.5/K2.6 support already present on `master`;
  this PR adds a bf16 training variant + a code-SFT chat template)
- **Training phases:** pretrain / sft