### PR TITLE
[vlm, ckpt] fix: separate Qwen2-VL adapter conversion

### DIFF
--- a/configs/models/image_projector/ckpt_convert/qwen2_vl_mlp_adapter_convert.yaml
+++ b/configs/models/image_projector/ckpt_convert/qwen2_vl_mlp_adapter_convert.yaml
@@ -1,0 +1,19 @@
+hydra:
+  searchpath:
+    - file://${oc.env:LOONGFORGE_PATH}/configs/models/
+
+defaults:
+  - image_projector@module: ???
+  - _self_
+
+# Qwen2-VL adapter configuration
+adapter.layernorm.weight: visual.merger.ln_q.weight
+adapter.layernorm.bias: visual.merger.ln_q.bias
+adapter.linear_fc1.weight: visual.merger.mlp.0.weight
+adapter.linear_fc1.bias: visual.merger.mlp.0.bias
+adapter.linear_fc2.weight: visual.merger.mlp.2.weight
+adapter.linear_fc2.bias: visual.merger.mlp.2.bias
+
+name_map:
+  mcore:
+    layer_prefix: adapter. # don't remove the dot

--- a/configs/models/image_projector/qwen2_vl_mlp_adapter.yaml
+++ b/configs/models/image_projector/qwen2_vl_mlp_adapter.yaml
@@ -1,0 +1,8 @@
+_target_: loongforge.models.encoder.MLPAdapterConfig
+
+# Qwen2-VL uses LayerNorm for visual.merger.ln_q.
+normalization: "LayerNorm"
+add_bias_linear: True
+model_type: "qwen2_vl_adapter"
+
+convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen2_vl_mlp_adapter_convert.yaml

--- a/tests/test_qwen_vl_projector_configs.py
+++ b/tests/test_qwen_vl_projector_configs.py
@@ -1,0 +1,36 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import yaml
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PROJECTOR_CONFIG_DIR = REPO_ROOT / "configs" / "models" / "image_projector"
+
+
+def _load_yaml(path: Path) -> dict:
+    with path.open(encoding="utf-8") as stream:
+        return yaml.safe_load(stream)
+
+
+def test_qwen2_vl_and_qwen2_5_vl_use_separate_norm_mappings():
+    qwen2_config = _load_yaml(PROJECTOR_CONFIG_DIR / "qwen2_vl_mlp_adapter.yaml")
+    qwen2_convert = _load_yaml(
+        PROJECTOR_CONFIG_DIR / "ckpt_convert" / "qwen2_vl_mlp_adapter_convert.yaml"
+    )
+    qwen2_5_config = _load_yaml(PROJECTOR_CONFIG_DIR / "qwen_mlp_adapter.yaml")
+    qwen2_5_convert = _load_yaml(
+        PROJECTOR_CONFIG_DIR / "ckpt_convert" / "qwen_mlp_adapter_convert.yaml"
+    )
+
+    assert qwen2_config["normalization"] == "LayerNorm"
+    assert qwen2_config["model_type"] == "qwen2_vl_adapter"
+    assert qwen2_config["convert_file"].endswith("qwen2_vl_mlp_adapter_convert.yaml")
+    assert "adapter.layernorm.bias" in qwen2_convert
+
+    assert qwen2_5_config["normalization"] == "RMSNorm"
+    assert qwen2_5_config["model_type"] == "qwen2_5_vl_adapter"
+    assert qwen2_5_config["convert_file"].endswith("qwen_mlp_adapter_convert.yaml")
+    assert "adapter.layernorm.bias" not in qwen2_5_convert


### PR DESCRIPTION
## Summary

- add a dedicated Qwen2-VL projector config using LayerNorm
- add a Qwen2-VL checkpoint mapping that converts `visual.merger.ln_q.bias`
- keep the existing Qwen2.5-VL RMSNorm mapping unchanged and cover both formats with a regression test

## Root cause

Qwen2-VL and Qwen2.5-VL do not use the same normalization in the visual merger. Qwen2-VL uses LayerNorm with weight and bias, while Qwen2.5-VL uses RMSNorm with weight only. Adding the bias key to the shared mapping would fix Qwen2-VL but cause missing-key failures for Qwen2.5-VL checkpoints.

## Validation

- `python -m pytest -q tests/test_qwen_vl_projector_configs.py`
- `uvx pre-commit run --files configs/models/image_projector/qwen2_vl_mlp_adapter.yaml configs/models/image_projector/ckpt_convert/qwen2_vl_mlp_adapter_convert.yaml tests/test_qwen_vl_projector_configs.py`
- `git diff --cached --check`

Closes #110
Related to #109
