### PR TITLE
[docs] docs: remove ENABLE_LEROBOT flag, unify to single Docker image

### DIFF
--- a/docs/source/get_started/installation.md
+++ b/docs/source/get_started/installation.md
@@ -68,14 +68,18 @@ git clone --recurse-submodules https://github.com/baidu-baige/LoongForge.git
 Then build the image:
 
 ```bash
-docker build --build-arg COMPILE_ENV=hopper --build-arg ENABLE_LEROBOT=false \
+docker build --build-arg COMPILE_ENV=hopper \
   -t loongforge:latest -f ./LoongForge/docker/Dockerfile .
 ```
+
+> **Note:** All model families (LLM / VLM / VLA / Diffusion) now share a single
+> Docker image. The `ENABLE_LEROBOT` build argument and the separate `_lerobot`
+> image variant have been removed — there is no longer a lerobot / non-lerobot
+> distinction when building or pulling images.
 
 | Build Arg | Description | Options |
 |---|---|---|
 | `COMPILE_ENV` | Target GPU architecture | `ampere`, `hopper`|
-| `ENABLE_LEROBOT` | Enable LeRobot dependencies for VLA model training (e.g., Pi0.5, GR00T). Disabled by default due to dependency conflicts with the base environment. | `true`, `false` |
 
 After the build finishes, verify:
 
@@ -91,23 +95,19 @@ LoongForge Docker images are available on Docker Hub:
 [https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge).
 
 LoongForge publishes versioned pre-built Docker images. Select the desired tag
-from Docker Hub. LeRobot images use the same version tag with a `_lerobot` suffix
-when available.
+from Docker Hub. A single image covers all model families (LLM / VLM / VLA /
+Diffusion) — there is no longer a separate `_lerobot` variant.
 
 | Image | Tag Pattern | Description |
 |---|---|---|
-| `loongforge/loongforge` | `<version>` | Base image: LLM / VLM / Diffusion training only |
-| `loongforge/loongforge` | `<version>_lerobot` | Includes LeRobot dependencies for VLA training (Pi0.5 + GR00T) |
+| `loongforge/loongforge` | `<version>` | Unified image: LLM / VLM / VLA / Diffusion training |
 
 ```bash
 # Set the version tag you want to use, for example: 0.1.1
 LOONGFORGE_VERSION=<version>
 
-# Pull the base image
+# Pull the image
 docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
-
-# Pull the image with LeRobot support
-docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 ```
 
 ### Run the container
@@ -116,52 +116,14 @@ docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 # Set the version tag you want to use, for example: 0.1.1
 LOONGFORGE_VERSION=<version>
 
-# Using the base image (LLM/VLM/Diffusion)
 docker run --runtime=nvidia --gpus all -itd --rm \
   -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
   -v /path/to/data:/mnt/cluster/LoongForge/ \
   loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
-
-# Using the LeRobot image (VLA: Pi0.5 + GR00T)
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
 ```
 
 Once inside the container, navigate to `/workspace/LoongForge/examples/` and
-launch the desired training script. For GR00T training, remember to activate
-the GR00T virtual environment first (see Dual Python Environment below).
-
-### Dual Python Environment in the LeRobot Image
-
-The LeRobot image (`<version>_lerobot`) uses a **dual virtual-environment** setup to resolve
-dependency conflicts between Pi0.5 and GR00T:
-
-| Environment | Path | Default? | Use Case |
-|---|---|---|---|
-| Base (Pi0.5) | System Python | Yes | Pi0.5 VLA training |
-| GR00T | `/opt/venvs/gr00t` | No | GR00T-N1.6 VLA training |
-
-**To activate the GR00T environment inside the container:**
-
-```bash
-source /opt/venvs/gr00t/bin/activate
-# or use the convenience alias:
-use-gr00t
-```
-
-**To return to the base (Pi0.5) environment:**
-
-```bash
-deactivate
-```
-
-**For distributed training, use the venv's torchrun:**
-
-```bash
-/opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
-```
+launch the desired training script.
 
 ---
 

--- a/docs/source/kunlun_tutorial/install_p800.md
+++ b/docs/source/kunlun_tutorial/install_p800.md
@@ -28,22 +28,24 @@ Then build the image:
 
 ```bash
 BASE_IMAGE=loongforge/loongforge_kunlun:py310_torch25
-ENABLE_LEROBOT=false
 DEFAULT_XPYTORCH_URL_ARG=https://baidu-kunlun-public.su.bcebos.com/baidu-kunlun-share/20260409/torch25/xpytorch-cp310-torch251-ubuntu2004-x64.run
 
 docker build  \
     --build-arg BASE_IMAGE=${BASE_IMAGE} \
