### PR TITLE
[fastwam] perf: use channels_last memory format in VAE encode

### DIFF
--- a/loongforge/embodied/model/fastwam/wan/vae.py
+++ b/loongforge/embodied/model/fastwam/wan/vae.py
@@ -186,8 +186,10 @@ class Resample(nn.Module):
                     x = x.reshape(b, c, t * 2, h, w)
         t = x.shape[2]
         x = rearrange(x, 'b c t h w -> (b t) c h w')
+        x = x.to(memory_format=torch.channels_last)  # maintain NHWC for 4D ops
         x = self.resample(x)
         x = rearrange(x, '(b t) c h w -> b c t h w', t=t)
+        x = x.to(memory_format=torch.channels_last_3d)  # restore 5D NHWC
 
         if self.mode == 'downsample3d':
             if feat_cache is not None:
@@ -362,6 +364,7 @@ class AttentionBlock(nn.Module):
         identity = x
         b, c, t, h, w = x.size()
         x = rearrange(x, 'b c t h w -> (b t) c h w')
+        x = x.to(memory_format=torch.channels_last)  # maintain NHWC for 4D ops
         x = self.norm(x)
         # compute query, key, value
         q, k, v = self.to_qkv(x).reshape(b * t, 1, c * 3, -1).permute(
@@ -379,6 +382,7 @@ class AttentionBlock(nn.Module):
         # output
         x = self.proj(x)
         x = rearrange(x, '(b t) c h w-> b c t h w', t=t)
+        x = x.to(memory_format=torch.channels_last_3d)  # restore 5D NHWC
         return x + identity
 
 
@@ -408,7 +412,7 @@ class AvgDown3D(nn.Module):
         pad = (0, 0, 0, 0, pad_t, 0)
         x = F.pad(x, pad)
         B, C, T, H, W = x.shape
-        x = x.view(
+        x = x.reshape(
             B,
             C,
             T // self.factor_t,
@@ -1410,6 +1414,7 @@ class VideoVAE38Core(VideoVAECore):
         """Encode videos or tensors into latent states."""
         self.clear_cache()
         x = patchify(x, patch_size=2)
+        x = x.to(memory_format=torch.channels_last_3d)  # NHWC to avoid per-layer format conversion
         t = x.shape[2]
         iter_ = 1 + (t - 1) // 4
         for i in range(iter_):
@@ -1433,7 +1438,7 @@ class VideoVAE38Core(VideoVAECore):
                 scale = scale.to(dtype=mu.dtype, device=mu.device)
                 mu = (mu - scale[0]) * scale[1]
         self.clear_cache()
-        return mu
+        return mu.contiguous()
 
 
     def decode(self, z, scale=None):


### PR DESCRIPTION
## Summary

Optimize memory layout in the FastWAM Wan VAE to eliminate redundant NCHW/NHWC
conversions during the encode path.

## Root cause

cuDNN executes Conv3d internally in NHWC (channels-last), while PyTorch tensors
default to NCHW (contiguous). As a result, every conv layer pays for a layout
conversion on both its input and output.

## Approach

- Convert the layout once at the entry point: after `patchify`, the input is moved
  to `torch.channels_last_3d`.
- Preserve the matching channels-last format across 4D/5D transitions: where the
  tensor is reshaped from 5D to 4D for 2D ops (`Resample`, `AttentionBlock`),
  explicitly switch to `torch.channels_last`, and restore `torch.channels_last_3d`
  on the way back.
- Convert back to a contiguous tensor at the exit point, so downstream consumers
  see the original layout.
- `AvgDown3D` uses `reshape` instead of `view`, since the tensor is no longer
  guaranteed to be contiguous under channels-last.

## Results

- Loss curves match the baseline (bitwise-equivalent training behavior).
<img width="1152" height="864" alt="4fd5d2ccc11e54f66cb405178453ce32" src="https://github.com/user-attachments/assets/1cb0603e-e696-4391-aa54-94c05f328fcc" />

- End-to-end throughput improves by **5.66%**. The VAE only runs a forward pass
  here, so the gain comes entirely from the forward stage.
<img width="1526" height="759" alt="d6085a340d1e29443788dbb50ad20a59" src="https://github.com/user-attachments/assets/acc8cb50-5161-431f-96b0-38461be84591" />

## Scope

Single file: `loongforge/embodied/model/fastwam/wan/vae.py`




