### PR TITLE
[vla] perf: use fused F.rms_norm in FastWAM VAE RMSNorm

### DIFF
--- a/loongforge/embodied/model/fastwam/wan/vae.py
+++ b/loongforge/embodied/model/fastwam/wan/vae.py
@@ -76,7 +76,7 @@ class CausalConv3d(nn.Conv3d):
 class RMSNorm(nn.Module):
     """Root mean square normalization supporting channel-first tensors."""
 
-    def __init__(self, dim, channel_first=True, images=True):
+    def __init__(self, dim, channel_first=True, images=True, bias=False):
         """Initialize learnable RMS normalization parameters."""
         super().__init__()
         broadcastable_dims = (1, 1, 1) if not images else (1, 1)
@@ -85,15 +85,18 @@ class RMSNorm(nn.Module):
         self.channel_first = channel_first
         self.eps = 1e-12
         self.gamma = nn.Parameter(torch.ones(shape))
+        self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.
 
     def forward(self, x):
-        """Normalize input tensor and apply scale parameters."""
+        """Normalize input tensor and apply scale and bias parameters."""
         weight = self.gamma.reshape(-1)
         if self.channel_first:
             # Move channels to the last axis so F.rms_norm can use the fused kernel.
             x = F.rms_norm(x.movedim(1, -1), weight.shape, weight=weight, eps=self.eps)
-            return x.movedim(-1, 1)
-        return F.rms_norm(x, weight.shape, weight=weight, eps=self.eps)
+            x = x.movedim(-1, 1)
+        else:
+            x = F.rms_norm(x, weight.shape, weight=weight, eps=self.eps)
+        return x + self.bias
 
 
 class Upsample(nn.Upsample):

--- a/loongforge/embodied/model/fastwam/wan/vae.py
+++ b/loongforge/embodied/model/fastwam/wan/vae.py
@@ -76,22 +76,24 @@ class CausalConv3d(nn.Conv3d):
 class RMSNorm(nn.Module):
     """Root mean square normalization supporting channel-first tensors."""
 
-    def __init__(self, dim, channel_first=True, images=True, bias=False):
+    def __init__(self, dim, channel_first=True, images=True):
         """Initialize learnable RMS normalization parameters."""
         super().__init__()
         broadcastable_dims = (1, 1, 1) if not images else (1, 1)
         shape = (dim, *broadcastable_dims) if channel_first else (dim,)
 
         self.channel_first = channel_first
-        self.scale = dim**0.5
+        self.eps = 1e-12
         self.gamma = nn.Parameter(torch.ones(shape))
-        self.bias = nn.Parameter(torch.zeros(shape)) if bias else 0.
 
     def forward(self, x):
-        """Normalize input tensor and apply scale and bias parameters."""
-        return F.normalize(
-            x, dim=(1 if self.channel_first else
-                    -1)) * self.scale * self.gamma + self.bias
+        """Normalize input tensor and apply scale parameters."""
+        weight = self.gamma.reshape(-1)
+        if self.channel_first:
+            # Move channels to the last axis so F.rms_norm can use the fused kernel.
+            x = F.rms_norm(x.movedim(1, -1), weight.shape, weight=weight, eps=self.eps)
+            return x.movedim(-1, 1)
+        return F.rms_norm(x, weight.shape, weight=weight, eps=self.eps)
 
 
 class Upsample(nn.Upsample):


### PR DESCRIPTION

Replace the hand-written RMSNorm in the Wan VAE with `F.rms_norm`.

The previous implementation expressed RMS normalization as `F.normalize(x, dim) * dim**0.5 * gamma + bias`, which launches four separate elementwise kernels over the full activation. `F.rms_norm` does the same work — `mean(x^2)` -> `rsqrt` -> scale by `gamma` — in a single fused kernel.

`F.rms_norm` normalizes over trailing dimensions only, while this module normalizes over the channel axis of `(B, C, T, H, W)` tensors. The channel-first path therefore moves channels to the last axis with `movedim(1, -1)` and moves them back afterwards; `movedim` only changes strides and does not copy.

## Why it is equivalent

`F.normalize(x, dim)` is `x / max(||x||_2, eps)`; multiplying by `sqrt(dim)` gives `x / sqrt(mean(x^2))`, which is the RMSNorm definition. The only difference is where `eps` is applied — clamped in the denominator before, added inside the square root now. `eps` is set explicitly to `1e-12` to match the previous `F.normalize` default.

## Verification

- Training loss curves match the baseline. 
<img width="1104" height="730" alt="image" src="https://github.com/user-attachments/assets/f5daf8b5-4fb1-45ef-b0f3-35c1bf6f5883" />

- End-to-end throughput: ~1% improvement in the typical case.
<img width="1104" height="557" alt="image" src="https://github.com/user-attachments/assets/385482b2-c357-448c-8642-53977b5f1094" />

## Notes

- Requires PyTorch >= 2.4 for `F.rms_norm`. No fallback is kept.
- Removes the unused `bias` argument from `RMSNorm.__init__`. It defaulted to `False` and no call site ever set it, so no parameter was created and checkpoint compatibility is unaffected. 