-    --build-arg ENABLE_LEROBOT=${ENABLE_LEROBOT} \
     --build-arg XPYTORCH_URL_ARG="${DEFAULT_XPYTORCH_URL_ARG}" \
     -t LoongForge-kunlun:latest -f LoongForge/docker/Dockerfile.xpu .
     # For internal conda image:
     #-t LoongForge-kunlun:latest -f LoongForge/docker/Dockerfile.xpu.internal .
 ```
+
+> **Note:** All model families (LLM / VLM / VLA / Diffusion) now share a single
+> Docker image. The `ENABLE_LEROBOT` build argument has been removed — there is
+> no longer a lerobot / non-lerobot distinction when building images.
+
 - `BASE_IMAGE` is the base image used for building. Options include:
   * `loongforge/loongforge_kunlun:py310_torch25` (default) [available at Docker Hub]
   * `iregistry.baidu-int.com/xmlir/xmlir_ubuntu_2004_x86_64:v0.33` [internal use only]
 - `XPYTORCH_URL_ARG` is the xpytorch installer url argument.
-- `ENABLE_LEROBOT`: enable LeRobot dependencies for VLA model training (e.g., Pi0.5, GR00T). Disabled by default due to dependency conflicts with the base environment. Options: `true`, `false` (default).
 After building, you can verify the image:
 
 ```bash

--- a/docs/source_zh/get_started/installation.md
+++ b/docs/source_zh/get_started/installation.md
@@ -60,14 +60,15 @@ git clone --recurse-submodules https://github.com/baidu-baige/LoongForge.git
 然后构建镜像：
 
 ```bash
-docker build --build-arg COMPILE_ENV=hopper --build-arg ENABLE_LEROBOT=false \
+docker build --build-arg COMPILE_ENV=hopper \
   -t loongforge:latest -f ./LoongForge/docker/Dockerfile .
 ```
+
+> **说明**：所有模型系列（LLM / VLM / VLA / Diffusion）现在共用同一个 Docker 镜像。`ENABLE_LEROBOT` 构建参数以及单独的 `_lerobot` 镜像变体已被移除 —— 构建或拉取镜像时不再区分 lerobot 与非 lerobot。
 
 | 构建参数 | 描述 | 选项 |
 |---|---|---|
 | `COMPILE_ENV` | 目标 GPU 架构 | `ampere`, `hopper`|
-| `ENABLE_LEROBOT` | 启用 VLA 模型训练（如 Pi0.5, GR00T）的 LeRobot 依赖。由于与基础环境存在依赖冲突，默认禁用。 | `true`, `false` |
 
 构建完成后，验证：
 
