### PR TITLE
[vlm, ckpt] fix: align LayerNorm projector conversion configs

### DIFF
--- a/configs/models/llava_onevision/llava_onevision_1_5_4b.yaml
+++ b/configs/models/llava_onevision/llava_onevision_1_5_4b.yaml
@@ -17,3 +17,4 @@ model:
     convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/qwen3/ckpt_convert/qwen3_convert_llava.yaml
   image_projector:
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/llava_mlp_adapter_convert.yaml

--- a/configs/models/qwen3.5/qwen3_5_0_8b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_0_8b.yaml
@@ -30,6 +30,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_122b_a10b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_122b_a10b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_27b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_27b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_2b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_2b.yaml
@@ -28,6 +28,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_35b_a3b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_35b_a3b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_397b_a17b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_397b_a17b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_4b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_4b.yaml
@@ -28,6 +28,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.5/qwen3_5_9b.yaml
+++ b/configs/models/qwen3.5/qwen3_5_9b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec", 

--- a/configs/models/qwen3.6/qwen3_6_27b.yaml
+++ b/configs/models/qwen3.6/qwen3_6_27b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec",

--- a/configs/models/qwen3.6/qwen3_6_35b_a3b.yaml
+++ b/configs/models/qwen3.6/qwen3_6_35b_a3b.yaml
@@ -24,6 +24,7 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_5_vision_models.qwen3_5_vision_layer_spec",

--- a/configs/models/qwen3_vl/qwen3_vl_235b_a22b.yaml
+++ b/configs/models/qwen3_vl/qwen3_vl_235b_a22b.yaml
@@ -22,6 +22,8 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    model_type: "qwen3_vl_adapter"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_vl_vision_models.qwen3_vl_layer_spec",

--- a/configs/models/qwen3_vl/qwen3_vl_30b_a3b.yaml
+++ b/configs/models/qwen3_vl/qwen3_vl_30b_a3b.yaml
@@ -23,6 +23,8 @@ model:
   image_projector:
     activation_func: ${act:gelu}
     normalization: "LayerNorm"
