### PR TITLE
Add embodied blog post and refresh homepage from latest README

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -190,6 +190,11 @@ pre,
   color: #15803d;
 }
 
+.feat-tag-embodied {
+  background: #f3e8ff;
+  color: #7e22ce;
+}
+
 .dark .feat-tag-moe {
   background: rgb(67 56 202 / 0.2);
   color: #a5b4fc;
@@ -218,6 +223,11 @@ pre,
 .dark .feat-tag-train {
   background: rgb(21 128 61 / 0.25);
   color: #86efac;
+}
+
+.dark .feat-tag-embodied {
+  background: rgb(126 34 206 / 0.25);
+  color: #e9d5ff;
 }
 
 /* Gradient-border card */
@@ -505,8 +515,49 @@ pre.cite-pre>code[class*="language-"] {
   text-align: center;
 }
 
+.prose-lf table {
+  width: 100%;
+  border-collapse: collapse;
+  margin: 1.2rem 0;
+  font-size: .92rem;
+  display: block;
+  overflow-x: auto;
+}
+
+.prose-lf thead th {
+  background: #EEF2FF;
+  color: #3730A3;
+  font-weight: 700;
+  text-align: left;
+}
+
+.prose-lf th,
+.prose-lf td {
+  border: 1px solid #E5E7EB;
+  padding: .55rem .75rem;
+  vertical-align: top;
+}
+
+.prose-lf tbody tr:nth-child(even) {
+  background: #F9FAFB;
+}
+
 .dark .prose-lf {
   color: #E5E7EB;
+}
+
+.dark .prose-lf thead th {
+  background: #1E1B4B;
+  color: #C7D2FE;
+}
+
+.dark .prose-lf th,
+.dark .prose-lf td {
+  border-color: #374151;
+}
+
+.dark .prose-lf tbody tr:nth-child(even) {
+  background: #111827;
 }
 
 .dark .prose-lf blockquote {

--- a/assets/data/posts.json
+++ b/assets/data/posts.json
@@ -1,5 +1,34 @@
 [
     {
+        "slug": "2026-07-announcing-loongforge-embodied",
+        "date": "2026-07-01",
+        "featured": false,
+        "tags_en": [
+            "LoongForge",
+            "Embodied",
+            "VLA",
+            "WAM"
+        ],
+        "tags_zh": [
+            "LoongForge",
+            "具身智能",
+            "VLA",
+            "WAM"
+        ],
+        "en": {
+            "title": "Announcing LoongForge-Embodied: a high-performance training subsystem for embodied models",
+            "author": "The LoongForge Team",
+            "summary": "LoongForge releases LoongForge-Embodied — a torch-native training subsystem for VLA and WAM models covering Pi0.5, GR00T N1.6, X-VLA, FastWAM, LingBot-VA, Cosmos3, and DreamZero, with 1.6x-2.67x training speedups over official implementations on the same hardware.",
+            "url": "blog/2026-07-announcing-loongforge-embodied.html"
+        },
+        "zh": {
+            "title": "LoongForge-Embodied 正式发布：面向具身模型的高性能训练子系统",
+            "author": "LoongForge 团队",
+            "summary": "LoongForge 正式发布 LoongForge-Embodied——面向 VLA 与 WAM 的 torch-native 训练子系统，一次覆盖 Pi0.5、GR00T N1.6、X-VLA、FastWAM、LingBot-VA、Cosmos3、DreamZero 等主流具身模型，同等硬件下相对官方实现取得 1.6×~2.67× 训练加速。",
+            "url": "blog/2026-07-announcing-loongforge-embodied.zh.html"
+        }
+    },
+    {
         "slug": "2026-06-loongforge-groot-n16-acceleration",
         "date": "2026-06-02",
         "featured": false,

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,7 +16,7 @@
       'footer.training': 'Training framework', 'footer.workflow': 'Agent framework',
 
       'hero.badge': '🐉 Part of the Baidu-Baige Loong open-source series',
-      'hero.subtitle_html': 'A <b>modular</b>, <b>scalable</b>, <b>high-performance</b> training framework for <b>LLMs</b>, <b>VLMs</b>, <b>diffusion</b>, and <b>embodied</b> models — built on Megatron-LM with native NVIDIA GPU & Kunlun XPU support',
+      'hero.subtitle_html': 'A <b>modular</b>, <b>scalable</b>, <b>high-performance</b> training framework for <b>LLMs</b>, <b>VLMs</b>, <b>diffusion</b>, and <b>embodied</b> models — multi-backend (<b>Megatron-LM</b> for LLM/VLM/diffusion, <b>torch-native DDP/FSDP</b> for embodied), with native NVIDIA GPU & Kunlun XPU support',
       'hero.cta.start': '🚀 Quick Start',
       'hero.cta.github': '⭐ View on GitHub',
       'hero.cta.docs': '📚 Read the Docs',
@@ -49,10 +49,8 @@
       'feat.cat.2.subtitle': 'Parallelism built for VLM / VLA',
       'feat.cat.2.item.1.t': 'Model Composition',
       'feat.cat.2.item.1.d': 'Swap ViT × LLM for VLMs via YAML.',
-      'feat.cat.2.item.2.t': 'Heterogeneous Parallelism',
-      'feat.cat.2.item.2.d': 'Independent TP / PP / DP per model component.',
-      'feat.cat.2.item.3.t': 'Disaggregated Training',
-      'feat.cat.2.item.3.d': 'Decoupled ViT / LLM scheduling kills pipeline bubbles.',
+      'feat.cat.2.item.2.t': 'Heterogeneous & Disaggregated',
+      'feat.cat.2.item.2.d': 'Independent TP / PP / DP per component + decoupled ViT / LLM scheduling that kills pipeline bubbles.',
       'feat.cat.2.item.4.t': 'DP Load Balancing',
       'feat.cat.2.item.4.d': 'Fixes packing-induced imbalance at cluster scale.',
 
@@ -75,6 +73,10 @@
       'feat.cat.6.title': 'Training',
       'feat.cat.6.item.1.t': 'Pretrain + SFT + LoRA',
       'feat.cat.6.item.1.d': 'One codebase covers key training stages.',
+
+      'feat.cat.7.title': 'Embodied',
+      'feat.cat.7.item.1.t': 'Embodied Training',
+      'feat.cat.7.item.1.d': 'Dedicated torch-native DDP/FSDP subsystem for VLA & WAM models, with DDP / ZeRO-1 / FSDP / HSDP.',
 
 
       'models.title': '🏛️ Supported Models',
@@ -99,14 +101,16 @@
       'qs.footer.browse_html': 'Browse <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/configs/models" target="_blank" rel="noopener"><code class="mono">configs/models/</code></a> · <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/examples" target="_blank" rel="noopener"><code class="mono">examples/</code></a> · <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/examples_xpu" target="_blank" rel="noopener"><code class="mono">examples_xpu/</code></a>',
 
       'powered.title': '🌟 Powered by LoongForge',
-      'powered.subtitle': 'Open-source projects trained on LoongForge — ordered from newest to earliest',
+      'powered.subtitle': 'Open-source models trained with LoongForge or its predecessor AIAK-Training-LLM',
       'powered.new': 'NEW',
       'powered.1.t': 'LLaVA-OneVision-2.0',
       'powered.1.d': 'Next-generation fully open multimodal model — improved data, training recipe, and scaling.',
-      'powered.2.t': 'LLaVA-OneVision-1.5',
-      'powered.2.d': 'Fully open framework for democratized multimodal training.',
-      'powered.3.t': 'Qianfan-VL',
-      'powered.3.d': 'Domain-enhanced universal vision-language models.',
+      'powered.2.t': 'Innovator-VL',
+      'powered.2.d': 'Scientific multimodal large language model for advanced reasoning.',
+      'powered.3.t': 'LLaVA-OneVision-1.5',
+      'powered.3.d': 'Fully open framework for democratized multimodal training.',
+      'powered.4.t': 'Qianfan-VL',
+      'powered.4.d': 'Domain-enhanced universal vision-language models.',
 
       'cta.title': 'Join the Community',
       'cta.desc': 'Report bugs, propose features, contribute code, or just say hi. We ❤️ community.',
@@ -143,7 +147,7 @@
       'about.ack.body': 'LoongForge is built upon NVIDIA\'s Megatron-LM. We also referenced and drew inspiration from excellent open-source projects including Transformers, LLaMA-Factory, and Megatron-Bridge. We sincerely thank these communities for their outstanding contributions.',
 
       'bench.title': '📊 Benchmark',
-      'bench.subtitle': 'Measured on latest LoongForge across LLM, VLM, VLA, and DIT workloads',
+      'bench.subtitle': 'Measured on latest LoongForge across VLA, WAM, and VLM workloads',
       'bench.baseline': '1.0× baseline',
       'bench.ds.title': '<strong>DeepSeek-V3.2 Lite</strong> · DSA operator-level optimizations',
       'bench.ds.desc': 'Validated on a reduced-layer configuration due to test-bed scale limits.',
@@ -186,7 +190,7 @@
       'footer.training': '训练框架', 'footer.workflow': '智能体框架',
 
       'hero.badge': '🐉 百度百舸 Loong 开源家族成员',
-      'hero.subtitle_html': '面向 <b>LLM</b>、<b>VLM</b>、<b>Diffusion</b> 与<b>具身智能</b>模型的<b>模块化</b>、<b>可扩展</b>、<b>高性能</b>训练框架 —— 基于 Megatron-LM 深度定制，原生支持 NVIDIA GPU 与昆仑芯 XPU',
+      'hero.subtitle_html': '面向 <b>LLM</b>、<b>VLM</b>、<b>Diffusion</b> 与<b>具身智能</b>模型的<b>模块化</b>、<b>可扩展</b>、<b>高性能</b>训练框架 —— 多后端架构（LLM/VLM/Diffusion 基于 <b>Megatron-LM</b>，具身模型基于 <b>torch-native DDP/FSDP</b>），原生支持 NVIDIA GPU 与昆仑芯 XPU',
       'hero.cta.start': '🚀 快速上手',
       'hero.cta.github': '⭐ 访问 GitHub',
       'hero.cta.docs': '📚 阅读文档',
@@ -217,10 +221,8 @@
       'feat.cat.2.title': '多模态',
       'feat.cat.2.item.1.t': '模型拼接',
       'feat.cat.2.item.1.d': '通过 YAML 自由拼接 ViT × LLM 构建 VLM。',
-      'feat.cat.2.item.2.t': '异构并行',
-      'feat.cat.2.item.2.d': '不同组件独立设置 TP / PP / DP。',
-      'feat.cat.2.item.3.t': '分离训练',
-      'feat.cat.2.item.3.d': 'ViT 与 LLM 解耦调度，消除流水气泡。',
+      'feat.cat.2.item.2.t': '异构并行 & 分离训练',
+      'feat.cat.2.item.2.d': '不同组件独立设置 TP / PP / DP，并通过 ViT / LLM 解耦调度消除流水气泡。',
       'feat.cat.2.item.4.t': 'DP 负载均衡',
       'feat.cat.2.item.4.d': '修复 packing 带来的 DP 倾斜。',
 
@@ -241,6 +243,10 @@
       'feat.cat.6.title': '训练范式',
       'feat.cat.6.item.1.t': 'Pretrain + SFT + LoRA',
       'feat.cat.6.item.1.d': '同一套代码覆盖关键训练阶段。',
+
+      'feat.cat.7.title': '具身智能',
+      'feat.cat.7.item.1.t': '具身模型训练',
+      'feat.cat.7.item.1.d': '面向 VLA 与 WAM 模型的独立 torch-native DDP/FSDP 子系统，支持 DDP / ZeRO-1 / FSDP / HSDP。',
 
       'models.title': '🏛️ 支持的模型',
       'models.subtitle': '从紧凑的小模型到大规模 MoE 巨兽 —— 开箱即用',
@@ -264,14 +270,16 @@
       'qs.footer.browse_html': '浏览 <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/configs/models" target="_blank" rel="noopener"><code class="mono">configs/models/</code></a> · <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/examples" target="_blank" rel="noopener"><code class="mono">examples/</code></a> · <a class="underline hover:text-indigo-600" href="https://github.com/baidu-baige/LoongForge/tree/master/examples_xpu" target="_blank" rel="noopener"><code class="mono">examples_xpu/</code></a>',
 
       'powered.title': '🌟 由 LoongForge 驱动',
-      'powered.subtitle': '基于 LoongForge 训练的开源项目 —— 按时间从新到旧排列',
+      'powered.subtitle': '基于 LoongForge 或其前身 AIAK-Training-LLM 训练的开源模型',
       'powered.new': 'NEW',
       'powered.1.t': 'LLaVA-OneVision-2.0',
       'powered.1.d': '新一代完全开放的多模态模型 —— 在数据、训练配方与 Scale 上全面升级。',
-      'powered.2.t': 'LLaVA-OneVision-1.5',
-      'powered.2.d': '面向多模态训练民主化的完全开放框架。',
-      'powered.3.t': 'Qianfan-VL',
-      'powered.3.d': '领域增强的通用视觉-语言模型。',
+      'powered.2.t': 'Innovator-VL',
+      'powered.2.d': '面向高阶推理的科学多模态大语言模型。',
+      'powered.3.t': 'LLaVA-OneVision-1.5',
+      'powered.3.d': '面向多模态训练民主化的完全开放框架。',
+      'powered.4.t': 'Qianfan-VL',
+      'powered.4.d': '领域增强的通用视觉-语言模型。',
 
       'cta.title': '加入社区',
       'cta.desc': '报告 Bug、提出建议、贡献代码，或只是打个招呼。我们 ❤️ 社区。',
@@ -308,7 +316,7 @@
       'about.ack.body': 'LoongForge 构建于 NVIDIA 的 Megatron-LM 之上，同时借鉴并参考了 Transformers、LLaMA-Factory、Megatron-Bridge 等优秀开源项目。真诚感谢这些社区的卓越贡献。',
 
       'bench.title': '📊 性能基准',
-      'bench.subtitle': '基于 latest，在 A800 上覆盖 LLM、VLM、VLA、DIT 工作负载实测',
+      'bench.subtitle': '基于 latest，覆盖 VLA、WAM、VLM 工作负载实测',
       'bench.baseline': '1.0× 基线',
       'bench.ds.title': '<strong>DeepSeek-V3.2 Lite</strong> · DSA 算子级优化',
       'bench.ds.desc': '受测试集群规模限制，基于减层模型配置验证。',

--- a/blog/2026-07-announcing-loongforge-embodied.html
+++ b/blog/2026-07-announcing-loongforge-embodied.html
@@ -1,0 +1,319 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>Announcing LoongForge-Embodied: a high-performance training subsystem for embodied models | LoongForge Blog
+    </title>
+    <meta name="description"
+        content="LoongForge releases LoongForge-Embodied — a torch-native training subsystem for VLA and WAM models, covering Pi0.5, GR00T N1.6, X-VLA, FastWAM, LingBot-VA, Cosmos3, and DreamZero, with 1.6x-2.67x training speedups over official implementations on the same hardware." />
+    <link rel="icon" type="image/svg+xml" href="../assets/img/logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+        rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class' };</script>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" />
+</head>
+
+<body class="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+
+    <div id="scroll-progress"></div>
+
+    <!-- Shared navbar (rendered by main.js) -->
+    <header data-site-header data-active="blog" data-base="../" data-lang-mode="post"></header>
+
+    <article class="max-w-4xl mx-auto px-6 py-14">
+        <a href="../blog.html" class="text-sm text-indigo-600 dark:text-indigo-300 hover:underline">← Back to blog</a>
+        <div class="mt-6 mb-8">
+            <div class="flex gap-2 mb-4 flex-wrap"><span class="chip">LoongForge</span><span
+                    class="chip">Embodied</span><span class="chip">VLA</span><span class="chip">WAM</span><span
+                    class="chip">Release</span></div>
+            <h1 class="text-3xl md:text-5xl font-extrabold tracking-tight mb-4">Announcing LoongForge-Embodied: a
+                high-performance training subsystem for embodied models</h1>
+            <div class="text-sm text-gray-500">2026-07-01 · The LoongForge Team</div>
+        </div>
+
+        <div class="prose-lf">
+            <blockquote>
+                <p>Today we are releasing <strong>LoongForge-Embodied</strong> inside LoongForge — a torch-native
+                    training subsystem purpose-built for <strong>VLA (Vision-Language-Action)</strong> and <strong>WAM
+                        (World-Action Model)</strong> models. It covers mainstream embodied models such as Pi0.5, GR00T
+                    N1.6, X-VLA, FastWAM, LingBot-VA, Cosmos3, and DreamZero in one shot, and delivers <strong>1.6× ~
+                        2.67×</strong> training speedups over each model's official implementation on the same hardware.
+                </p>
+            </blockquote>
+            <p>📚 GitHub: <a href="https://github.com/baidu-baige/LoongForge/tree/master/loongforge/embodied"
+                    target="_blank"
+                    rel="noopener">https://github.com/baidu-baige/LoongForge/tree/master/loongforge/embodied</a></p>
+            <h2>1. What it is: a torch-native embodied training subsystem</h2>
+            <p>LoongForge is a unified training framework spanning LLM / VLM / Diffusion / Embodied. The LLM / VLM /
+                Diffusion stacks are built on <strong>Megatron-LM</strong>, targeting large-scale, model-parallel
+                pre-training and SFT. Embodied models have a fundamentally different shape, so we built a dedicated
+                subsystem for them.</p>
+            <p>The reason is that embodied models differ from typical large models in a fundamental way: they have far
+                fewer parameters (usually under 10B), and a typical VLA is often just a VLM plus an action head. This
+                scale does not need the TP / PP / EP model parallelism designed for giant models — forcing it on only
+                adds complexity and overhead. LoongForge-Embodied is therefore built directly on <strong>native PyTorch
+                    DDP / FSDP</strong>, focusing on training efficiency and model-onboarding experience in
+                small-to-medium, data-parallel scenarios.</p>
+            <p>The two stacks share the same repository, release process, and toolchain, but do not share the Megatron
+                core engine, nor args / parser / core, so each can evolve independently:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Dimension</th>
+                        <th>LoongForge core (LLM / VLM / Diffusion)</th>
+                        <th>LoongForge-Embodied</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Compute / distributed</td>
+                        <td>Megatron-LM — TP / PP / EP / CP / FSDP</td>
+                        <td>torch-native DDP / FSDP</td>
+                    </tr>
+                    <tr>
+                        <td>Workload profile</td>
+                        <td>Large-scale, model-parallel pre-training / SFT</td>
+                        <td>Small-to-medium, data-parallel SFT</td>
+                    </tr>
+                    <tr>
+                        <td>Model scale</td>
+                        <td>Billions to hundreds of billions of parameters</td>
+                        <td>Usually under 10B</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h2>2. Supported models: mainstream VLA and WAM, all at once</h2>
+            <p>The first release already covers mainstream VLA and WAM models, with a unified onboarding path:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Category</th>
+                        <th>Models</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Pi</strong></td>
+                        <td>pi0.5</td>
+                    </tr>
+                    <tr>
+                        <td><strong>GR00T</strong></td>
+                        <td>groot_n1_6, groot_n1_7</td>
+                    </tr>
+                    <tr>
+                        <td><strong>XVLA</strong></td>
+                        <td>xvla</td>
+                    </tr>
+                    <tr>
+                        <td><strong>FastWAM</strong></td>
+                        <td>fastwam</td>
+                    </tr>
+                    <tr>
+                        <td><strong>LingBot-VA</strong> (WAM)</td>
+                        <td>lingbot_va</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Cosmos3</strong></td>
+                        <td>cosmos3_nano</td>
+                    </tr>
+                    <tr>
+                        <td><strong>DreamZero</strong></td>
+                        <td>Series variants (Wan2.1 14B / Wan2.2 5B, LoRA and full fine-tuning, covering DROID / LIBERO
+                            / AgiBot / YAM and other datasets)</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>Full fine-tuning is a standard capability; on the data side it supports formats such as LeRobot / HDF5
+                (supported formats vary by model), and some models (e.g. DreamZero) also provide LoRA variants.</p>
+            <h2>3. Performance: measured speedups on the same hardware</h2>
+            <p>The following are measured speedups for LoongForge-Embodied on the same hardware configuration as each
+                model's official implementation:</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>Model</th>
+                        <th>Type</th>
+                        <th>Baseline</th>
+                        <th>Speedup</th>
+                        <th>Measured version</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Pi0.5</td>
+                        <td>VLA</td>
+                        <td>OpenPI</td>
+                        <td><strong>2.23×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>GR00T N1.6</td>
+                        <td>VLA</td>
+                        <td>LeRobot</td>
+                        <td><strong>2.31×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>X-VLA</td>
+                        <td>VLA</td>
+                        <td>X-VLA</td>
+                        <td><strong>1.6×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>DreamZero (DROID Wan2.2-5B full)</td>
+                        <td>WAM</td>
+                        <td>DreamZero</td>
+                        <td><strong>2.67×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>LingBot VA</td>
+                        <td>WAM</td>
+                        <td>LingBot-VA</td>
+                        <td><strong>1.80×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>This speedup spans both VLA and WAM categories and multiple mainstream implementations, rather than
+                holding for a single model only.</p>
+            <blockquote>
+                <p>The numbers above reflect the performance of each baseline and LoongForge version at measurement time
+                    (see the "Measured version" column) and may change as implementations evolve; the exact speedup also
+                    varies with model, data, and configuration.</p>
+            </blockquote>
+            <h2>4. Architecture: share common capabilities, push model differences down</h2>
+            <p>The design philosophy of this subsystem can be summed up in one line: <strong>share common capabilities,
+                    push model differences down</strong> — make the common layer deep and the model layer thin, so
+                adding a model requires no changes to the training main loop.</p>
+            <p><strong>① Model layer (<code>model/</code>) — one directory per model.</strong> Each model registers into
+                a unified entry point via <code>@register_model</code>: <code>modeling_&lt;name&gt;.py</code> handles
+                the network / forward / loss, and <code>model_configuration_&lt;name&gt;.py</code> is the
+                architecture-hyperparameter dataclass. A unified interface is exposed upward, so onboarding a new model
+                does not touch the training loop.</p>
+            <p><strong>② Data pipeline (<code>data/</code>) — common backends + per-model differences.</strong>
+                Dataset-reading backends (<code>lerobot / hdf5 / dummy</code>), a stateful distributed sampler, and a
+                composable transform framework are consolidated as common capabilities; model-specific data reading
+                (such as <code>fastwam</code>'s multi-frame geometry), action / image transforms, and batch assembly are
+                pushed down to <code>datasets/&lt;name&gt;/</code>; each model declares image size, action dimensions,
+                normalization statistics, etc. via <code>DataConfig</code>.</p>
+            <p><strong>③ Three-layer config parsing (<code>train/parser.py</code>) — frozen into immutable
+                    objects.</strong> The YAML <code>model:</code> section → <code>ModelConfig</code>, the YAML
+                <code>data:</code> section → <code>DataConfig</code>, the command line → <code>TrainingArgs</code>;
+                <code>--model-name</code> is routed via <code>config_map.py</code> to the corresponding YAML and type,
+                and the command line can also override fields via dotlist (e.g. <code>model.action_horizon=64</code>),
+                all finally frozen into a global singleton.</p>
+            <p><strong>④ Distributed trainer (<code>train/trainers/</code>, <code>distributed/</code>) — flexible
+                    strategies.</strong> Standard SFT uses <code>FinetuneTrainer</code> directly; special paradigms such
+                as multi-stream and CUDA Graph inherit <code>BaseTrainer</code> and register in
+                <code>trainer_builder.py</code>, selected via <code>--trainer-type</code>; distribution can switch on
+                demand among <code>ddp</code> (data parallel), <code>ddp</code> + <code>--zero-optimizer</code> (ZeRO
+                Stage-1), <code>fsdp</code> (full sharding), and <code>hsdp</code> (hybrid sharding), matching the scale
+                and memory characteristics of embodied models. <code>BaseTrainer</code> also consolidates optimizer / LR
+                scheduling, gradient clipping and NaN cleanup, checkpoint resume, and determinism control into the
+                common layer, letting every model reuse the same implementation.</p>
+            <p><strong>Adding a new model takes just 5 steps</strong>: ① add the network and config under
+                <code>model/&lt;name&gt;/</code> and <code>@register_model</code>; ② add
+                <code>data/datasets/&lt;name&gt;/</code> (DataConfig + transform + collator); ③ add a YAML under
+                <code>configs/models/embodied/</code> and register it in <code>config_map.py</code>; ④ inherit
+                <code>BaseTrainer</code> if the paradigm differs, otherwise reuse <code>FinetuneTrainer</code>; ⑤ add a
+                launch script under <code>examples/</code>.</p>
+            <h2>5. Quick start</h2>
+            <p>Training is launched with <code>torchrun</code> running <code>loongforge/embodied/train.py</code>:</p>
+            <pre><code class="language-bash">export LOONGFORGE_PATH=/workspace/LoongForge
+
+PYTHONPATH=$LOONGFORGE_PATH:$PYTHONPATH \
+  torchrun --nproc_per_node 8 --nnodes 1 \
+    $LOONGFORGE_PATH/loongforge/embodied/train.py \
+    --model-name pi05 \
+    --trainer-type FinetuneTrainer \
+    --dataset-format lerobot_datasets \
+    --distributed-strategy fsdp \
+    --train-iters 30000 \
+    ...</code></pre>
+            <p>Different models differ in data format, processing pipeline, and performance-optimization config, so the
+                ready-to-run command varies by model. Out-of-the-box example scripts live under
+                <code>examples/embodied/</code>:</p>
+            <pre><code class="language-bash">bash examples/embodied/pi05/run_pi05_fsdp_finetune.sh        # ddp / ddp_zero1 variants also available
+bash examples/embodied/groot_n1_6/run_groot_n1_6_ddp_finetune.sh</code></pre>
+            <h2>6. Evaluation: offline benchmarks, process-decoupled</h2>
+            <p>Beyond training, LoongForge-Embodied ships with an offline evaluation module covering <strong>LIBERO /
+                    CALVIN / SimplerEnv / RoboTwin / ManiSkill</strong>. It splits the benchmark client and the model
+                policy server into separate processes, connected via a WebSocket / msgpack-numpy RPC protocol, with YAML
+                as the sole user entry point:</p>
+            <pre><code class="language-bash">cd /path/to/LoongForge
+examples/embodied/pi05/eval/run_libero_eval.sh</code></pre>
+            <p>The model side only needs to implement a unified <code>predict_action</code> interface; the generic
+                policy layer <code>GenericPredictActionPolicy</code> handles image-view selection, action shape
+                validation, chunk caching, latency statistics, and normalization-statistics loading. Onboarding a new
+                model only requires adding a lightweight factory under <code>eval/factories/</code>, with no changes to
+                the server main flow.</p>
+            <blockquote>
+                <p>The evaluation module is still under active development; more benchmarks and capabilities will be
+                    added.</p>
+            </blockquote>
+            <h2>7. Closing thoughts</h2>
+            <p>The release of LoongForge-Embodied marks the point where LoongForge's training capabilities for embodied
+                models graduate from scattered VLA support inside the main framework into an independent, decoupled
+                subsystem: mainstream VLA and WAM in one shot with unified onboarding, delivering 1.6× ~ 2.67× training
+                speedups over official implementations on the same hardware.</p>
+            <p>We believe the R&D efficiency of embodied models depends on whether you can train them with
+                infrastructure that best fits their shape. We welcome you to try it out, and to join the community via
+                GitHub Issues, WeChat, or Slack to help us make it better together.</p>
+            <ul>
+                <li><strong>GitHub</strong>: <a href="https://github.com/baidu-baige/LoongForge" target="_blank"
+                        rel="noopener">https://github.com/baidu-baige/LoongForge</a></li>
+                <li><strong>Docs</strong>: <a href="https://loongforge.readthedocs.io/" target="_blank"
+                        rel="noopener">https://loongforge.readthedocs.io/</a></li>
+                <li><strong>More blogs</strong>: <a href="https://baidu-baige.github.io/LoongForge/blog/"
+                        target="_blank" rel="noopener">https://baidu-baige.github.io/LoongForge/blog/</a></li>
+            </ul>
+        </div>
+
+        <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between text-sm">
+            <a href="2026-06-loongforge-groot-n16-acceleration.html"
+                class="text-indigo-600 dark:text-indigo-300 hover:underline">← Previous: GR00T N1.6 Training
+                Acceleration</a>
+            <a href="../blog.html" class="text-indigo-600 dark:text-indigo-300 hover:underline">All posts →</a>
+        </div>
+    </article>
+
+    <footer class="border-t border-gray-200 dark:border-gray-800">
+        <div class="max-w-7xl mx-auto px-6 py-8 text-center text-xs text-gray-500">© 2026 LoongForge Authors · Apache
+            2.0
+        </div>
+    </footer>
+
+    <script>
+        (function () {
+            const POST_EN = '2026-07-announcing-loongforge-embodied.html';
+            const POST_ZH = '2026-07-announcing-loongforge-embodied.zh.html';
+            document.querySelectorAll('[data-post-lang]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const target = btn.dataset.postLang;
+                    try { localStorage.setItem('lf-lang', target); } catch (e) { }
+                    location.href = target === 'zh' ? POST_ZH : POST_EN;
+                });
+            });
+            try {
+                const cur = (localStorage.getItem('lf-lang') === 'zh') ? 'zh' : 'en';
+                document.querySelectorAll('[data-post-lang]').forEach(b =>
+                    b.classList.toggle('active', b.dataset.postLang === cur)
+                );
+            } catch (e) { }
+        })();
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
+    <script src="../assets/js/main.js"></script>
+</body>
+
+</html>

--- a/blog/2026-07-announcing-loongforge-embodied.zh.html
+++ b/blog/2026-07-announcing-loongforge-embodied.zh.html
@@ -1,0 +1,279 @@
+<!DOCTYPE html>
+<html lang="zh-CN">
+
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+    <title>LoongForge-Embodied 正式发布：面向具身模型的高性能训练子系统 | LoongForge Blog</title>
+    <meta name="description"
+        content="LoongForge 正式发布 LoongForge-Embodied——面向 VLA 与 WAM 的 torch-native 训练子系统，覆盖 Pi0.5、GR00T N1.6、X-VLA、FastWAM、LingBot-VA、Cosmos3、DreamZero 等主流具身模型，同等硬件下相对官方实现取得 1.6×~2.67× 加速。" />
+    <link rel="icon" type="image/svg+xml" href="../assets/img/logo.svg" />
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link
+        href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap"
+        rel="stylesheet">
+    <script src="https://cdn.tailwindcss.com"></script>
+    <script>tailwind.config = { darkMode: 'class' };</script>
+    <link rel="stylesheet" href="../assets/css/style.css" />
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/themes/prism-tomorrow.min.css" />
+</head>
+
+<body class="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
+
+    <div id="scroll-progress"></div>
+
+    <!-- Shared navbar (rendered by main.js) -->
+    <header data-site-header data-active="blog" data-base="../" data-lang-mode="post"></header>
+
+    <article class="max-w-4xl mx-auto px-6 py-14">
+        <a href="../blog.html" class="text-sm text-indigo-600 dark:text-indigo-300 hover:underline">← 返回博客</a>
+        <div class="mt-6 mb-8">
+            <div class="flex gap-2 mb-4 flex-wrap"><span class="chip">LoongForge</span><span
+                    class="chip">具身智能</span><span class="chip">VLA</span><span class="chip">WAM</span><span
+                    class="chip">发布</span></div>
+            <h1 class="text-3xl md:text-5xl font-extrabold tracking-tight mb-4">LoongForge-Embodied 正式发布：面向具身模型的高性能训练子系统
+            </h1>
+            <div class="text-sm text-gray-500">2026-07-01 · LoongForge 团队</div>
+        </div>
+
+        <div class="prose-lf">
+            <blockquote>
+                <p>今天，我们在 LoongForge 中正式发布 <strong>LoongForge-Embodied</strong>——一个专为 <strong>VLA（视觉-语言-动作）</strong> 与
+                    <strong>WAM（世界-动作模型）</strong> 打造的 torch-native 训练子系统。它一次覆盖 Pi0.5、GR00T
+                    N1.6、X-VLA、FastWAM、LingBot-VA、Cosmos3、DreamZero 等主流具身模型，并在同等硬件下相对各模型官方实现取得 <strong>1.6× ~
+                        2.67×</strong> 的训练加速。</p>
+            </blockquote>
+            <p>📚 GitHub：<a href="https://github.com/baidu-baige/LoongForge/tree/master/loongforge/embodied"
+                    target="_blank"
+                    rel="noopener">https://github.com/baidu-baige/LoongForge/tree/master/loongforge/embodied</a></p>
+            <h2>1. 它是什么：一个 torch-native 的具身训练子系统</h2>
+            <p>LoongForge 是一套统一的训练框架，覆盖 LLM / VLM / Diffusion / Embodied。其中 LLM / VLM / Diffusion 构建在
+                <strong>Megatron-LM</strong> 之上，面向大规模、模型并行的预训练与 SFT；而具身模型有着截然不同的形态，我们为它单独构建了一套子系统。</p>
+            <p>原因在于，具身模型与典型大模型的差别是本质性的：它参数量小得多（通常在 10B 以内），一个典型 VLA 往往就是一个 VLM 叠加一个动作头。这个规模并不需要为超大模型准备的 TP / PP / EP
+                模型并行——硬套只会徒增复杂度与开销。因此 LoongForge-Embodied 直接构建在<strong>原生 PyTorch 的 DDP / FSDP</strong>
+                之上，聚焦于中小规模、数据并行场景下的训练效率与模型接入体验。</p>
+            <p>两套栈共享同一个代码仓库、发布流程与工具链，但不共享 Megatron 核心引擎，也不共享 args / parser / core，从而各自独立演进：</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>维度</th>
+                        <th>LoongForge 核心（LLM / VLM / Diffusion）</th>
+                        <th>LoongForge-Embodied</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>计算 / 分布式</td>
+                        <td>Megatron-LM —— TP / PP / EP / CP / FSDP</td>
+                        <td>torch-native DDP / FSDP</td>
+                    </tr>
+                    <tr>
+                        <td>负载特征</td>
+                        <td>大规模、模型并行的预训练 / SFT</td>
+                        <td>中小规模、数据并行的 SFT</td>
+                    </tr>
+                    <tr>
+                        <td>模型规模</td>
+                        <td>数十亿至数千亿参数</td>
+                        <td>通常 10B 以内</td>
+                    </tr>
+                </tbody>
+            </table>
+            <h2>2. 支持的模型：主流 VLA 与 WAM 一次到位</h2>
+            <p>首个版本即覆盖主流的 VLA 与 WAM 模型，且接入方式统一：</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>类别</th>
+                        <th>模型</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td><strong>Pi</strong></td>
+                        <td>pi0.5</td>
+                    </tr>
+                    <tr>
+                        <td><strong>GR00T</strong></td>
+                        <td>groot_n1_6、groot_n1_7</td>
+                    </tr>
+                    <tr>
+                        <td><strong>XVLA</strong></td>
+                        <td>xvla</td>
+                    </tr>
+                    <tr>
+                        <td><strong>FastWAM</strong></td>
+                        <td>fastwam</td>
+                    </tr>
+                    <tr>
+                        <td><strong>LingBot-VA</strong>（WAM）</td>
+                        <td>lingbot_va</td>
+                    </tr>
+                    <tr>
+                        <td><strong>Cosmos3</strong></td>
+                        <td>cosmos3_nano</td>
+                    </tr>
+                    <tr>
+                        <td><strong>DreamZero</strong></td>
+                        <td>系列变体（Wan2.1 14B / Wan2.2 5B，LoRA 与全量微调，覆盖 DROID / LIBERO / AgiBot / YAM 等数据集）</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>全量微调是标准能力，数据侧支持 LeRobot / HDF5 等多种格式（各模型支持的格式不尽相同）；部分模型（如 DreamZero）另提供 LoRA 变体。</p>
+            <h2>3. 性能：同等硬件下的实测加速</h2>
+            <p>以下为 LoongForge-Embodied 在与各模型官方实现相同硬件配置下的实测加速：</p>
+            <table>
+                <thead>
+                    <tr>
+                        <th>模型</th>
+                        <th>类型</th>
+                        <th>对比基线</th>
+                        <th>加速比</th>
+                        <th>测量版本</th>
+                    </tr>
+                </thead>
+                <tbody>
+                    <tr>
+                        <td>Pi0.5</td>
+                        <td>VLA</td>
+                        <td>OpenPI</td>
+                        <td><strong>2.23×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>GR00T N1.6</td>
+                        <td>VLA</td>
+                        <td>LeRobot</td>
+                        <td><strong>2.31×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>X-VLA</td>
+                        <td>VLA</td>
+                        <td>X-VLA</td>
+                        <td><strong>1.6×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>DreamZero（DROID Wan2.2-5B 全量）</td>
+                        <td>WAM</td>
+                        <td>DreamZero</td>
+                        <td><strong>2.67×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                    <tr>
+                        <td>LingBot VA</td>
+                        <td>WAM</td>
+                        <td>LingBot-VA</td>
+                        <td><strong>1.80×</strong></td>
+                        <td>main · 2026-07</td>
+                    </tr>
+                </tbody>
+            </table>
+            <p>这份加速横跨 VLA 与 WAM 两大类、多个主流实现，而不是只在单个模型上成立。</p>
+            <blockquote>
+                <p>上述数字反映测量时各基线与 LoongForge 版本的表现（见"测量版本"列），随实现演进可能变化；具体加速幅度也因模型、数据与配置而异。</p>
+            </blockquote>
+            <h2>4. 架构设计：公共能力共享，模型差异下沉</h2>
+            <p>这套子系统的设计哲学可以概括为一句话：<strong>共享公共能力，下沉模型差异</strong>——公共层做深，模型层做薄，新增一个模型无需改动训练主循环。</p>
+            <p><strong>① 模型层（<code>model/</code>）—— 一个模型一个目录。</strong> 每个模型通过 <code>@register_model</code>
+                注册到统一入口：<code>modeling_&lt;name&gt;.py</code> 负责组网 / 前向 /
+                损失，<code>model_configuration_&lt;name&gt;.py</code> 是架构超参数据类。对上层暴露统一接口，接入新模型不触碰训练循环。</p>
+            <p><strong>② 数据流水线（<code>data/</code>）—— 公共后端 + 每模型差异。</strong>
+                数据集读取后端（<code>lerobot / hdf5 / dummy</code>）、有状态的分布式采样器、可组合的 transform 框架统一沉淀为公共能力；模型特有的数据读取（如
+                <code>fastwam</code> 的多帧几何）、动作 / 图像变换、batch 拼装下沉到 <code>datasets/&lt;name&gt;/</code>；每个模型用
+                <code>DataConfig</code> 声明图像尺寸、动作维度、归一化统计等。</p>
+            <p><strong>③ 三层配置解析（<code>train/parser.py</code>）—— 冻结为不可变对象。</strong> YAML <code>model:</code> 段 →
+                <code>ModelConfig</code>、YAML <code>data:</code> 段 → <code>DataConfig</code>、命令行 →
+                <code>TrainingArgs</code>；<code>--model-name</code> 经 <code>config_map.py</code> 路由到对应 YAML 与类型，命令行还可用
+                dotlist 覆盖字段（如 <code>model.action_horizon=64</code>），最终统一冻结为全局单例。</p>
+            <p><strong>④ 分布式训练器（<code>train/trainers/</code>、<code>distributed/</code>）—— 策略灵活。</strong> 标准 SFT 直接用
+                <code>FinetuneTrainer</code>，多流、CUDA Graph 等特殊范式继承 <code>BaseTrainer</code> 并在
+                <code>trainer_builder.py</code> 注册，通过 <code>--trainer-type</code> 选择；分布式则可在
+                <code>ddp</code>（数据并行）、<code>ddp</code> + <code>--zero-optimizer</code>（ZeRO
+                Stage-1）、<code>fsdp</code>（全分片）、<code>hsdp</code>（混合分片）之间按需切换，贴合具身模型的规模与显存特征。<code>BaseTrainer</code>
+                还把优化器 / LR 调度、梯度裁剪与 NaN 清理、checkpoint 续训、确定性控制等收敛到公共层，让每个模型复用同一套实现。</p>
+            <p><strong>新增一个模型只需 5 步</strong>：① 加 <code>model/&lt;name&gt;/</code> 的组网与配置并 <code>@register_model</code>；②
+                加 <code>data/datasets/&lt;name&gt;/</code>（DataConfig + transform + collator）；③ 在
+                <code>configs/models/embodied/</code> 加 YAML 并在 <code>config_map.py</code> 登记；④ 范式不同则继承
+                <code>BaseTrainer</code>，否则复用 <code>FinetuneTrainer</code>；⑤ 在 <code>examples/</code> 加启动脚本。</p>
+            <h2>5. 快速开始</h2>
+            <p>训练通过 <code>torchrun</code> 启动 <code>loongforge/embodied/train.py</code>：</p>
+            <pre><code class="language-bash">export LOONGFORGE_PATH=/workspace/LoongForge
+
+PYTHONPATH=$LOONGFORGE_PATH:$PYTHONPATH \
+  torchrun --nproc_per_node 8 --nnodes 1 \
+    $LOONGFORGE_PATH/loongforge/embodied/train.py \
+    --model-name pi05 \
+    --trainer-type FinetuneTrainer \
+    --dataset-format lerobot_datasets \
+    --distributed-strategy fsdp \
+    --train-iters 30000 \
+    ...</code></pre>
+            <p>不同模型在数据格式、处理流程、性能优化配置上各有差异，可直接运行的命令因模型而异。开箱即用的示例脚本见 <code>examples/embodied/</code>：</p>
+            <pre><code class="language-bash">bash examples/embodied/pi05/run_pi05_fsdp_finetune.sh        # 另有 ddp / ddp_zero1 变体
+bash examples/embodied/groot_n1_6/run_groot_n1_6_ddp_finetune.sh</code></pre>
+            <h2>6. 评测：离线 benchmark，进程解耦</h2>
+            <p>训练之外，LoongForge-Embodied 内置一套离线评测模块，覆盖 <strong>LIBERO / CALVIN / SimplerEnv / RoboTwin /
+                    ManiSkill</strong>。它将 benchmark 客户端与模型策略服务器拆分为独立进程，通过 WebSocket / msgpack-numpy 的 RPC 协议连接，以 YAML
+                作为唯一用户入口：</p>
+            <pre><code class="language-bash">cd /path/to/LoongForge
+examples/embodied/pi05/eval/run_libero_eval.sh</code></pre>
+            <p>模型侧只需实现统一的 <code>predict_action</code> 接口，通用策略层 <code>GenericPredictActionPolicy</code> 负责图像视图选择、动作 shape
+                校验、chunk 缓存、延迟统计与归一化统计加载；接入新模型只需在 <code>eval/factories/</code> 下新增一个轻量工厂，无需改动服务器主流程。</p>
+            <blockquote>
+                <p>评测模块仍在持续开发中，后续会有更多 benchmark 与能力加入。</p>
+            </blockquote>
+            <h2>7. 写在最后</h2>
+            <p>LoongForge-Embodied 的发布，标志着 LoongForge 面向具身模型的训练能力，从此前散落在主框架中的 VLA 支持，正式沉淀为一个独立、解耦的子系统：主流 VLA 与 WAM
+                一次到位、接入统一，同时在同等硬件下相对官方实现带来 1.6× ~ 2.67× 的训练加速。</p>
+            <p>我们相信，具身模型的研发效率，取决于能否用最贴合其形态的基础设施去训练它。欢迎试用，也欢迎通过 GitHub Issue、微信或 Slack 加入社区，一起把它打磨得更好。</p>
+            <ul>
+                <li><strong>GitHub</strong>：<a href="https://github.com/baidu-baige/LoongForge" target="_blank"
+                        rel="noopener">https://github.com/baidu-baige/LoongForge</a></li>
+                <li><strong>文档</strong>：<a href="https://loongforge.readthedocs.io/" target="_blank"
+                        rel="noopener">https://loongforge.readthedocs.io/</a></li>
+                <li><strong>更多 blog</strong>：<a href="https://baidu-baige.github.io/LoongForge/blog/" target="_blank"
+                        rel="noopener">https://baidu-baige.github.io/LoongForge/blog/</a></li>
+            </ul>
+        </div>
+
+        <div class="mt-12 pt-8 border-t border-gray-200 dark:border-gray-800 flex items-center justify-between text-sm">
+            <a href="2026-06-loongforge-groot-n16-acceleration.zh.html"
+                class="text-indigo-600 dark:text-indigo-300 hover:underline">← 上一篇：GR00T N1.6 训练加速</a>
+            <a href="../blog.html" class="text-indigo-600 dark:text-indigo-300 hover:underline">所有文章 →</a>
+        </div>
+    </article>
+
+    <footer class="border-t border-gray-200 dark:border-gray-800">
+        <div class="max-w-7xl mx-auto px-6 py-8 text-center text-xs text-gray-500">© 2026 LoongForge Authors · Apache
+            2.0
+        </div>
+    </footer>
+
+    <script>
+        (function () {
+            const POST_EN = '2026-07-announcing-loongforge-embodied.html';
+            const POST_ZH = '2026-07-announcing-loongforge-embodied.zh.html';
+            document.querySelectorAll('[data-post-lang]').forEach(btn => {
+                btn.addEventListener('click', () => {
+                    const target = btn.dataset.postLang;
+                    try { localStorage.setItem('lf-lang', target); } catch (e) { }
+                    location.href = target === 'zh' ? POST_ZH : POST_EN;
+                });
+            });
+            try {
+                const cur = (localStorage.getItem('lf-lang') === 'en') ? 'en' : 'zh';
+                document.querySelectorAll('[data-post-lang]').forEach(b =>
+                    b.classList.toggle('active', b.dataset.postLang === cur)
+                );
+            } catch (e) { }
+        })();
+    </script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/prism.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
+    <script src="../assets/js/main.js"></script>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -60,8 +60,8 @@
       </h1>
       <p class="max-w-3xl mx-auto text-lg md:text-xl text-gray-200 mb-10" data-i18n-html="hero.subtitle_html">
         A <b>modular</b>, <b>scalable</b>, <b>high-performance</b> training framework for <b>LLMs</b>, <b>VLMs</b>,
-        <b>diffusion</b>, and <b>embodied</b> models — built on Megatron-LM with native NVIDIA GPU &amp; Kunlun XPU
-        support
+        <b>diffusion</b>, and <b>embodied</b> models — multi-backend (<b>Megatron-LM</b> for LLM/VLM/diffusion,
+        <b>torch-native DDP/FSDP</b> for embodied), with native NVIDIA GPU &amp; Kunlun XPU support
       </p>
       <div class="flex flex-wrap gap-3 justify-center">
         <a href="#quickstart"
@@ -135,6 +135,14 @@
       </div>
 
       <div class="grid sm:grid-cols-2 lg:grid-cols-5 gap-4">
+        <!-- Embodied (highlighted first) -->
+        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
+          <span class="feat-tag feat-tag-embodied" data-i18n="feat.cat.7.title">Embodied</span>
+          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.7.item.1.t">Embodied Training</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.7.item.1.d">Dedicated torch-native
+            DDP/FSDP subsystem for VLA &amp; WAM models, with DDP / ZeRO-1 / FSDP / HSDP.</div>
+        </div>
+
         <!-- MoE -->
         <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
           <span class="feat-tag feat-tag-moe" data-i18n="feat.cat.1.title">MoE</span>
@@ -146,15 +154,9 @@
         <!-- Multimodal -->
         <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
           <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.2.t">Heterogeneous Parallelism</div>
+          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.2.t">Heterogeneous &amp; Disaggregated</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.2.d">Independent TP / PP / DP
-            per model component.</div>
-        </div>
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.3.t">Disaggregated Training</div>
-          <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.3.d">Decoupled ViT / LLM
-            scheduling kills pipeline bubbles.</div>
+            per component + decoupled ViT / LLM scheduling that kills pipeline bubbles.</div>
         </div>
         <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
           <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
@@ -217,38 +219,38 @@
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="bench.title">📊 Benchmark</h2>
         <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="bench.subtitle">Measured on
-          latest LoongForge across LLM, VLM, VLA, and DIT workloads</p>
+          latest LoongForge across VLA, WAM, and VLM workloads</p>
       </div>
       <div class="max-w-3xl mx-auto">
         <div class="space-y-4">
           <div class="bench-row">
-            <div class="bench-label">GR00T N1.6 <span class="bench-type">VLA</span></div>
+            <div class="bench-label">DreamZero <span class="bench-type">WAM</span></div>
             <div class="bench-track">
-              <div class="bench-bar bench-bar-top" style="width: 100%"><span class="bench-val">2.31×</span></div>
+              <div class="bench-bar bench-bar-top" style="width: 100%"><span class="bench-val">2.67×</span></div>
             </div>
           </div>
           <div class="bench-row">
-            <div class="bench-label">Wan2.2 <span class="bench-type">DIT</span></div>
+            <div class="bench-label">GR00T N1.6 <span class="bench-type">VLA</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 93.5%"><span class="bench-val">2.16×</span></div>
+              <div class="bench-bar" style="width: 86.5%"><span class="bench-val">2.31×</span></div>
             </div>
           </div>
           <div class="bench-row">
             <div class="bench-label">Pi0.5 <span class="bench-type">VLA</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 71.4%"><span class="bench-val">1.65×</span></div>
+              <div class="bench-bar" style="width: 83.5%"><span class="bench-val">2.23×</span></div>
+            </div>
+          </div>
+          <div class="bench-row">
+            <div class="bench-label">LingBot VA <span class="bench-type">WAM</span></div>
+            <div class="bench-track">
+              <div class="bench-bar" style="width: 67.4%"><span class="bench-val">1.80×</span></div>
             </div>
           </div>
           <div class="bench-row">
             <div class="bench-label">Qwen3-VL-30B-A3B <span class="bench-type">VLM</span></div>
             <div class="bench-track">
-              <div class="bench-bar" style="width: 62.8%"><span class="bench-val">1.45×</span></div>
-            </div>
-          </div>
-          <div class="bench-row">
-            <div class="bench-label">Qwen3-30B-A3B <span class="bench-type">MoE</span></div>
-            <div class="bench-track">
-              <div class="bench-bar" style="width: 50.2%"><span class="bench-val">1.16×</span></div>
+              <div class="bench-bar" style="width: 54.3%"><span class="bench-val">1.45×</span></div>
             </div>
           </div>
         </div>
@@ -312,7 +314,7 @@
           <button data-tab="llm" class="tab-btn active">LLM</button>
           <button data-tab="vlm" class="tab-btn">VLM</button>
           <button data-tab="diff" class="tab-btn">Diffusion</button>
-          <button data-tab="vla" class="tab-btn">VLA</button>
+          <button data-tab="vla" class="tab-btn">Embodied</button>
         </div>
 
         <div data-panel="llm" class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
@@ -327,6 +329,10 @@
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">DeepSeek-V3.2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">v3.2</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">DeepSeek-V4</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">v4-flash</span><span class="chip">v4-pro</span></div>
           </div>
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LLaMA2</h4>
@@ -401,6 +407,10 @@
             <div class="flex flex-wrap gap-1.5"><span class="chip">27B</span><span class="chip">35B-A3B</span></div>
           </div>
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">Kimi-K2.x</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">k2.5</span><span class="chip">k2.6</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">ERNIE4.5-VL</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">28B-A3B</span></div>
           </div>
@@ -426,21 +436,53 @@
           </div>
         </div>
 
-        <div data-panel="diff" class="hidden grid md:grid-cols-2 gap-4">
+        <div data-panel="diff" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
-            <h4 class="font-semibold mb-2">WAN2.2</h4>
-            <div class="flex flex-wrap gap-1.5"><span class="chip">wan2.2_i2v_a14b</span></div>
+            <h4 class="font-semibold mb-2">Wan2.1</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">wan2-1-i2v</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">Wan2.2</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">wan2-2-i2v</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">Qwen-Image</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">qwen-image-edit-2511</span></div>
           </div>
         </div>
 
-        <div data-panel="vla" class="hidden grid md:grid-cols-2 gap-4">
+        <div data-panel="vla" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-4">
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Pi</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">pi0.5</span></div>
           </div>
           <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">GR00T</h4>
-            <div class="flex flex-wrap gap-1.5"><span class="chip">groot-n1.6</span></div>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">groot_n1_6</span><span class="chip">groot_n1_7</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">XVLA</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">xvla</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">FastWAM</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">fastwam</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">LingBot-VA</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">lingbot_va</span></div>
+          </div>
+          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+            <h4 class="font-semibold mb-2">Cosmos3</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">cosmos3_nano</span></div>
+          </div>
+          <div
+            class="rounded-2xl p-5 bg-gradient-to-br from-indigo-500/10 to-amber-500/10 border border-indigo-200 dark:border-indigo-900 md:col-span-2 lg:col-span-3 card-hover">
+            <h4 class="font-semibold mb-2">DreamZero</h4>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">lora_wan22_5b</span><span
+                class="chip">full_wan22_5b</span><span class="chip">lora_wan21_14b</span><span
+                class="chip">full_wan21_14b</span><span class="chip">libero_wan22_5b</span><span
+                class="chip">agibot_wan21_14b</span><span class="chip">yam_wan21_14b</span></div>
           </div>
         </div>
       </div>
@@ -645,9 +687,9 @@ MODEL_PARALLEL_ARGS=(
     <div class="max-w-7xl mx-auto px-6 py-20 reveal">
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-3" data-i18n="powered.title">🌟 Powered by LoongForge
       </h2>
-      <p class="text-center text-gray-600 dark:text-gray-400 mb-10" data-i18n="powered.subtitle">Open-source projects
-        trained on LoongForge — ordered from newest to earliest</p>
-      <div class="grid md:grid-cols-3 gap-5">
+      <p class="text-center text-gray-600 dark:text-gray-400 mb-10" data-i18n="powered.subtitle">Open-source models
+        trained with LoongForge or its predecessor AIAK-Training-LLM</p>
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
         <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2" target="_blank"
           class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="flex items-center gap-2 mb-2">
@@ -660,18 +702,30 @@ MODEL_PARALLEL_ARGS=(
           <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.1.d">Next-generation fully open
             multimodal model — improved data, training recipe, and scaling.</p>
         </a>
-        <a href="https://arxiv.org/abs/2509.23661" target="_blank"
+        <a href="https://github.com/InnovatorLM/Innovator-VL/tree/main" target="_blank"
+          class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div class="flex items-center gap-2 mb-2">
+            <span class="text-2xl">🧪</span>
+            <span
+              class="text-[10px] font-bold tracking-wider px-2 py-0.5 rounded-full bg-emerald-100 dark:bg-emerald-900/40 text-emerald-700 dark:text-emerald-300"
+              data-i18n="powered.new">NEW</span>
+          </div>
+          <h3 class="font-semibold mb-1" data-i18n="powered.2.t">Innovator-VL</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.2.d">Scientific multimodal large
+            language model for advanced reasoning.</p>
+        </a>
+        <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2/tree/1.5" target="_blank"
           class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="text-2xl mb-2">🔬</div>
-          <h3 class="font-semibold mb-1" data-i18n="powered.2.t">LLaVA-OneVision-1.5</h3>
-          <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.2.d">Fully open framework for
+          <h3 class="font-semibold mb-1" data-i18n="powered.3.t">LLaVA-OneVision-1.5</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.3.d">Fully open framework for
             democratized multimodal training.</p>
         </a>
         <a href="https://github.com/baidubce/Qianfan-VL" target="_blank"
           class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="text-2xl mb-2">🎯</div>
-          <h3 class="font-semibold mb-1" data-i18n="powered.3.t">Qianfan-VL</h3>
-          <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.3.d">Domain-enhanced universal
+          <h3 class="font-semibold mb-1" data-i18n="powered.4.t">Qianfan-VL</h3>
+          <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.4.d">Domain-enhanced universal
             vision-language models.</p>
         </a>
       </div>
@@ -805,7 +859,7 @@ MODEL_PARALLEL_ARGS=(
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-yaml.min.js"></script>
-  <script src="assets/js/main.js?v=20260522-benchmark"></script>
+  <script src="assets/js/main.js?v=20260612-embodied3"></script>
   <script src="assets/js/home-news.js"></script>
 </body>
 

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -3,6 +3,8 @@
   <url><loc>https://baidu-baige.github.io/LoongForge/</loc><changefreq>weekly</changefreq><priority>1.0</priority></url>
   <url><loc>https://baidu-baige.github.io/LoongForge/blog.html</loc><changefreq>weekly</changefreq><priority>0.9</priority></url>
   <url><loc>https://baidu-baige.github.io/LoongForge/about.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
+  <url><loc>https://baidu-baige.github.io/LoongForge/blog/2026-07-announcing-loongforge-embodied.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
+  <url><loc>https://baidu-baige.github.io/LoongForge/blog/2026-07-announcing-loongforge-embodied.zh.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://baidu-baige.github.io/LoongForge/blog/2026-06-loongforge-groot-n16-acceleration.html</loc><changefreq>monthly</changefreq><priority>0.8</priority></url>
   <url><loc>https://baidu-baige.github.io/LoongForge/blog/2026-06-loongforge-groot-n16-acceleration.zh.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>
   <url><loc>https://baidu-baige.github.io/LoongForge/blog/2026-05-loongforge-heterogeneous-parallel-training.html</loc><changefreq>monthly</changefreq><priority>0.7</priority></url>


### PR DESCRIPTION
- New blog: LoongForge-Embodied release announcement (EN + ZH), plus posts.json / sitemap entries and prose-lf table styling.
- Homepage: multi-backend tagline (Megatron-LM + torch-native DDP/FSDP), new Embodied feature card, merged Heterogeneous/Disaggregated card, refreshed benchmark bars (DreamZero/GR00T/Pi0.5/LingBot VA/Qwen3-VL), expanded Supported Models (DeepSeek-V4, Kimi-K2.x, Diffusion trio, Embodied tab), Powered-by adds Innovator-VL and clearer subtitle.
- blog.js already auto-features the latest post by date.