@@ -83,22 +84,18 @@ LoongForge Docker 镜像保存在 Docker Hub：
 [https://hub.docker.com/u/loongforge](https://hub.docker.com/u/loongforge)。
 
 LoongForge 发布带版本号的预构建 Docker 镜像。请在 Docker Hub 中选择需要的 tag。
-LeRobot 镜像在可用时使用相同版本号并追加 `_lerobot` 后缀。
+单个镜像覆盖所有模型系列（LLM / VLM / VLA / Diffusion），不再提供单独的 `_lerobot` 变体。
 
 | 镜像 | 标签模式 | 描述 |
 |---|---|---|
-| `loongforge/loongforge` | `<version>` | 基础镜像：仅支持 LLM / VLM / Diffusion 训练 |
-| `loongforge/loongforge` | `<version>_lerobot` | 包含 VLA 训练（Pi0.5 + GR00T）的 LeRobot 依赖 |
+| `loongforge/loongforge` | `<version>` | 统一镜像：支持 LLM / VLM / VLA / Diffusion 训练 |
 
 ```bash
 # 设置需要使用的版本 tag，例如：0.1.1
 LOONGFORGE_VERSION=<version>
 
-# 拉取基础镜像
+# 拉取镜像
 docker pull loongforge/loongforge:${LOONGFORGE_VERSION}
-
-# 拉取带 LeRobot 支持的镜像
-docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 ```
 
 ### 运行容器
@@ -107,50 +104,13 @@ docker pull loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot
 # 设置需要使用的版本 tag，例如：0.1.1
 LOONGFORGE_VERSION=<version>
 
-# 使用基础镜像（LLM/VLM/Diffusion）
 docker run --runtime=nvidia --gpus all -itd --rm \
   -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
   -v /path/to/data:/mnt/cluster/LoongForge/ \
   loongforge/loongforge:${LOONGFORGE_VERSION} /bin/bash
-
-# 使用 LeRobot 镜像（VLA: Pi0.5 + GR00T）
-docker run --runtime=nvidia --gpus all -itd --rm \
-  -v /path/to/your/hf/models:/mnt/cluster/huggingface.co/ \
-  -v /path/to/data:/mnt/cluster/LoongForge/ \
-  loongforge/loongforge:${LOONGFORGE_VERSION}_lerobot /bin/bash
 ```
 
 进入容器后，导航到 `/workspace/LoongForge/examples/` 并启动所需的训练脚本。
-对于 GR00T 训练，请先激活 GR00T 虚拟环境（参见下方双 Python 环境说明）。
-
-### LeRobot 镜像中的双 Python 环境
-
-LeRobot 镜像（`<version>_lerobot`）使用**双虚拟环境**方案解决 Pi0.5 和 GR00T 之间的依赖冲突：
-
-| 环境 | 路径 | 是否默认 | 用途 |
-|---|---|---|---|
-| 基础环境（Pi0.5） | 系统 Python | 是 | Pi0.5 VLA 训练 |
-| GR00T | `/opt/venvs/gr00t` | 否 | GR00T-N1.6 VLA 训练 |
-
-**在容器中激活 GR00T 环境：**
-
-```bash
-source /opt/venvs/gr00t/bin/activate
-# 或使用快捷命令：
-use-gr00t
-```
-
-**返回基础（Pi0.5）环境：**
-
-```bash
-deactivate
-```
-
-**分布式训练请使用虚拟环境内的 torchrun：**
-
-```bash
-/opt/venvs/gr00t/bin/torchrun ${DISTRIBUTED_ARGS[@]} ...
-```
 
 ---
 

--- a/docs/source_zh/kunlun_tutorial/install_p800.md
+++ b/docs/source_zh/kunlun_tutorial/install_p800.md
@@ -28,22 +28,22 @@ git clone --recurse-submodules https://github.com/baidu-baige/LoongForge.git
 
 ```bash
 BASE_IMAGE=loongforge/loongforge_kunlun:py310_torch25
-ENABLE_LEROBOT=false
 DEFAULT_XPYTORCH_URL_ARG=https://baidu-kunlun-public.su.bcebos.com/baidu-kunlun-share/20260409/torch25/xpytorch-cp310-torch251-ubuntu2004-x64.run
 
 docker build  \
     --build-arg BASE_IMAGE=${BASE_IMAGE} \
-    --build-arg ENABLE_LEROBOT=${ENABLE_LEROBOT} \
     --build-arg XPYTORCH_URL_ARG="${DEFAULT_XPYTORCH_URL_ARG}" \
     -t LoongForge-kunlun:latest -f LoongForge/docker/Dockerfile.xpu .
     # 内部 conda 镜像：
     #-t LoongForge-kunlun:latest -f LoongForge/docker/Dockerfile.xpu.internal .
 ```
+
+> **说明**：所有模型系列（LLM / VLM / VLA / Diffusion）现在共用同一个 Docker 镜像。`ENABLE_LEROBOT` 构建参数已被移除 —— 构建镜像时不再区分 lerobot 与非 lerobot。
+
 - `BASE_IMAGE` 是用于构建的基础镜像。可选值包括：
   * `loongforge/loongforge_kunlun:py310_torch25`（默认）[Docker Hub 提供]
   * `iregistry.baidu-int.com/xmlir/xmlir_ubuntu_2004_x86_64:v0.33`[仅限内部使用]
 - `XPYTORCH_URL_ARG` 是 xpytorch 安装程序的 URL 参数。
-- `ENABLE_LEROBOT`：启用 VLA 模型训练（如 Pi0.5、GR00T）的 LeRobot 依赖。由于与基础环境存在依赖冲突，默认禁用。可选值：`true`、`false`（默认）。
 
 构建完成后，可验证镜像：
 


### PR DESCRIPTION
All model families (LLM/VLM/VLA/Diffusion) now share one image, so the ENABLE_LEROBOT build arg and the separate _lerobot image variant are gone.

- installation.md (EN/ZH): drop ENABLE_LEROBOT from the build command and build-arg table; collapse pre-built images to a single unified image; remove the _lerobot pull/run variants and the GR00T dual-Python-environment section; add a note explaining the single-image change
- install_p800.md (EN/ZH): drop ENABLE_LEROBOT from the build command and argument list; add a note