+    model_type: "qwen3_vl_adapter"
+    convert_file: ${oc.env:LOONGFORGE_PATH}/configs/models/image_projector/ckpt_convert/qwen_3_mlp_adapter_convert.yaml
     bias_activation_fusion: False
     gated_linear_unit: False
     model_spec: ["loongforge.models.encoder.qwen3_vl_vision_models.qwen3_vl_layer_spec",

--- a/tests/test_qwen_vl_projector_configs.py
+++ b/tests/test_qwen_vl_projector_configs.py
@@ -7,13 +7,53 @@ import yaml
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
-PROJECTOR_CONFIG_DIR = REPO_ROOT / "configs" / "models" / "image_projector"
-QWEN3_VL_CONFIG_DIR = REPO_ROOT / "configs" / "models" / "qwen3_vl"
+MODEL_CONFIG_DIR = REPO_ROOT / "configs" / "models"
+PROJECTOR_CONFIG_DIR = MODEL_CONFIG_DIR / "image_projector"
+PROJECTOR_DEFAULT_KEY = "../../models/image_projector@model.image_projector"
+
+QWEN3_PROJECTOR_CONFIGS = {
+    "qwen3_vl": ("qwen3_vl_30b_a3b.yaml", "qwen3_vl_235b_a22b.yaml"),
+    "qwen3.5": (
+        "qwen3_5_0_8b.yaml",
+        "qwen3_5_2b.yaml",
+        "qwen3_5_4b.yaml",
+        "qwen3_5_9b.yaml",
+        "qwen3_5_27b.yaml",
+        "qwen3_5_35b_a3b.yaml",
+        "qwen3_5_122b_a10b.yaml",
+        "qwen3_5_397b_a17b.yaml",
+    ),
+    "qwen3.6": ("qwen3_6_27b.yaml", "qwen3_6_35b_a3b.yaml"),
+}
 
 
 def _load_yaml(path: Path) -> dict:
     with path.open(encoding="utf-8") as stream:
         return yaml.safe_load(stream)
+
+
+def _get_projector_preset_name(config: dict):
+    return next(
+        (
+            item[PROJECTOR_DEFAULT_KEY]
+            for item in config.get("defaults", [])
+            if isinstance(item, dict) and PROJECTOR_DEFAULT_KEY in item
+        ),
+        None,
+    )
+
+
+def _load_effective_projector(path: Path) -> dict:
+    config = _load_yaml(path)
+    preset_name = _get_projector_preset_name(config)
+    assert preset_name is not None, path
+    projector = _load_yaml(PROJECTOR_CONFIG_DIR / f"{preset_name}.yaml")
+    projector.update(config["model"]["image_projector"])
+    return projector
+
+
+def _adapter_mapping(config: dict) -> dict:
+    return {key: value for key, value in config.items() if key.startswith("adapter.")}
 
 
 def test_qwen2_vl_and_qwen2_5_vl_use_separate_norm_mappings():
@@ -37,26 +77,66 @@ def test_qwen2_vl_and_qwen2_5_vl_use_separate_norm_mappings():
     assert "adapter.layernorm.bias" not in qwen2_5_convert
 
 
-def test_qwen3_vl_configs_explicitly_use_qwen3_projector_mapping():
+def test_normalization_overrides_explicitly_bind_projector_mapping():
+    for config_path in sorted(MODEL_CONFIG_DIR.glob("*/*.yaml")):
+        config = _load_yaml(config_path)
+        preset_name = _get_projector_preset_name(config)
+        projector = config.get("model", {}).get("image_projector", {})
+
+        if preset_name is None or "normalization" not in projector:
+            continue
+
+        preset = _load_yaml(PROJECTOR_CONFIG_DIR / f"{preset_name}.yaml")
+        if projector["normalization"] != preset["normalization"]:
+            assert "convert_file" in projector, config_path.relative_to(REPO_ROOT)
+
+
+def test_qwen3_family_configs_explicitly_use_qwen3_projector_mapping():
     qwen3_convert = _load_yaml(
         PROJECTOR_CONFIG_DIR / "ckpt_convert" / "qwen_3_mlp_adapter_convert.yaml"
     )
 
-    for config_name in ("qwen3_vl_30b_a3b.yaml", "qwen3_vl_235b_a22b.yaml"):
-        config = _load_yaml(QWEN3_VL_CONFIG_DIR / config_name)
-        projector = config["model"]["image_projector"]
+    for family, config_names in QWEN3_PROJECTOR_CONFIGS.items():
+        for config_name in config_names:
+            projector = _load_effective_projector(
+                MODEL_CONFIG_DIR / family / config_name
+            )
 
-        assert projector["normalization"] == "LayerNorm", config_name
-        assert projector["model_type"] == "qwen3_vl_adapter", config_name
-        assert projector["convert_file"].endswith(
-            "qwen_3_mlp_adapter_convert.yaml"
-        ), config_name
+            assert projector["normalization"] == "LayerNorm", config_name
+            assert projector["add_bias_linear"] is True, config_name
+            assert projector["convert_file"].endswith(
+                "qwen_3_mlp_adapter_convert.yaml"
+            ), config_name
 
-    assert (
-        qwen3_convert["adapter.layernorm.weight"]
-        == "model.visual.merger.norm.weight"
+            if family == "qwen3_vl":
+                assert projector["model_type"] == "qwen3_vl_adapter", config_name
+
+    assert _adapter_mapping(qwen3_convert) == {
+        "adapter.layernorm.weight": "model.visual.merger.norm.weight",
+        "adapter.layernorm.bias": "model.visual.merger.norm.bias",
+        "adapter.linear_fc1.weight": "model.visual.merger.linear_fc1.weight",
+        "adapter.linear_fc1.bias": "model.visual.merger.linear_fc1.bias",
+        "adapter.linear_fc2.weight": "model.visual.merger.linear_fc2.weight",
+        "adapter.linear_fc2.bias": "model.visual.merger.linear_fc2.bias",
+    }
+
+
+def test_llava_onevision_config_explicitly_uses_layernorm_projector_mapping():
+    projector = _load_effective_projector(
+        MODEL_CONFIG_DIR / "llava_onevision" / "llava_onevision_1_5_4b.yaml"
     )
-    assert (
-        qwen3_convert["adapter.layernorm.bias"]
-        == "model.visual.merger.norm.bias"
+    llava_convert = _load_yaml(
+        PROJECTOR_CONFIG_DIR / "ckpt_convert" / "llava_mlp_adapter_convert.yaml"
     )
+
+    assert projector["normalization"] == "LayerNorm"
+    assert projector["add_bias_linear"] is True
+    assert projector["convert_file"].endswith("llava_mlp_adapter_convert.yaml")
+    assert _adapter_mapping(llava_convert) == {
+        "adapter.layernorm.weight": "visual.merger.ln_q.weight",
+        "adapter.layernorm.bias": "visual.merger.ln_q.bias",
+        "adapter.linear_fc1.weight": "visual.merger.mlp.0.weight",
+        "adapter.linear_fc1.bias": "visual.merger.mlp.0.bias",
+        "adapter.linear_fc2.weight": "visual.merger.mlp.2.weight",
+        "adapter.linear_fc2.bias": "visual.merger.mlp.2.bias",
+    }

--- a/tests/test_qwen_vl_projector_configs.py
+++ b/tests/test_qwen_vl_projector_configs.py
@@ -8,6 +8,7 @@ import yaml
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
 PROJECTOR_CONFIG_DIR = REPO_ROOT / "configs" / "models" / "image_projector"
+QWEN3_VL_CONFIG_DIR = REPO_ROOT / "configs" / "models" / "qwen3_vl"
 
 
 def _load_yaml(path: Path) -> dict:
@@ -34,3 +35,28 @@ def test_qwen2_vl_and_qwen2_5_vl_use_separate_norm_mappings():
     assert qwen2_5_config["model_type"] == "qwen2_5_vl_adapter"
     assert qwen2_5_config["convert_file"].endswith("qwen_mlp_adapter_convert.yaml")
     assert "adapter.layernorm.bias" not in qwen2_5_convert
+
+
+def test_qwen3_vl_configs_explicitly_use_qwen3_projector_mapping():
+    qwen3_convert = _load_yaml(
+        PROJECTOR_CONFIG_DIR / "ckpt_convert" / "qwen_3_mlp_adapter_convert.yaml"
+    )
+
+    for config_name in ("qwen3_vl_30b_a3b.yaml", "qwen3_vl_235b_a22b.yaml"):
+        config = _load_yaml(QWEN3_VL_CONFIG_DIR / config_name)
+        projector = config["model"]["image_projector"]
+
+        assert projector["normalization"] == "LayerNorm", config_name
+        assert projector["model_type"] == "qwen3_vl_adapter", config_name
+        assert projector["convert_file"].endswith(
+            "qwen_3_mlp_adapter_convert.yaml"
+        ), config_name
+
+    assert (
+        qwen3_convert["adapter.layernorm.weight"]
+        == "model.visual.merger.norm.weight"
+    )
+    assert (
+        qwen3_convert["adapter.layernorm.bias"]
+        == "model.visual.merger.norm.bias"
+    )


### PR DESCRIPTION
## What changed

- Bind Qwen3-VL, Qwen3.5, and Qwen3.6 image projectors to `qwen_3_mlp_adapter_convert.yaml` while keeping their runtime normalization as `LayerNorm`.
- Bind LLaVA-OneVision 1.5 to `llava_mlp_adapter_convert.yaml`, including its LayerNorm bias mapping.
- Keep the shared Qwen2.5-VL `qwen_mlp_adapter` preset and RMSNorm mapping unchanged.
- Expand the projector regression tests to cover all affected Qwen3-family and LLaVA configs, verify the complete adapter mappings, and reject future normalization overrides that silently inherit a converter.

## Root cause

The affected model configs select the shared Qwen2.5-VL `qwen_mlp_adapter` preset and then override only `normalization` to `LayerNorm`. The distributed checkpoint path reads the still-inherited `model.image_projector.convert_file`:

- Qwen3-VL, Qwen3.5, and Qwen3.6 inherited Qwen2.5 key names instead of `model.visual.merger.norm.{weight,bias}` and `linear_fc1/2.*`.
- LLaVA-OneVision inherited a weight-only RMSNorm mapping and therefore omitted `visual.merger.ln_q.bias`.

## Impact

Config-driven checkpoint conversion now selects the same family-specific projector mappings already used by the repository's explicit conversion scripts. This prevents missing-key failures for Qwen3-family projectors and missing LayerNorm bias parameters for LLaVA-OneVision.

## Validation

- `uv run --no-project --isolated --with pytest --with pyyaml pytest -q tests/test_qwen_vl_projector_configs.py` — 4 passed
- Hydra-composed all 13 affected/fixed Qwen3-family and LLaVA configs and verified `LayerNorm` plus the expected converter file
- `git diff --check`