### PR TITLE
fix bug: add "adapter.layernorm.bias" key mapping when converting mcore to HF for qwen_mlp_adapter

### DIFF
--- a/configs/models/image_projector/ckpt_convert/qwen_mlp_adapter_convert.yaml
+++ b/configs/models/image_projector/ckpt_convert/qwen_mlp_adapter_convert.yaml
@@ -8,6 +8,7 @@ defaults:
 
 # Adapter configuration
 adapter.layernorm.weight: visual.merger.ln_q.weight
+adapter.layernorm.bias: visual.merger.ln_q.bias
 adapter.linear_fc1.weight: visual.merger.mlp.0.weight
 adapter.linear_fc1.bias: visual.merger.mlp.0.bias
 adapter.linear_fc2.weight: visual.merger.mlp.2.weight


### PR DESCRIPTION
### Describe the bug:

You forget to add "adapter.layernorm.bias" key mapping, or else some weights of xxx were not initialized from the model checkpoint at yyy and are newly initialized: ['model.visual.merger.ln_q.bias'] when loading HF model. And the decoding output may be strange like the following:

```
[vlm-infer] 2026-07-19 14:33:35 generation finished in 51.8s
[vlm-infer] 2026-07-19 14:33:35 decoding output
İslâm
 İslâm
 İslâm
 İslâm一生命生命任何生命生命生命任何我我任何我我我我我我我夕夕
夕夕
我夕夕
夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕 之夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕 之夕夕夕 之夕夕夕夕夕夕夕夕夕夕夕 之夕夕夕 之夕夕夕夕夕夕夕 之夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕夕
[vlm-infer] 2026-07-19 14:33:35 done in 76.4s
```