### PR TITLE
Refresh homepage visual design (Froala-inspired, light & spacious)

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,30 +1,44 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
-<meta charset="UTF-8" />
-<meta name="viewport" content="width=device-width,initial-scale=1.0" />
-<title>404 — LoongForge</title>
-<meta name="robots" content="noindex" />
-<link rel="icon" type="image/svg+xml" href="assets/img/logo.svg" />
-<link rel="preconnect" href="https://fonts.googleapis.com"><link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap" rel="stylesheet">
-<script src="https://cdn.tailwindcss.com"></script>
-<script>tailwind.config={darkMode:'class'};</script>
-<link rel="stylesheet" href="assets/css/style.css" />
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width,initial-scale=1.0" />
+  <title>404 — LoongForge</title>
+  <meta name="robots" content="noindex" />
+  <link rel="icon" type="image/svg+xml" href="assets/img/logo.svg" />
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&display=swap"
+    rel="stylesheet">
+  <script src="https://cdn.tailwindcss.com"></script>
+  <script>tailwind.config = { darkMode: 'class' };</script>
+  <link rel="stylesheet" href="assets/css/style.css" />
 </head>
+
 <body class="bg-white text-gray-900 dark:bg-gray-950 dark:text-gray-100">
-<main class="hero-gradient text-white min-h-screen flex items-center justify-center relative overflow-hidden">
-  <div class="hero-grid absolute inset-0"></div>
-  <div class="relative text-center px-6">
-    <div class="text-8xl md:text-9xl font-extrabold mb-4 text-gradient">404</div>
-    <h1 class="text-2xl md:text-3xl font-bold mb-3">This page drifted out of the pipeline.</h1>
-    <p class="text-gray-300 max-w-md mx-auto mb-8">The page you were looking for doesn't exist — or has been moved. Let's get you back on track.</p>
-    <div class="flex flex-wrap gap-3 justify-center">
-      <a href="index.html" class="px-6 py-3 rounded-full bg-white text-indigo-700 font-semibold hover:bg-indigo-50">🏠 Back to Home</a>
-      <a href="docs.html" class="px-6 py-3 rounded-full bg-white/10 hover:bg-white/20 border border-white/25 font-semibold">📚 Documentation</a>
-      <a href="https://github.com/baidu-baige/LoongForge" target="_blank" class="px-6 py-3 rounded-full bg-white/10 hover:bg-white/20 border border-white/25 font-semibold">⭐ GitHub</a>
+  <main
+    class="hero-gradient text-gray-900 dark:text-white min-h-screen flex items-center justify-center relative overflow-hidden">
+    <div class="hero-grid absolute inset-0"></div>
+    <div class="relative text-center px-6">
+      <div class="text-8xl md:text-9xl font-extrabold mb-4 text-gradient">404</div>
+      <h1 class="text-2xl md:text-3xl font-bold mb-3">This page drifted out of the pipeline.</h1>
+      <p class="text-gray-600 dark:text-gray-300 max-w-md mx-auto mb-8">The page you were looking for doesn't exist — or
+        has been moved. Let's get you back on track.</p>
+      <div class="flex flex-wrap gap-3 justify-center">
+        <a href="index.html"
+          class="px-6 py-3 rounded-full bg-indigo-600 text-white font-semibold hover:bg-indigo-500 dark:bg-white dark:text-indigo-700 dark:hover:bg-indigo-50">🏠
+          Back to Home</a>
+        <a href="docs.html"
+          class="px-6 py-3 rounded-full bg-white border border-indigo-200 text-indigo-700 hover:bg-indigo-50 font-semibold dark:bg-white/10 dark:hover:bg-white/20 dark:border-white/25 dark:text-white">📚
+          Documentation</a>
+        <a href="https://github.com/baidu-baige/LoongForge" target="_blank"
+          class="px-6 py-3 rounded-full bg-white border border-indigo-200 text-indigo-700 hover:bg-indigo-50 font-semibold dark:bg-white/10 dark:hover:bg-white/20 dark:border-white/25 dark:text-white">⭐
+          GitHub</a>
+      </div>
     </div>
-  </div>
-</main>
-<script src="assets/js/main.js"></script>
-</body></html>
+  </main>
+  <script src="assets/js/main.js"></script>
+</body>
+
+</html>

--- a/about.html
+++ b/about.html
@@ -25,12 +25,13 @@
   <!-- Shared navbar (rendered by main.js) -->
   <header data-site-header data-active="about"></header>
 
-  <section class="hero-gradient text-white">
-    <div class="max-w-7xl mx-auto px-6 py-20 text-center relative">
+  <section class="hero-gradient text-gray-900 dark:text-white">
+    <div class="max-w-7xl mx-auto px-6 py-24 md:py-28 text-center relative">
       <div class="hero-grid absolute inset-0"></div>
       <div class="relative">
         <h1 class="text-4xl md:text-5xl font-extrabold mb-3" data-i18n="about.hero.title">About LoongForge</h1>
-        <p class="text-gray-300 max-w-2xl mx-auto" data-i18n="about.hero.desc">A training framework born from
+        <p class="text-gray-600 dark:text-gray-300 max-w-2xl mx-auto" data-i18n="about.hero.desc">A training framework
+          born from
           real-world, large-scale production workloads — and shared back with the community</p>
       </div>
     </div>

--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -3,7 +3,7 @@
 /* Reserve navbar height before JS injects the shared header (prevents layout shift) */
 header[data-site-header]:empty {
   display: block;
-  min-height: 61px;
+  min-height: 73px;
   background: rgba(255, 255, 255, 0.8);
   backdrop-filter: blur(8px);
   border-bottom: 1px solid #e5e7eb;
@@ -22,6 +22,241 @@ header[data-site-header]:empty {
   --lf-primary-dark: #4F46E5;
   --lf-accent: #F59E0B;
   --lf-ink: #0B1020;
+
+  /* Airy light surfaces + spacing scale (visual refresh) */
+  --lf-surface: #ffffff;
+  --lf-surface-soft: #F7F8FF;
+  /* very light indigo wash for light sections */
+  --lf-hero-from: #FFFFFF;
+  --lf-hero-to: #EEF1FF;
+  /* white -> soft indigo hero */
+  --lf-card-radius: 1.25rem;
+  --lf-card-pad: 1.75rem;
+  --lf-card-shadow: 0 12px 32px -18px rgba(79, 70, 229, .28);
+  --lf-card-shadow-hover: 0 24px 56px -24px rgba(79, 70, 229, .40);
+
+  /* Round 2: signature gradient + fresh secondary accent */
+  --lf-cyan: #06B6D4;
+  --lf-grad: linear-gradient(120deg, #4F46E5 0%, #7C3AED 50%, #DB2777 100%);
+  --lf-grad-soft: linear-gradient(120deg, #6366F1 0%, #8B5CF6 55%, #06B6D4 100%);
+}
+
+/* ===== Round 2 components ===== */
+
+/* Gradient primary button */
+.lf-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .85rem 1.6rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  color: #fff;
+  background: var(--lf-grad);
+  box-shadow: 0 14px 30px -12px rgba(124, 58, 237, .55);
+  transition: transform .2s ease, box-shadow .2s ease, filter .2s ease;
+}
+
+.lf-btn:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 20px 40px -14px rgba(124, 58, 237, .65);
+  filter: saturate(1.08);
+}
+
+.lf-btn-ghost {
+  display: inline-flex;
+  align-items: center;
+  gap: .5rem;
+  padding: .85rem 1.6rem;
+  border-radius: 9999px;
+  font-weight: 700;
+  color: #4F46E5;
+  background: #fff;
+  border: 1.5px solid #C7D2FE;
+  transition: all .2s ease;
+}
+
+.lf-btn-ghost:hover {
+  background: #EEF2FF;
+  border-color: #A5B4FC;
+  transform: translateY(-2px);
+}
+
+.dark .lf-btn-ghost {
+  background: rgba(255, 255, 255, .08);
+  color: #E0E7FF;
+  border-color: rgba(255, 255, 255, .2);
+}
+
+.dark .lf-btn-ghost:hover {
+  background: rgba(255, 255, 255, .16);
+}
+
+/* Gradient stat band (the "grand" anchor under the hero) */
+.lf-statband {
+  background: var(--lf-grad);
+  color: #fff;
+  position: relative;
+  overflow: hidden;
+}
+
+.lf-statband::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background:
+    radial-gradient(600px 260px at 15% 0%, rgba(255, 255, 255, .18), transparent 60%),
+    radial-gradient(600px 260px at 85% 100%, rgba(6, 182, 212, .28), transparent 60%);
+  pointer-events: none;
+}
+
+.lf-statband .lf-stat-grid {
+  position: relative;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 0;
+}
+
+.lf-statband .lf-stat {
+  text-align: center;
+  padding: 1.5rem 1rem;
+  border-right: 1px solid rgba(255, 255, 255, .18);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.lf-statband .lf-stat:last-child {
+  border-right: 0;
+}
+
+.lf-statband .lf-stat-num {
+  font-size: clamp(1.75rem, 2.4vw, 2.3rem);
+  font-weight: 800;
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  white-space: nowrap;
+  height: 2.6rem;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.lf-statband .lf-stat-label {
+  margin-top: .35rem;
+  font-size: .82rem;
+  font-weight: 500;
+  color: rgba(255, 255, 255, .82);
+}
+
+.dark .lf-statband {
+  background: linear-gradient(120deg, #3730A3 0%, #5B21B6 50%, #9D174D 100%);
+}
+
+@media (max-width: 900px) {
+  .lf-statband .lf-stat-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .lf-statband .lf-stat:nth-child(2n) {
+    border-right: 0;
+  }
+
+  .lf-statband .lf-stat {
+    border-bottom: 1px solid rgba(255, 255, 255, .18);
+  }
+}
+
+/* Round icon chip for feature cards */
+.lf-ico {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: .9rem;
+  font-size: 1.4rem;
+  background: linear-gradient(135deg, #EEF2FF, #F5F3FF);
+  border: 1px solid #E0E7FF;
+}
+
+.dark .lf-ico {
+  background: linear-gradient(135deg, rgba(99, 102, 241, .18), rgba(139, 92, 246, .16));
+  border-color: rgba(99, 102, 241, .3);
+}
+
+/* Circular step number badge (Quick Start) */
+.lf-step-num {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.5rem;
+  height: 2.5rem;
+  border-radius: 9999px;
+  background: var(--lf-grad);
+  color: #fff;
+  font-weight: 800;
+  font-size: 1.1rem;
+  box-shadow: 0 8px 20px -8px rgba(124, 58, 237, .5);
+  flex-shrink: 0;
+}
+
+/* Highlighted quick-start example chip */
+.qs-chip {
+  display: inline-flex;
+  align-items: center;
+  gap: .45rem;
+  padding: .6rem 1.05rem;
+  border-radius: 9999px;
+  font-size: .9rem;
+  font-weight: 600;
+  background: #EEF2FF;
+  color: #4338CA;
+  border: 1px solid #E0E7FF;
+  transition: all .15s ease;
+}
+
+.qs-chip code {
+  color: inherit;
+}
+
+.qs-chip:hover {
+  background: #E0E7FF;
+  border-color: #C7D2FE;
+  transform: translateY(-1px);
+}
+
+.dark .qs-chip {
+  background: rgba(99, 102, 241, .15);
+  color: #C7D2FE;
+  border-color: rgba(99, 102, 241, .3);
+}
+
+.dark .qs-chip:hover {
+  background: rgba(99, 102, 241, .25);
+}
+
+/* Big, airy card block */
+.lf-card {
+  border-radius: var(--lf-card-radius);
+  padding: var(--lf-card-pad);
+  background: var(--lf-surface);
+  border: 1px solid #E9EBF5;
+  box-shadow: var(--lf-card-shadow);
+  transition: transform .25s ease, box-shadow .25s ease, border-color .25s ease;
+}
+
+.lf-card:hover {
+  transform: translateY(-4px);
+  box-shadow: var(--lf-card-shadow-hover);
+  border-color: #C7D2FE;
+}
+
+.dark .lf-card {
+  background: #0f172a;
+  border-color: #1f2937;
+  box-shadow: none;
 }
 
 html {
@@ -53,22 +288,37 @@ pre,
   box-shadow: 0 0 8px rgba(99, 102, 241, .6);
 }
 
-/* Animated gradient hero background */
+/* Airy light hero background (light mode) */
 .hero-gradient {
+  background:
+    radial-gradient(1100px 520px at 12% -8%, rgba(99, 102, 241, 0.16), transparent 60%),
+    radial-gradient(900px 480px at 88% 8%, rgba(245, 158, 11, 0.12), transparent 60%),
+    radial-gradient(820px 520px at 50% 108%, rgba(139, 92, 246, 0.14), transparent 60%),
+    linear-gradient(180deg, var(--lf-hero-from) 0%, var(--lf-hero-to) 100%);
+  position: relative;
+}
+
+/* Dark mode keeps the original deep background */
+.dark .hero-gradient {
   background:
     radial-gradient(1200px 600px at 10% -10%, rgba(99, 102, 241, 0.35), transparent 60%),
     radial-gradient(900px 500px at 90% 10%, rgba(245, 158, 11, 0.22), transparent 60%),
     radial-gradient(800px 500px at 50% 100%, rgba(139, 92, 246, 0.25), transparent 60%),
     linear-gradient(180deg, #0B1020 0%, #0B1020 100%);
-  position: relative;
 }
 
 .hero-grid {
   background-image:
-    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
+    linear-gradient(rgba(99, 102, 241, 0.06) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(99, 102, 241, 0.06) 1px, transparent 1px);
   background-size: 48px 48px;
   mask-image: radial-gradient(ellipse at center, black 40%, transparent 80%);
+}
+
+.dark .hero-grid {
+  background-image:
+    linear-gradient(rgba(255, 255, 255, 0.05) 1px, transparent 1px),
+    linear-gradient(90deg, rgba(255, 255, 255, 0.05) 1px, transparent 1px);
 }
 
 /* Floating glow orbs in hero */
@@ -76,9 +326,13 @@ pre,
   position: absolute;
   border-radius: 50%;
   filter: blur(60px);
-  opacity: .45;
+  opacity: .28;
   pointer-events: none;
   animation: orb-float 18s ease-in-out infinite alternate;
+}
+
+.dark .hero-orb {
+  opacity: .45;
 }
 
 .hero-orb.o1 {
@@ -121,12 +375,37 @@ pre,
   }
 }
 
-/* Text gradient */
+/* Text gradient (light mode: deeper brand hues for contrast on light hero) */
 .text-gradient {
+  background: linear-gradient(90deg, #4F46E5 0%, #7C3AED 50%, #DB2777 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+}
+
+.dark .text-gradient {
   background: linear-gradient(90deg, #A5B4FC 0%, #FDE68A 50%, #F472B6 100%);
   -webkit-background-clip: text;
   background-clip: text;
   color: transparent;
+}
+
+/* Wave divider between hero and content */
+.lf-wave {
+  line-height: 0;
+  margin-top: -1px;
+}
+
+.lf-wave svg {
+  display: block;
+  width: 100%;
+  height: 120px;
+}
+
+@media (max-width: 640px) {
+  .lf-wave svg {
+    height: 64px;
+  }
 }
 
 /* Card hover */
@@ -135,8 +414,8 @@ pre,
 }
 
 .card-hover:hover {
-  transform: translateY(-3px);
-  box-shadow: 0 20px 40px -20px rgba(99, 102, 241, .35);
+  transform: translateY(-4px);
+  box-shadow: var(--lf-card-shadow-hover);
 }
 
 /* Key Features — flat card grid with category tag */
@@ -233,7 +512,7 @@ pre,
 /* Gradient-border card */
 .gradient-border {
   position: relative;
-  border-radius: 1rem;
+  border-radius: var(--lf-card-radius);
   background: #fff;
 }
 
@@ -626,7 +905,7 @@ pre.cite-pre>code[class*="language-"] {
   border: 1px solid #E5E7EB;
   border-radius: 9999px;
   padding: 2px;
-  font-size: 12px;
+  font-size: 13px;
   font-weight: 600;
 }
 
@@ -636,7 +915,7 @@ pre.cite-pre>code[class*="language-"] {
 }
 
 .lang-switch button {
-  padding: 4px 10px;
+  padding: 5px 12px;
   border-radius: 9999px;
   color: #6B7280;
   transition: all .15s ease;
@@ -656,13 +935,13 @@ pre.cite-pre>code[class*="language-"] {
 .gh-pill {
   display: inline-flex;
   align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
+  gap: 7px;
+  padding: 8px 14px;
   border-radius: 9999px;
   border: 1px solid #D1D5DB;
   background: #fff;
   color: #111827;
-  font-size: 13px;
+  font-size: 14px;
   font-weight: 600;
   transition: all .15s ease;
 }
@@ -684,8 +963,8 @@ pre.cite-pre>code[class*="language-"] {
 }
 
 .gh-pill svg {
-  width: 16px;
-  height: 16px;
+  width: 18px;
+  height: 18px;
 }
 
 .gh-pill .star {
@@ -843,7 +1122,7 @@ footer a:hover {
 
 .stats-strip>div {
   flex: 1 1 200px;
-  padding: 1.25rem;
+  padding: 1.75rem;
   text-align: center;
   border-right: 1px solid rgba(99, 102, 241, .12);
 }

--- a/assets/img/loongforge-architecture-dark.svg
+++ b/assets/img/loongforge-architecture-dark.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="8 10 1786 830" width="100%" font-family="'Comic Sans MS','Comic Sans','Chalkboard SE','Bradley Hand',cursive">
+  <defs>
+    <filter id="sketch" x="-4%" y="-4%" width="108%" height="108%">
+      <feTurbulence type="turbulence" baseFrequency="0.013" numOctaves="2" seed="7" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="3" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+  </defs>
+
+  <!-- dark card background -->
+  <rect x="12" y="14" width="1778" height="822" rx="24" fill="#0F1420" stroke="#2A3040" stroke-width="2"/>
+
+  <!-- ============ SHAPES (hand-drawn / filtered) ============ -->
+  <g filter="url(#sketch)">
+    <!-- MODEL row cards -->
+    <rect x="320" y="118" width="820" height="214" rx="18" fill="#171D30" stroke="#6E82FF" stroke-width="2.6"/>
+    <rect x="1160" y="118" width="560" height="214" rx="18" fill="#241B10" stroke="#F0A040" stroke-width="2.6"/>
+
+    <!-- model tag pills : Foundation (blue) -->
+    <rect x="356" y="196" width="70" height="30" rx="9" fill="#4E63E6"/>
+    <rect x="356" y="240" width="70" height="30" rx="9" fill="#4E63E6"/>
+    <rect x="356" y="284" width="104" height="30" rx="9" fill="#4E63E6"/>
+    <!-- model tag pills : Embodied (amber) -->
+    <rect x="1192" y="210" width="66" height="30" rx="9" fill="#E89A32"/>
+    <rect x="1192" y="262" width="66" height="30" rx="9" fill="#E89A32"/>
+
+    <!-- ENGINE row cards -->
+    <rect x="320" y="360" width="820" height="320" rx="18" fill="#171D30" stroke="#6E82FF" stroke-width="2.6"/>
+    <rect x="1160" y="360" width="560" height="320" rx="18" fill="#241B10" stroke="#F0A040" stroke-width="2.6"/>
+
+    <!-- Megatron capability chips (2 x 3) -->
+    <rect x="350" y="425" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+    <rect x="738" y="425" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+    <rect x="350" y="511" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+    <rect x="738" y="511" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+    <rect x="350" y="597" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+    <rect x="738" y="597" width="372" height="72" rx="12" fill="#1E2540" stroke="#5566D8" stroke-width="1.6"/>
+
+    <!-- torch-native track capability chips (1 x 4) -->
+    <rect x="1192" y="428" width="496" height="54" rx="12" fill="#2C2114" stroke="#B5772A" stroke-width="1.6"/>
+    <rect x="1192" y="490" width="496" height="54" rx="12" fill="#2C2114" stroke="#B5772A" stroke-width="1.6"/>
+    <rect x="1192" y="552" width="496" height="54" rx="12" fill="#2C2114" stroke="#B5772A" stroke-width="1.6"/>
+    <rect x="1192" y="614" width="496" height="54" rx="12" fill="#2C2114" stroke="#B5772A" stroke-width="1.6"/>
+
+    <!-- HARDWARE band -->
+    <rect x="320" y="710" width="1400" height="100" rx="18" fill="#0E2420" stroke="#2BB9A8" stroke-width="2.6"/>
+    <!-- hardware backends (uniform: both are supported accelerators) -->
+    <rect x="360" y="732" width="640" height="56" rx="14" fill="#16382F" stroke="#2BB9A8" stroke-width="2.4"/>
+    <rect x="1040" y="732" width="640" height="56" rx="14" fill="#16382F" stroke="#2BB9A8" stroke-width="2.4"/>
+  </g>
+
+  <!-- ============ ICONS (small accents) ============ -->
+  <g filter="url(#sketch)">
+    <!-- star before Foundation title -->
+    <path transform="translate(370,150)" d="M0,-10 C1,-3 3,-1 10,0 C3,1 1,3 0,10 C-1,3 -3,1 -10,0 C-3,-1 -1,-3 0,-10 Z" fill="#6E82FF"/>
+    <!-- sparkle before Embodied title -->
+    <path transform="translate(1206,150)" d="M0,-10 C1,-3 3,-1 10,0 C3,1 1,3 0,10 C-1,3 -3,1 -10,0 C-3,-1 -1,-3 0,-10 Z" fill="#F0A040"/>
+    <!-- lightning before Megatron title -->
+    <path transform="translate(370,395)" d="M3,-13 L-5,3 L0,3 L-3,13 L8,-3 L2,-3 Z" fill="#6E82FF"/>
+    <!-- lightning before torch-native title -->
+    <path transform="translate(1208,395)" d="M3,-13 L-5,3 L0,3 L-3,13 L8,-3 L2,-3 Z" fill="#F0A040"/>
+    <!-- pillar icons (left axis) -->
+    <g transform="translate(160,205)" fill="#B79BFF">
+      <rect x="-16" y="-16" width="13" height="13" rx="3"/>
+      <rect x="3" y="-16" width="13" height="13" rx="3"/>
+      <rect x="-16" y="3" width="13" height="13" rx="3"/>
+      <rect x="3" y="3" width="13" height="13" rx="3"/>
+    </g>
+    <path transform="translate(160,500)" d="M5,-17 L-8,4 L-1,4 L-5,17 L9,-5 L2,-5 Z" fill="#8496FF"/>
+    <g transform="translate(160,740)" stroke="#33D0BE" stroke-width="2.6" fill="none">
+      <rect x="-13" y="-13" width="26" height="26" rx="4" fill="#33D0BE" opacity="0.2"/>
+      <line x1="-5" y1="-13" x2="-5" y2="-19"/><line x1="5" y1="-13" x2="5" y2="-19"/>
+      <line x1="-5" y1="13" x2="-5" y2="19"/><line x1="5" y1="13" x2="5" y2="19"/>
+      <line x1="-13" y1="-5" x2="-19" y2="-5"/><line x1="-13" y1="5" x2="-19" y2="5"/>
+      <line x1="13" y1="-5" x2="19" y2="-5"/><line x1="13" y1="5" x2="19" y2="5"/>
+    </g>
+  </g>
+
+  <!-- ============ TEXT (crisp) ============ -->
+  <g fill="#DBE0EC">
+    <!-- Title -->
+    <text x="875" y="64" text-anchor="middle" font-size="48" font-weight="bold" letter-spacing="0.5" fill="#F2F5FA">LoongForge Architecture</text>
+
+    <!-- ===== value pillars (left axis, aligned to each layer) ===== -->
+    <text x="160" y="253" font-size="26" font-weight="bold" fill="#B79BFF" text-anchor="middle">Unified</text>
+    <text x="160" y="548" font-size="26" font-weight="bold" fill="#8496FF" text-anchor="middle">High-Performance</text>
+    <text x="160" y="788" font-size="26" font-weight="bold" fill="#33D0BE" text-anchor="middle">Multi-Chip</text>
+
+    <!-- ===== Foundation & Multimodal Models ===== -->
+    <text x="390" y="159" font-size="27" font-weight="bold" fill="#8496FF">Foundation &amp; Multimodal Models</text>
+    <text x="391" y="217" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">LLM</text>
+    <text x="391" y="261" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">VLM</text>
+    <text x="408" y="305" font-size="16" font-weight="bold" letter-spacing="0.4" fill="#FFFFFF" text-anchor="middle">Diffusion</text>
+    <text x="480" y="217" font-size="19" fill="#DBE0EC">DeepSeek &#183; Qwen &#183; GLM &#183; LLaMA &#183; MiniMax &#183; MIMO</text>
+    <text x="480" y="261" font-size="19" fill="#DBE0EC">Qwen-VL &#183; InternVL &#183; LLaVA-OV &#183; Kimi &#183; ERNIE &#183; Custom</text>
+    <text x="480" y="305" font-size="19" fill="#DBE0EC">Wan2.2 &#183; Wan2.1 &#183; Qwen-Image</text>
+
+    <!-- ===== Embodied Models ===== -->
+    <text x="1226" y="159" font-size="27" font-weight="bold" fill="#F5A93D">Embodied Models</text>
+    <text x="1225" y="231" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">VLA</text>
+    <text x="1225" y="283" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">WAM</text>
+    <text x="1272" y="231" font-size="18" fill="#DBE0EC">GR00T N1.6/N1.7 &#183; Pi0.5 &#183; X-VLA</text>
+    <text x="1272" y="283" font-size="18" fill="#DBE0EC">FastWAM &#183; DreamZero &#183; LingBot-VA &#183; Cosmos3</text>
+
+    <!-- ===== Megatron Track ===== -->
+    <text x="390" y="405" font-size="27" font-weight="bold" fill="#8496FF">Megatron Track</text>
+    <text x="700" y="406" font-size="16" font-style="italic" fill="#AAB2C1">LLM &#183; VLM &#183; Diffusion</text>
+
+    <!-- Megatron chips -->
+    <text x="366" y="455" font-size="17" font-weight="bold" fill="#EAEEF6">MoE Parallelism</text>
+    <text x="366" y="477" font-size="13" fill="#BBC4D2">Overlapped All2All &#183; offload &#183; compute &#183; EP balance</text>
+    <text x="754" y="455" font-size="17" font-weight="bold" fill="#EAEEF6">Heterogeneous Parallelism</text>
+    <text x="754" y="477" font-size="13" fill="#BBC4D2">Per-component TP/DP/recompute &#183; decoupled ED</text>
+    <text x="366" y="541" font-size="17" font-weight="bold" fill="#EAEEF6">Long-Seq Training</text>
+    <text x="366" y="563" font-size="14" fill="#BBC4D2">Context Parallel &#183; ChunkPipe</text>
+    <text x="754" y="541" font-size="17" font-weight="bold" fill="#EAEEF6">DP Load Balancing</text>
+    <text x="754" y="563" font-size="14" fill="#BBC4D2">Data packing &#183; load-aware</text>
+    <text x="366" y="627" font-size="17" font-weight="bold" fill="#EAEEF6">Compute Efficiency</text>
+    <text x="366" y="649" font-size="14" fill="#BBC4D2">Adaptive FP8 &#183; fused ops</text>
+    <text x="754" y="627" font-size="17" font-weight="bold" fill="#EAEEF6">Checkpoint Bridge</text>
+    <text x="754" y="649" font-size="14" fill="#BBC4D2">Megatron &#8596; HF &#183; online/offline</text>
+
+    <!-- ===== torch-native Track ===== -->
+    <text x="1228" y="405" font-size="27" font-weight="bold" fill="#F5A93D">torch-native Track</text>
+    <text x="1525" y="406" font-size="16" font-style="italic" fill="#AAB2C1">VLA &#183; WAM</text>
+    <text x="1212" y="452" font-size="17" font-weight="bold" fill="#EAEEF6">Flexible Sharding</text>
+    <text x="1212" y="471" font-size="14" fill="#BBC4D2">DDP &#183; ZeRO-1 &#183; FSDP &#183; HSDP</text>
+    <text x="1212" y="514" font-size="17" font-weight="bold" fill="#EAEEF6">Data Pipeline</text>
+    <text x="1212" y="533" font-size="14" fill="#BBC4D2">LeRobot/HDF5 &#183; async prefetch</text>
+    <text x="1212" y="576" font-size="17" font-weight="bold" fill="#EAEEF6">Fast Iteration</text>
+    <text x="1212" y="595" font-size="14" fill="#BBC4D2">CUDA Graph &#183; torch.compile &#183; fusion</text>
+    <text x="1212" y="638" font-size="17" font-weight="bold" fill="#EAEEF6">Offline Eval</text>
+    <text x="1212" y="657" font-size="14" fill="#BBC4D2">LIBERO &#183; CALVIN &#183; SimplerEnv &#183; RoboTwin</text>
+
+    <!-- ===== Hardware backends ===== -->
+    <text x="680" y="768" font-size="22" font-weight="bold" letter-spacing="0.5" fill="#33D0BE" text-anchor="middle">NVIDIA GPU</text>
+    <text x="1360" y="768" font-size="22" font-weight="bold" letter-spacing="0.5" fill="#33D0BE" text-anchor="middle">Kunlun XPU</text>
+  </g>
+</svg>

--- a/assets/img/loongforge-architecture.svg
+++ b/assets/img/loongforge-architecture.svg
@@ -1,0 +1,138 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="8 10 1786 830" width="100%" font-family="'Comic Sans MS','Comic Sans','Chalkboard SE','Bradley Hand',cursive">
+  <defs>
+    <filter id="sketch" x="-4%" y="-4%" width="108%" height="108%">
+      <feTurbulence type="turbulence" baseFrequency="0.013" numOctaves="2" seed="7" result="noise"/>
+      <feDisplacementMap in="SourceGraphic" in2="noise" scale="3" xChannelSelector="R" yChannelSelector="G"/>
+    </filter>
+  </defs>
+
+  <!-- paper background: a rounded card so it reads well on both light & dark READMEs -->
+  <rect x="12" y="14" width="1778" height="822" rx="24" fill="#FCFCFB" stroke="#E7E9ED" stroke-width="2"/>
+
+  <!-- ============ SHAPES (hand-drawn / filtered) ============ -->
+  <g filter="url(#sketch)">
+    <!-- MODEL row cards -->
+    <rect x="320" y="118" width="820" height="214" rx="18" fill="#F6F8FF" stroke="#3B4FD8" stroke-width="2.6"/>
+    <rect x="1160" y="118" width="560" height="214" rx="18" fill="#FFFBF4" stroke="#E08A1E" stroke-width="2.6"/>
+
+    <!-- model tag pills : Foundation (blue) -->
+    <rect x="356" y="196" width="70" height="30" rx="9" fill="#3B4FD8"/>
+    <rect x="356" y="240" width="70" height="30" rx="9" fill="#3B4FD8"/>
+    <rect x="356" y="284" width="104" height="30" rx="9" fill="#3B4FD8"/>
+    <!-- model tag pills : Embodied (amber) -->
+    <rect x="1192" y="210" width="66" height="30" rx="9" fill="#E08A1E"/>
+    <rect x="1192" y="262" width="66" height="30" rx="9" fill="#E08A1E"/>
+
+    <!-- ENGINE row cards -->
+    <rect x="320" y="360" width="820" height="320" rx="18" fill="#F6F8FF" stroke="#3B4FD8" stroke-width="2.6"/>
+    <rect x="1160" y="360" width="560" height="320" rx="18" fill="#FFFBF4" stroke="#E08A1E" stroke-width="2.6"/>
+
+    <!-- Megatron capability chips (2 x 3) -->
+    <rect x="350" y="425" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+    <rect x="738" y="425" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+    <rect x="350" y="511" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+    <rect x="738" y="511" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+    <rect x="350" y="597" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+    <rect x="738" y="597" width="372" height="72" rx="12" fill="#EAEEFF" stroke="#3B4FD8" stroke-width="1.6"/>
+
+    <!-- torch-native track capability chips (1 x 4) -->
+    <rect x="1192" y="428" width="496" height="54" rx="12" fill="#FFF3E2" stroke="#E08A1E" stroke-width="1.6"/>
+    <rect x="1192" y="490" width="496" height="54" rx="12" fill="#FFF3E2" stroke="#E08A1E" stroke-width="1.6"/>
+    <rect x="1192" y="552" width="496" height="54" rx="12" fill="#FFF3E2" stroke="#E08A1E" stroke-width="1.6"/>
+    <rect x="1192" y="614" width="496" height="54" rx="12" fill="#FFF3E2" stroke="#E08A1E" stroke-width="1.6"/>
+
+    <!-- HARDWARE band -->
+    <rect x="320" y="710" width="1400" height="100" rx="18" fill="#EAF7F5" stroke="#0E9488" stroke-width="2.6"/>
+    <!-- hardware backends (uniform: both are supported accelerators) -->
+    <rect x="360" y="732" width="640" height="56" rx="14" fill="#FFFFFF" stroke="#0E9488" stroke-width="2.4"/>
+    <rect x="1040" y="732" width="640" height="56" rx="14" fill="#FFFFFF" stroke="#0E9488" stroke-width="2.4"/>
+  </g>
+
+  <!-- ============ ICONS (small accents) ============ -->
+  <g filter="url(#sketch)">
+    <!-- star before Foundation title -->
+    <path transform="translate(370,150)" d="M0,-10 C1,-3 3,-1 10,0 C3,1 1,3 0,10 C-1,3 -3,1 -10,0 C-3,-1 -1,-3 0,-10 Z" fill="#3B4FD8"/>
+    <!-- sparkle before Embodied title -->
+    <path transform="translate(1206,150)" d="M0,-10 C1,-3 3,-1 10,0 C3,1 1,3 0,10 C-1,3 -3,1 -10,0 C-3,-1 -1,-3 0,-10 Z" fill="#E08A1E"/>
+    <!-- lightning before Megatron title -->
+    <path transform="translate(370,395)" d="M3,-13 L-5,3 L0,3 L-3,13 L8,-3 L2,-3 Z" fill="#3B4FD8"/>
+    <!-- lightning before torch-native title -->
+    <path transform="translate(1208,395)" d="M3,-13 L-5,3 L0,3 L-3,13 L8,-3 L2,-3 Z" fill="#E08A1E"/>
+    <!-- pillar icons (left axis) -->
+    <g transform="translate(160,205)" fill="#7C3AED">
+      <rect x="-16" y="-16" width="13" height="13" rx="3"/>
+      <rect x="3" y="-16" width="13" height="13" rx="3"/>
+      <rect x="-16" y="3" width="13" height="13" rx="3"/>
+      <rect x="3" y="3" width="13" height="13" rx="3"/>
+    </g>
+    <path transform="translate(160,500)" d="M5,-17 L-8,4 L-1,4 L-5,17 L9,-5 L2,-5 Z" fill="#3B4FD8"/>
+    <g transform="translate(160,740)" stroke="#0E9488" stroke-width="2.6" fill="none">
+      <rect x="-13" y="-13" width="26" height="26" rx="4" fill="#0E9488" opacity="0.15"/>
+      <line x1="-5" y1="-13" x2="-5" y2="-19"/><line x1="5" y1="-13" x2="5" y2="-19"/>
+      <line x1="-5" y1="13" x2="-5" y2="19"/><line x1="5" y1="13" x2="5" y2="19"/>
+      <line x1="-13" y1="-5" x2="-19" y2="-5"/><line x1="-13" y1="5" x2="-19" y2="5"/>
+      <line x1="13" y1="-5" x2="19" y2="-5"/><line x1="13" y1="5" x2="19" y2="5"/>
+    </g>
+  </g>
+
+  <!-- ============ TEXT (crisp) ============ -->
+  <g fill="#2A2E37">
+    <!-- Title -->
+    <text x="875" y="64" text-anchor="middle" font-size="48" font-weight="bold" letter-spacing="0.5" fill="#2A2E37">LoongForge Architecture</text>
+
+    <!-- ===== value pillars (left axis, aligned to each layer) ===== -->
+    <text x="160" y="253" font-size="26" font-weight="bold" fill="#7C3AED" text-anchor="middle">Unified</text>
+    <text x="160" y="548" font-size="26" font-weight="bold" fill="#3B4FD8" text-anchor="middle">High-Performance</text>
+    <text x="160" y="788" font-size="26" font-weight="bold" fill="#0E9488" text-anchor="middle">Multi-Chip</text>
+
+    <!-- ===== Foundation & Multimodal Models ===== -->
+    <text x="390" y="159" font-size="27" font-weight="bold" fill="#3B4FD8">Foundation &amp; Multimodal Models</text>
+    <text x="391" y="217" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">LLM</text>
+    <text x="391" y="261" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">VLM</text>
+    <text x="408" y="305" font-size="16" font-weight="bold" letter-spacing="0.4" fill="#FFFFFF" text-anchor="middle">Diffusion</text>
+    <text x="480" y="217" font-size="19" fill="#2A2E37">DeepSeek &#183; Qwen &#183; GLM &#183; LLaMA &#183; MiniMax &#183; MIMO</text>
+    <text x="480" y="261" font-size="19" fill="#2A2E37">Qwen-VL &#183; InternVL &#183; LLaVA-OV &#183; Kimi &#183; ERNIE &#183; Custom</text>
+    <text x="480" y="305" font-size="19" fill="#2A2E37">Wan2.2 &#183; Wan2.1 &#183; Qwen-Image</text>
+
+    <!-- ===== Embodied Models ===== -->
+    <text x="1226" y="159" font-size="27" font-weight="bold" fill="#E08A1E">Embodied Models</text>
+    <text x="1225" y="231" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">VLA</text>
+    <text x="1225" y="283" font-size="16" font-weight="bold" letter-spacing="0.8" fill="#FFFFFF" text-anchor="middle">WAM</text>
+    <text x="1272" y="231" font-size="18" fill="#2A2E37">GR00T N1.6/N1.7 &#183; Pi0.5 &#183; X-VLA</text>
+    <text x="1272" y="283" font-size="18" fill="#2A2E37">FastWAM &#183; DreamZero &#183; LingBot-VA &#183; Cosmos3</text>
+
+    <!-- ===== Megatron Track ===== -->
+    <text x="390" y="405" font-size="27" font-weight="bold" fill="#3B4FD8">Megatron Track</text>
+    <text x="700" y="406" font-size="16" font-style="italic" fill="#4B5563">LLM &#183; VLM &#183; Diffusion</text>
+
+    <!-- Megatron chips -->
+    <text x="366" y="455" font-size="17" font-weight="bold" fill="#2A2E37">MoE Parallelism</text>
+    <text x="366" y="477" font-size="13" fill="#374151">Overlapped All2All &#183; offload &#183; compute &#183; EP balance</text>
+    <text x="754" y="455" font-size="17" font-weight="bold" fill="#2A2E37">Heterogeneous Parallelism</text>
+    <text x="754" y="477" font-size="13" fill="#374151">Per-component TP/DP/recompute &#183; decoupled ED</text>
+    <text x="366" y="541" font-size="17" font-weight="bold" fill="#2A2E37">Long-Seq Training</text>
+    <text x="366" y="563" font-size="14" fill="#374151">Context Parallel &#183; ChunkPipe</text>
+    <text x="754" y="541" font-size="17" font-weight="bold" fill="#2A2E37">DP Load Balancing</text>
+    <text x="754" y="563" font-size="14" fill="#374151">Data packing &#183; load-aware</text>
+    <text x="366" y="627" font-size="17" font-weight="bold" fill="#2A2E37">Compute Efficiency</text>
+    <text x="366" y="649" font-size="14" fill="#374151">Adaptive FP8 &#183; fused ops</text>
+    <text x="754" y="627" font-size="17" font-weight="bold" fill="#2A2E37">Checkpoint Bridge</text>
+    <text x="754" y="649" font-size="14" fill="#374151">Megatron &#8596; HF &#183; online/offline</text>
+
+    <!-- ===== torch-native Track ===== -->
+    <text x="1228" y="405" font-size="27" font-weight="bold" fill="#E08A1E">torch-native Track</text>
+    <text x="1525" y="406" font-size="16" font-style="italic" fill="#4B5563">VLA &#183; WAM</text>
+    <text x="1212" y="452" font-size="17" font-weight="bold" fill="#2A2E37">Flexible Sharding</text>
+    <text x="1212" y="471" font-size="14" fill="#374151">DDP &#183; ZeRO-1 &#183; FSDP &#183; HSDP</text>
+    <text x="1212" y="514" font-size="17" font-weight="bold" fill="#2A2E37">Data Pipeline</text>
+    <text x="1212" y="533" font-size="14" fill="#374151">LeRobot/HDF5 &#183; async prefetch</text>
+    <text x="1212" y="576" font-size="17" font-weight="bold" fill="#2A2E37">Fast Iteration</text>
+    <text x="1212" y="595" font-size="14" fill="#374151">CUDA Graph &#183; torch.compile &#183; fusion</text>
+    <text x="1212" y="638" font-size="17" font-weight="bold" fill="#2A2E37">Offline Eval</text>
+    <text x="1212" y="657" font-size="14" fill="#374151">LIBERO &#183; CALVIN &#183; SimplerEnv &#183; RoboTwin</text>
+
+    <!-- ===== Hardware backends ===== -->
+    <text x="680" y="768" font-size="22" font-weight="bold" letter-spacing="0.5" fill="#0E9488" text-anchor="middle">NVIDIA GPU</text>
+    <text x="1360" y="768" font-size="22" font-weight="bold" letter-spacing="0.5" fill="#0E9488" text-anchor="middle">Kunlun XPU</text>
+  </g>
+</svg>

--- a/assets/js/main.js
+++ b/assets/js/main.js
@@ -16,7 +16,7 @@
       'footer.training': 'Training framework', 'footer.workflow': 'Agent framework',
 
       'hero.badge': '🐉 Part of the Baidu-Baige Loong open-source series',
-      'hero.subtitle_html': 'A <b>modular</b>, <b>scalable</b>, <b>high-performance</b> training framework for <b>LLMs</b>, <b>VLMs</b>, <b>diffusion</b>, and <b>embodied</b> models — multi-backend (<b>Megatron-LM</b> for LLM/VLM/diffusion, <b>torch-native DDP/FSDP</b> for embodied), with native NVIDIA GPU & Kunlun XPU support',
+      'hero.subtitle_html': 'A <b>unified</b>, <b>high-performance</b> framework for training <b>LLMs</b>, <b>VLMs</b>, <b>diffusion</b>, and <b>embodied</b> models — <span class="whitespace-nowrap">multi-backend</span>, with native NVIDIA GPU & Kunlun XPU support',
       'hero.cta.start': '🚀 Quick Start',
       'hero.cta.github': '⭐ View on GitHub',
       'hero.cta.docs': '📚 Read the Docs',
@@ -24,6 +24,11 @@
       'hero.stat.xpu': 'XPU production scale',
       'hero.stat.modal': 'LLM · VLM · VLA · Diffusion',
       'hero.stat.fp8': 'Adaptive FP8 precision',
+      'hero.slogan': 'Train LLMs, VLMs, Diffusion & Embodied models — faster.',
+      'sb.models': 'Model families supported',
+      'sb.chips': 'NVIDIA & Kunlun backends',
+      'sb.scale': 'Production cluster scale',
+      'sb.license': 'Open source license',
 
       'hero.vp.1.k': 'Easy',
       'hero.vp.1.t': 'One framework, broad coverage',
@@ -36,6 +41,9 @@
       'hero.vp.3.d': 'Native heterogeneous hardware support — one framework, minimal migration between GPU and XPU.',
 
       'news.title': '🔥 Latest News', 'news.all': 'All posts →',
+
+      'arch.title': '🏗️ Architecture',
+      'arch.subtitle': 'One unified stack — from model composition down to GPU / XPU silicon.',
 
       'feat.title': '✨ Key Features',
       'feat.subtitle_html': 'A quick tour of what sets LoongForge apart',
@@ -87,7 +95,23 @@
       'models.custom.d_html': 'Compose any ViT + any LLM backbone via a YAML file. <a href="https://github.com/baidu-baige/LoongForge/blob/master/configs/models/custom/qwen_vit_llama3_8b.yaml" target="_blank" class="text-indigo-500 underline">Example →</a>',
 
       'qs.title': '🚀 Quick Start',
-      'qs.subtitle': 'YAML-driven — a few steps from install to launch',
+      'qs.subtitle': 'From install to launch — jump straight to the tutorial for your model type',
+      'qs2.install.t': 'Install',
+      'qs2.install.d': 'Recommended: one Docker image bundles the CUDA/XPU toolchains, patched Megatron, and TransformerEngine — so every node trains from the same environment. Source build is also supported.',
+      'qs2.docs': 'Read the Docs ↗',
+      'qs2.docker': 'Show Docker build commands',
+      'qs2.guide': 'Installation guide ↗',
+      'qs2.path.t': 'Pick your path',
+      'qs2.path.d': 'Choose your model type — each card opens a runnable, step-by-step tutorial.',
+      'qs2.open': 'Open tutorial ↗',
+      'qs2.cat.llm.d': 'Dense & MoE LLMs — pretrain, SFT & LoRA.',
+      'qs2.cat.vlm.d': 'Vision-language models — composable ViT × LLM.',
+      'qs2.cat.diff.d': 'Video & image diffusion — WAN & Qwen-Image.',
+      'qs2.cat.vla.d': 'VLA & world-action models — DDP / FSDP.',
+      'qs2.cat.xpu.d': 'Run the same codebase on Baidu Kunlun XPU.',
+      'qs2.explore.t': 'Explore & launch',
+      'qs2.explore.d': 'Browse ready-to-run configs and example scripts, or expand a common launch command.',
+      'qs2.cmd': 'Show a common torchrun launch command',
       'qs.s1.tab': 'Install', 'qs.s2.tab': 'Compose', 'qs.s2.opt': 'optional', 'qs.s3.tab': 'Weights', 'qs.s4.tab': 'Data', 'qs.s5.tab': 'Configure', 'qs.s6.tab': 'Launch',
       'qs.s1.desc': 'Docker is the recommended path — a single image bundles CUDA/XPU toolchains, the patched Megatron submodule, and TransformerEngine, so every developer and every node trains from the same environment. Source install is also fully supported for advanced setups.',
       'qs.s2.desc': 'Optional — only needed for custom combinations. LoongForge uses declarative configs to compose different modality components into a full multimodal model. Take <code class="mono">qwen3_vl_30b_a3b</code> as an example: a single YAML assembles the vision encoder, projector, and language backbone. To swap the language backbone to DeepSeek V3, change one line under <code class="mono">model.foundation</code>.',
@@ -190,7 +214,7 @@
       'footer.training': '训练框架', 'footer.workflow': '智能体框架',
 
       'hero.badge': '🐉 百度百舸 Loong 开源家族成员',
-      'hero.subtitle_html': '面向 <b>LLM</b>、<b>VLM</b>、<b>Diffusion</b> 与<b>具身智能</b>模型的<b>模块化</b>、<b>可扩展</b>、<b>高性能</b>训练框架 —— 多后端架构（LLM/VLM/Diffusion 基于 <b>Megatron-LM</b>，具身模型基于 <b>torch-native DDP/FSDP</b>），原生支持 NVIDIA GPU 与昆仑芯 XPU',
+      'hero.subtitle_html': '面向 <b>LLM</b>、<b>VLM</b>、<b>Diffusion</b> 与<b>具身智能</b>模型训练的<b>统一</b>、<b>高性能</b>框架 —— 多后端架构，原生支持 NVIDIA GPU 与昆仑芯 XPU',
       'hero.cta.start': '🚀 快速上手',
       'hero.cta.github': '⭐ 访问 GitHub',
       'hero.cta.docs': '📚 阅读文档',
@@ -198,6 +222,11 @@
       'hero.stat.xpu': 'XPU 集群规模',
       'hero.stat.modal': '覆盖模态：LLM/VLM/VLA/Diffusion',
       'hero.stat.fp8': '端到端自适应精度',
+      'hero.slogan': '更快地训练 LLM、VLM、Diffusion 与具身智能模型。',
+      'sb.models': '支持模型家族',
+      'sb.chips': 'NVIDIA 与昆仑芯后端',
+      'sb.scale': '生产集群规模',
+      'sb.license': '开源许可协议',
 
       'hero.vp.1.k': '易用',
       'hero.vp.1.t': '一套框架，广泛覆盖',
@@ -210,6 +239,9 @@
       'hero.vp.3.d': '原生异构硬件支持 —— 同一套框架，GPU 与 XPU 之间迁移成本极低。',
 
       'news.title': '🔥 最新动态', 'news.all': '查看全部 →',
+
+      'arch.title': '🏗️ 架构',
+      'arch.subtitle': '一套统一架构 —— 从模型组装贯通到 GPU / XPU 芯片。',
 
       'feat.title': '✨ 关键特性',
       'feat.subtitle_html': 'LoongForge 差异化能力速览',
@@ -256,7 +288,23 @@
       'models.custom.d_html': '通过 YAML 自由组合任意 ViT + 任意 LLM 主干。<a href="https://github.com/baidu-baige/LoongForge/blob/master/configs/models/custom/qwen_vit_llama3_8b.yaml" target="_blank" class="text-indigo-500 underline">示例 →</a>',
 
       'qs.title': '🚀 快速开始',
-      'qs.subtitle': 'YAML 驱动，简单几步完成从安装到启动',
+      'qs.subtitle': '从安装到启动 —— 按你的模型类型直达对应教程',
+      'qs2.install.t': '安装',
+      'qs2.install.d': '推荐使用 Docker：单一镜像打包了 CUDA/XPU 工具链、打过补丁的 Megatron 与 TransformerEngine，保证每个节点环境一致；同时也完整支持源码安装。',
+      'qs2.docs': '查看文档 ↗',
+      'qs2.docker': '展开 Docker 构建命令',
+      'qs2.guide': '安装指南 ↗',
+      'qs2.path.t': '选择你的路径',
+      'qs2.path.d': '选择你的模型类型 —— 每张卡片直达可运行的分步教程。',
+      'qs2.open': '查看教程 ↗',
+      'qs2.cat.llm.d': '稠密与 MoE 大语言模型 —— 预训练、SFT、LoRA。',
+      'qs2.cat.vlm.d': '视觉-语言模型 —— 可组合 ViT × LLM。',
+      'qs2.cat.diff.d': '视频与图像扩散 —— WAN、Qwen-Image。',
+      'qs2.cat.vla.d': '具身 VLA 与世界-动作模型 —— DDP / FSDP。',
+      'qs2.cat.xpu.d': '同一套代码运行于百度昆仑芯 XPU。',
+      'qs2.explore.t': '探索与启动',
+      'qs2.explore.d': '浏览开箱即用的配置与示例脚本，或展开查看通用启动命令。',
+      'qs2.cmd': '展开查看通用 torchrun 启动命令',
       'qs.s1.tab': '安装', 'qs.s2.tab': '组装模型', 'qs.s2.opt': '可选', 'qs.s3.tab': '准备权重', 'qs.s4.tab': '准备训练数据', 'qs.s5.tab': '配置训练参数', 'qs.s6.tab': '启动训练',
       'qs.s1.desc': '推荐使用 Docker —— 单一镜像打包 CUDA/XPU 工具链、已打补丁的 Megatron 子模块以及 TransformerEngine，让每位开发者、每个节点都在完全一致的环境中训练。如需更灵活的部署方式，也完整支持源码安装。',
       'qs.s2.desc': '可选步骤 —— 仅当你需要自定义组合时再来这一步。LoongForge 通过声明式配置，支持将不同模态组件灵活组合为完整的多模态模型。以 <code class="mono">qwen3_vl_30b_a3b</code> 为例，一份 YAML 即可完成视觉编码器、投影层与语言主干的组网。如果需要将语言主干替换为 DeepSeek V3，仅需要修改 <code class="mono">model.foundation</code> 即可。',
@@ -420,19 +468,19 @@
       const ghSvg = `<svg viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M12 .5C5.37.5 0 5.87 0 12.5c0 5.3 3.44 9.79 8.21 11.39.6.11.82-.26.82-.58 0-.29-.01-1.05-.02-2.06-3.34.72-4.04-1.61-4.04-1.61-.55-1.39-1.33-1.76-1.33-1.76-1.09-.74.08-.73.08-.73 1.2.09 1.83 1.24 1.83 1.24 1.07 1.83 2.8 1.3 3.49.99.11-.77.42-1.3.76-1.6-2.67-.3-5.47-1.34-5.47-5.96 0-1.32.47-2.39 1.24-3.23-.12-.3-.54-1.52.12-3.16 0 0 1.01-.32 3.3 1.23a11.48 11.48 0 0 1 6 0c2.29-1.55 3.3-1.23 3.3-1.23.66 1.64.24 2.86.12 3.16.77.84 1.24 1.91 1.24 3.23 0 4.63-2.8 5.65-5.48 5.95.43.37.81 1.1.81 2.22 0 1.6-.01 2.89-.01 3.28 0 .32.22.7.83.58A12.01 12.01 0 0 0 24 12.5C24 5.87 18.63.5 12 .5z"/></svg>`;
       host.className = 'sticky top-0 z-40 backdrop-blur bg-white/80 dark:bg-gray-950/75 border-b border-gray-200 dark:border-gray-800';
       host.innerHTML = `
-    <div class="max-w-7xl mx-auto px-6 py-3 flex items-center justify-between">
-      <a href="${base}index.html" class="flex items-center gap-2 font-bold text-lg">
-        <img src="${base}assets/img/logo.svg" class="w-8 h-8" alt="logo" />
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-4 flex items-center justify-between">
+      <a href="${base}index.html" class="flex items-center gap-2.5 font-bold text-xl">
+        <img src="${base}assets/img/logo.svg" class="w-9 h-9" alt="logo" />
         <span>LoongForge</span>
       </a>
-      <nav class="hidden md:flex items-center gap-7 text-sm font-medium">
+      <nav class="hidden md:flex items-center gap-8 text-[15px] font-medium">
         <a href="${base}index.html" class="${act('home')}" data-i18n="nav.home">Home</a>
         <a href="https://loongforge.readthedocs.io/en/latest/index.html" target="_blank" rel="noopener" data-docs-link class="ext ${act('docs')}" data-i18n="nav.docs">Docs</a>
         <a href="${base}blog.html" class="${act('blog')}" data-i18n="nav.blog">Blog</a>
         <a href="${base}about.html" class="${act('about')}" data-i18n="nav.about">About</a>
         <a href="${base}index.html#community" class="hover:text-indigo-600 dark:hover:text-indigo-300" data-i18n="nav.contact">Contact</a>
       </nav>
-      <div class="flex items-center gap-2">
+      <div class="flex items-center gap-3">
         <div class="lang-switch hidden sm:inline-flex" role="group" aria-label="Language">${langBtns}</div>
         <a href="https://github.com/baidu-baige/LoongForge" target="_blank" rel="noopener"
           class="gh-pill hidden sm:inline-flex" aria-label="Star LoongForge on GitHub" title="Star LoongForge on GitHub ★">
@@ -442,13 +490,13 @@
           <span class="star">★</span>
           <span data-gh-stars>Star</span>
         </a>
-        <button data-theme-toggle class="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Toggle theme">
+        <button data-theme-toggle class="p-2.5 rounded-lg text-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Toggle theme">
           <span data-theme-icon>🌙</span>
         </button>
-        <button data-mobile-toggle class="md:hidden p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Menu">☰</button>
+        <button data-mobile-toggle class="md:hidden p-2.5 rounded-lg text-xl leading-none hover:bg-gray-100 dark:hover:bg-gray-800" aria-label="Menu">☰</button>
       </div>
     </div>
-    <div id="mobile-menu" class="md:hidden hidden border-t border-gray-200 dark:border-gray-800 px-6 py-3 space-y-2 text-sm">
+    <div id="mobile-menu" class="md:hidden hidden border-t border-gray-200 dark:border-gray-800 px-5 sm:px-8 py-4 space-y-2 text-base">
       <a href="${base}index.html" class="${actMob('home')}" data-i18n="nav.home">Home</a>
       <a href="https://loongforge.readthedocs.io/en/latest/index.html" target="_blank" rel="noopener" data-docs-link class="block py-1 ext" data-i18n="nav.docs">Docs</a>
       <a href="${base}blog.html" class="${actMob('blog')}" data-i18n="nav.blog">Blog</a>
@@ -602,6 +650,34 @@
     });
   }
 
+  // ===== Animated stat counters =====
+  function initCounters() {
+    const els = document.querySelectorAll('[data-count-to]');
+    if (!els.length) return;
+    const run = el => {
+      const to = parseFloat(el.dataset.countTo);
+      const pre = el.dataset.prefix || '';
+      const suf = el.dataset.suffix || '';
+      const dur = 1100;
+      const start = performance.now();
+      const tick = now => {
+        const p = Math.min(1, (now - start) / dur);
+        const eased = 1 - Math.pow(1 - p, 3);
+        el.textContent = pre + Math.round(to * eased) + suf;
+        if (p < 1) requestAnimationFrame(tick);
+        else el.textContent = pre + to + suf;
+      };
+      requestAnimationFrame(tick);
+    };
+    if (!('IntersectionObserver' in window)) { els.forEach(run); return; }
+    const io = new IntersectionObserver(entries => {
+      entries.forEach(en => {
+        if (en.isIntersecting) { run(en.target); io.unobserve(en.target); }
+      });
+    }, { threshold: 0.4 });
+    els.forEach(e => io.observe(e));
+  }
+
   // ===== Init =====
   document.addEventListener('DOMContentLoaded', () => {
     renderSiteHeader();
@@ -613,6 +689,7 @@
     initTocSpy();
     initScrollProgress();
     initQuickStart();
+    initCounters();
     window.LF = { toggleTheme, toggleMobileMenu, setLang };
 
     document.querySelectorAll('[data-theme-toggle]').forEach(el => el.addEventListener('click', toggleTheme));

--- a/blog.html
+++ b/blog.html
@@ -25,12 +25,13 @@
   <!-- Shared navbar (rendered by main.js) -->
   <header data-site-header data-active="blog"></header>
 
-  <section class="hero-gradient text-white">
-    <div class="max-w-7xl mx-auto px-6 py-16 text-center relative">
+  <section class="hero-gradient text-gray-900 dark:text-white">
+    <div class="max-w-7xl mx-auto px-6 py-24 md:py-28 text-center relative">
       <div class="hero-grid absolute inset-0"></div>
       <div class="relative">
         <h1 class="text-4xl md:text-5xl font-extrabold mb-3" data-i18n="blog.hero.title">Engineering Blog</h1>
-        <p class="text-gray-300 max-w-2xl mx-auto" data-i18n="blog.hero.desc">Releases, performance deep-dives, and
+        <p class="text-gray-600 dark:text-gray-300 max-w-2xl mx-auto" data-i18n="blog.hero.desc">Releases, performance
+          deep-dives, and
           stories from the LoongForge team</p>
       </div>
     </div>

--- a/index.html
+++ b/index.html
@@ -45,166 +45,259 @@
   <header data-site-header data-active="home"></header>
 
   <!-- ===== Hero ===== -->
-  <section class="hero-gradient text-white relative overflow-hidden">
+  <section class="hero-gradient text-gray-900 dark:text-white relative overflow-hidden">
     <div class="hero-orb o1"></div>
     <div class="hero-orb o2"></div>
     <div class="hero-orb o3"></div>
     <div class="absolute inset-0 hero-grid"></div>
-    <div class="relative max-w-7xl mx-auto px-6 pt-24 pb-28 text-center">
-      <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/10 border border-white/15 text-xs mb-6"
-        data-i18n="hero.badge">
-        🐉 Part of the Baidu-Baige Loong open-source series
+    <div
+      class="relative max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 pt-24 pb-28 text-center">
+      <!-- Copy -->
+      <div class="max-w-5xl mx-auto">
+        <div
+          class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-white/70 border border-indigo-200 text-indigo-700 dark:bg-white/10 dark:border-white/15 dark:text-white text-xs mb-6"
+          data-i18n="hero.badge">
+          🐉 Part of the Baidu-Baige Loong open-source series
+        </div>
+        <h1 class="text-6xl md:text-8xl font-extrabold tracking-tight mb-4 leading-[1.05]">
+          <span class="text-gradient">LoongForge</span>
+        </h1>
+        <div
+          class="text-xl md:text-2xl font-bold text-gray-900 dark:text-white mb-5 md:whitespace-nowrap [text-wrap:balance]"
+          data-i18n="hero.slogan">
+          Train LLMs, VLMs, Diffusion &amp; Embodied models — faster.
+        </div>
+        <p class="max-w-[60rem] mx-auto text-base md:text-lg text-gray-600 dark:text-gray-300 mb-8 [text-wrap:balance]"
+          data-i18n-html="hero.subtitle_html">
+          A <b>unified</b>, <b>high-performance</b> framework for training <b>LLMs</b>, <b>VLMs</b>, <b>diffusion</b>,
+          and <b>embodied</b> models — <span class="whitespace-nowrap">multi-backend</span>, with native NVIDIA GPU
+          &amp;
+          Kunlun XPU support
+        </p>
+        <div class="flex flex-wrap gap-3 justify-center mb-6">
+          <a href="#quickstart" class="lf-btn" data-i18n="hero.cta.start">🚀 Quick Start</a>
+          <a href="https://github.com/baidu-baige/LoongForge" target="_blank" rel="noopener" class="lf-btn-ghost"
+            data-i18n="hero.cta.github">⭐ View on GitHub</a>
+          <a href="https://loongforge.readthedocs.io/en/latest/index.html" target="_blank" rel="noopener" data-docs-link
+            class="lf-btn-ghost" data-i18n="hero.cta.docs">📚 Read the Docs</a>
+        </div>
+        <div class="flex flex-wrap gap-2 justify-center text-xs font-semibold">
+          <span
+            class="px-3 py-1 rounded-full bg-indigo-50 text-indigo-700 border border-indigo-100 dark:bg-white/10 dark:text-indigo-200 dark:border-white/10"
+            data-i18n="hero.vp.1.k">Easy</span>
+          <span
+            class="px-3 py-1 rounded-full bg-amber-50 text-amber-700 border border-amber-100 dark:bg-white/10 dark:text-amber-200 dark:border-white/10"
+            data-i18n="hero.vp.2.k">Efficient</span>
+          <span
+            class="px-3 py-1 rounded-full bg-cyan-50 text-cyan-700 border border-cyan-100 dark:bg-white/10 dark:text-cyan-200 dark:border-white/10"
+            data-i18n="hero.vp.3.k">Multi-chip</span>
+        </div>
       </div>
-      <h1 class="text-5xl md:text-7xl font-extrabold tracking-tight mb-6">
-        <span class="text-gradient">LoongForge</span>
-      </h1>
-      <p class="max-w-3xl mx-auto text-lg md:text-xl text-gray-200 mb-10" data-i18n-html="hero.subtitle_html">
-        A <b>modular</b>, <b>scalable</b>, <b>high-performance</b> training framework for <b>LLMs</b>, <b>VLMs</b>,
-        <b>diffusion</b>, and <b>embodied</b> models — multi-backend (<b>Megatron-LM</b> for LLM/VLM/diffusion,
-        <b>torch-native DDP/FSDP</b> for embodied), with native NVIDIA GPU &amp; Kunlun XPU support
-      </p>
-      <div class="flex flex-wrap gap-3 justify-center">
-        <a href="#quickstart"
-          class="px-6 py-3 rounded-full bg-white text-indigo-700 font-semibold hover:bg-indigo-50 shadow-lg shadow-indigo-900/30 transition"
-          data-i18n="hero.cta.start">🚀 Quick Start</a>
-        <a href="https://github.com/baidu-baige/LoongForge" target="_blank" rel="noopener"
-          class="px-6 py-3 rounded-full bg-white/10 hover:bg-white/20 border border-white/25 font-semibold transition"
-          data-i18n="hero.cta.github">⭐ View on GitHub</a>
-        <a href="https://loongforge.readthedocs.io/en/latest/index.html" target="_blank" rel="noopener" data-docs-link
-          class="px-6 py-3 rounded-full bg-white/10 hover:bg-white/20 border border-white/25 font-semibold transition"
-          data-i18n="hero.cta.docs">📚 Read the Docs</a>
-      </div>
+    </div>
+    <!-- Wave divider -->
+    <div class="lf-wave" aria-hidden="true">
+      <svg viewBox="0 0 1440 120" preserveAspectRatio="none">
+        <defs>
+          <linearGradient id="lfWave" x1="0" y1="0" x2="1" y2="0">
+            <stop offset="0" stop-color="#4F46E5" />
+            <stop offset=".5" stop-color="#7C3AED" />
+            <stop offset="1" stop-color="#DB2777" />
+          </linearGradient>
+        </defs>
+        <path d="M0,64 C240,120 480,16 720,48 C960,80 1200,120 1440,56 L1440,120 L0,120 Z" fill="url(#lfWave)" />
+      </svg>
+    </div>
+  </section>
 
-      <!-- Quick stats -->
-      <!-- Value props (Easy · Efficient · Multi-chip) -->
-      <div class="mt-14 grid md:grid-cols-3 gap-5 max-w-6xl mx-auto text-left">
-        <div class="rounded-2xl bg-white/5 border border-white/10 p-6 backdrop-blur-sm hover:bg-white/10 transition">
-          <div class="flex items-center gap-2 mb-3">
-            <span class="text-2xl">🧩</span>
-            <span class="text-sm font-semibold uppercase tracking-wider text-indigo-200"
-              data-i18n="hero.vp.1.k">Easy</span>
-          </div>
-          <div class="text-lg font-semibold text-white mb-1.5" data-i18n="hero.vp.1.t">One framework, broad coverage
-          </div>
-          <div class="text-sm text-gray-300" data-i18n="hero.vp.1.d">Full coverage of mainstream open-source LLMs, VLMs,
-            MoE, diffusion, and VLA models. Ready-to-run configs and launch scripts included.</div>
+  <!-- ===== Stat band ===== -->
+  <section class="lf-statband reveal">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 lf-stat-grid">
+      <div class="lf-stat">
+        <div class="lf-stat-num" data-count-to="5" data-prefix="~" data-suffix="×">~5×</div>
+        <div class="lf-stat-label" data-i18n="hero.stat.speedup">Max training speedup</div>
+      </div>
+      <div class="lf-stat">
+        <div class="lf-stat-num" data-count-to="35" data-suffix="+">35+</div>
+        <div class="lf-stat-label" data-i18n="sb.models">Model families supported</div>
+      </div>
+      <div class="lf-stat">
+        <div class="lf-stat-num">GPU·XPU</div>
+        <div class="lf-stat-label" data-i18n="sb.chips">NVIDIA &amp; Kunlun backends</div>
+      </div>
+      <div class="lf-stat">
+        <div class="lf-stat-num" data-count-to="5000" data-suffix="+">5000+</div>
+        <div class="lf-stat-label" data-i18n="sb.scale">Production cluster scale</div>
+      </div>
+      <div class="lf-stat">
+        <div class="lf-stat-num">Apache 2.0</div>
+        <div class="lf-stat-label" data-i18n="sb.license">Open source license</div>
+      </div>
+    </div>
+  </section>
+
+  <!-- ===== Why LoongForge (value props) ===== -->
+  <section
+    class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 pt-16 md:pt-20 pb-10 reveal">
+    <div class="grid md:grid-cols-3 gap-6">
+      <div class="lf-card">
+        <div class="lf-ico mb-4">🧩</div>
+        <div class="text-sm font-semibold uppercase tracking-wider text-indigo-600 dark:text-indigo-300 mb-1"
+          data-i18n="hero.vp.1.k">Easy</div>
+        <div class="text-lg font-bold text-gray-900 dark:text-white mb-2" data-i18n="hero.vp.1.t">One framework, broad
+          coverage</div>
+        <div class="text-sm text-gray-600 dark:text-gray-300" data-i18n="hero.vp.1.d">Full coverage of mainstream
+          open-source LLMs, VLMs, MoE, diffusion, and VLA models. Ready-to-run configs and launch scripts included.
         </div>
-        <div class="rounded-2xl bg-white/5 border border-white/10 p-6 backdrop-blur-sm hover:bg-white/10 transition">
-          <div class="flex items-center gap-2 mb-3">
-            <span class="text-2xl">⚡</span>
-            <span class="text-sm font-semibold uppercase tracking-wider text-amber-200"
-              data-i18n="hero.vp.2.k">Efficient</span>
-          </div>
-          <div class="text-lg font-semibold text-white mb-1.5" data-i18n="hero.vp.2.t">Up to ~5× training speedup</div>
-          <div class="text-sm text-gray-300" data-i18n="hero.vp.2.d">Deep performance optimizations — fused kernels,
-            adaptive FP8, MoE A2A overlap, and multimodal pipeline scheduling.</div>
-        </div>
-        <div class="rounded-2xl bg-white/5 border border-white/10 p-6 backdrop-blur-sm hover:bg-white/10 transition">
-          <div class="flex items-center gap-2 mb-3">
-            <span class="text-2xl">💎</span>
-            <span class="text-sm font-semibold uppercase tracking-wider text-emerald-200"
-              data-i18n="hero.vp.3.k">Multi-chip</span>
-          </div>
-          <div class="text-lg font-semibold text-white mb-1.5" data-i18n="hero.vp.3.t">NVIDIA GPU &amp; Kunlun XPU</div>
-          <div class="text-sm text-gray-300" data-i18n="hero.vp.3.d">Native heterogeneous hardware support — one
-            framework, minimal migration between GPU and XPU.</div>
-        </div>
+      </div>
+      <div class="lf-card">
+        <div class="lf-ico mb-4">⚡</div>
+        <div class="text-sm font-semibold uppercase tracking-wider text-amber-600 dark:text-amber-300 mb-1"
+          data-i18n="hero.vp.2.k">Efficient</div>
+        <div class="text-lg font-bold text-gray-900 dark:text-white mb-2" data-i18n="hero.vp.2.t">Up to ~5× training
+          speedup</div>
+        <div class="text-sm text-gray-600 dark:text-gray-300" data-i18n="hero.vp.2.d">Deep performance optimizations —
+          fused kernels, adaptive FP8, MoE A2A overlap, and multimodal pipeline scheduling.</div>
+      </div>
+      <div class="lf-card">
+        <div class="lf-ico mb-4">💎</div>
+        <div class="text-sm font-semibold uppercase tracking-wider text-cyan-600 dark:text-cyan-300 mb-1"
+          data-i18n="hero.vp.3.k">Multi-chip</div>
+        <div class="text-lg font-bold text-gray-900 dark:text-white mb-2" data-i18n="hero.vp.3.t">NVIDIA GPU &amp;
+          Kunlun
+          XPU</div>
+        <div class="text-sm text-gray-600 dark:text-gray-300" data-i18n="hero.vp.3.d">Native heterogeneous hardware
+          support — one framework, minimal migration between GPU and XPU.</div>
       </div>
     </div>
   </section>
 
   <!-- ===== Latest News ===== -->
-  <section class="max-w-7xl mx-auto px-6 py-16 reveal">
+  <section
+    class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 pt-10 pb-20 md:pb-24 reveal">
     <div class="flex items-end justify-between mb-8">
       <h2 class="text-2xl md:text-3xl font-bold" data-i18n="news.title">🔥 Latest News</h2>
       <a href="blog.html" class="text-sm text-indigo-600 dark:text-indigo-300 hover:underline" data-i18n="news.all">All
         posts →</a>
     </div>
-    <div id="home-news-list" class="grid md:grid-cols-3 gap-5">
+    <div id="home-news-list" class="grid md:grid-cols-3 gap-6">
       <!-- Auto-rendered from assets/data/posts.json by assets/js/home-news.js -->
     </div>
   </section>
 
   <!-- ===== Features ===== -->
-  <section id="features" class="bg-gray-50 dark:bg-gray-900/50 border-y border-gray-200 dark:border-gray-800">
-    <div class="max-w-7xl mx-auto px-6 py-16 reveal">
+  <section id="features" class="bg-[#F7F8FF] dark:bg-gray-900/50 border-y border-indigo-100/70 dark:border-gray-800">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="feat.title">✨ Key Features</h2>
         <p class="text-gray-600 dark:text-gray-400 max-w-3xl mx-auto" data-i18n-html="feat.subtitle_html">A quick tour
           of what sets LoongForge apart</p>
       </div>
 
-      <div class="grid sm:grid-cols-2 lg:grid-cols-5 gap-4">
+      <div class="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
         <!-- Embodied (highlighted first) -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-embodied" data-i18n="feat.cat.7.title">Embodied</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.7.item.1.t">Embodied Training</div>
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🤖</span>
+            <span class="feat-tag feat-tag-embodied" data-i18n="feat.cat.7.title">Embodied</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.7.item.1.t">Embodied
+            Training</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.7.item.1.d">Dedicated torch-native
             DDP/FSDP subsystem for VLA &amp; WAM models, with DDP / ZeRO-1 / FSDP / HSDP.</div>
         </div>
 
         <!-- MoE -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-moe" data-i18n="feat.cat.1.title">MoE</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.1.item.1.t">Tri-Stream Overlap</div>
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🧠</span>
+            <span class="feat-tag feat-tag-moe" data-i18n="feat.cat.1.title">MoE</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.1.item.1.t">Tri-Stream
+            Overlap</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.1.item.1.d">MoE EP comm × compute ×
             offload in parallel — higher throughput than upstream.</div>
         </div>
 
         <!-- Multimodal -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.2.t">Heterogeneous &amp; Disaggregated</div>
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🎛️</span>
+            <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.2.item.2.t">
+            Heterogeneous &amp; Disaggregated</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.2.d">Independent TP / PP / DP
             per component + decoupled ViT / LLM scheduling that kills pipeline bubbles.</div>
         </div>
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.4.t">DP Load Balancing</div>
-          <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.4.d">Fixes packing-induced
-            imbalance at cluster scale.</div>
-        </div>
 
-        <!-- Performance -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.3.item.1.t">Adaptive FP8</div>
+        <!-- Performance: Adaptive FP8 -->
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">⚡</span>
+            <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.3.item.1.t">Adaptive
+            FP8</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.3.item.1.d">Per-operator FP8
             decisions by GEMM shape.</div>
         </div>
 
-        <!-- Row 2 starts -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.3.item.2.t">Fused Operators</div>
+        <!-- Performance: Fused Operators -->
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🔧</span>
+            <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.3.item.2.t">Fused
+            Operators</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.3.item.2.d">FusedDSA / Sparse MLA
             kernels for end-to-end speedup.</div>
         </div>
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.4.item.1.t">ChunkPipe</div>
+
+        <!-- Performance: ChunkPipe -->
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🧵</span>
+            <span class="feat-tag feat-tag-compute" data-i18n="feat.cat.3.title">Performance</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.4.item.1.t">ChunkPipe
+          </div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.4.item.1.d">Chunked long-sequence
             pipelining toward million-length contexts.</div>
         </div>
 
+        <!-- Multimodal: DP Load Balancing -->
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">⚖️</span>
+            <span class="feat-tag feat-tag-mm" data-i18n="feat.cat.2.title">Multimodal</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.2.item.4.t">DP Load
+            Balancing</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.4.d">Fixes packing-induced
+            imbalance at cluster scale.</div>
+        </div>
+
         <!-- Training Paradigms -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-train" data-i18n="feat.cat.6.title">Training</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.6.item.1.t">Pretrain + SFT + LoRA</div>
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🎯</span>
+            <span class="feat-tag feat-tag-train" data-i18n="feat.cat.6.title">Training</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.6.item.1.t">Pretrain +
+            SFT + LoRA</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.6.item.1.d">One codebase covers key
             training stages.</div>
         </div>
 
-        <!-- Usability -->
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-eco" data-i18n="feat.cat.5.title">Usability</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.2.item.1.t">Model Composition</div>
-          <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.2.item.1.d">Swap ViT × LLM for VLMs
-            via YAML.</div>
-        </div>
-        <div class="feat-card rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800">
-          <span class="feat-tag feat-tag-eco" data-i18n="feat.cat.5.title">Usability</span>
-          <div class="font-semibold mt-3 mb-1" data-i18n="feat.cat.5.item.1.t">HF ↔ Megatron</div>
+        <!-- Usability: HF <-> Megatron -->
+        <div class="lf-card">
+          <div class="flex items-center gap-3 mb-4">
+            <span class="lf-ico">🔁</span>
+            <span class="feat-tag feat-tag-eco" data-i18n="feat.cat.5.title">Usability</span>
+          </div>
+          <div class="text-lg font-bold text-gray-900 dark:text-white mb-1.5" data-i18n="feat.cat.5.item.1.t">HF ↔
+            Megatron</div>
           <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="feat.cat.5.item.1.d">Bidirectional checkpoint
             conversion + online HF load/save.</div>
         </div>
@@ -212,10 +305,26 @@
     </div>
   </section>
 
+  <!-- ===== Architecture ===== -->
+  <section class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
+    <div class="text-center mb-10">
+      <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="arch.title">🏗️ Architecture</h2>
+      <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="arch.subtitle">One unified stack — from
+        model composition down to GPU / XPU silicon.</p>
+    </div>
+
+    <div class="lf-card max-w-6xl mx-auto">
+      <img src="assets/img/loongforge-architecture.svg" alt="LoongForge architecture" loading="lazy"
+        class="w-full h-auto block dark:hidden" />
+      <img src="assets/img/loongforge-architecture-dark.svg" alt="LoongForge architecture" loading="lazy"
+        class="w-full h-auto hidden dark:block" />
+    </div>
+  </section>
+
   <!-- ===== Benchmark ===== -->
   <section id="benchmark"
     class="bg-indigo-50/40 dark:bg-indigo-950/20 border-y border-indigo-100 dark:border-indigo-900/40">
-    <div class="max-w-7xl mx-auto px-6 py-20 reveal">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="bench.title">📊 Benchmark</h2>
         <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="bench.subtitle">Measured on
@@ -270,14 +379,14 @@
   </section>
 
   <!-- ===== Hardware Compatibility ===== -->
-  <section class="max-w-7xl mx-auto px-6 py-20 reveal">
+  <section class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
     <div class="text-center mb-10">
       <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="hw.title">💎 Hardware Compatibility</h2>
       <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="hw.subtitle">One codebase, two silicon
         stacks — production-ready on NVIDIA GPU and Baidu Kunlun XPU</p>
     </div>
     <div class="grid md:grid-cols-2 gap-6">
-      <div class="gradient-border p-7">
+      <div class="gradient-border p-8">
         <div class="flex items-center gap-3 mb-3">
           <div
             class="w-11 h-11 rounded-xl bg-gradient-to-br from-emerald-500 to-green-600 text-white flex items-center justify-center font-bold shadow-lg shadow-green-900/20">
@@ -287,7 +396,7 @@
         <p class="text-gray-600 dark:text-gray-400" data-i18n="hw.nv.d">Built on the community Megatron +
           TransformerEngine ecosystem, with LoongForge optimizations layered on top.</p>
       </div>
-      <div class="gradient-border p-7">
+      <div class="gradient-border p-8">
         <div class="flex items-center gap-3 mb-3">
           <div
             class="w-11 h-11 rounded-xl bg-gradient-to-br from-indigo-500 to-violet-600 text-white flex items-center justify-center font-bold shadow-lg shadow-indigo-900/20">
@@ -301,8 +410,8 @@
   </section>
 
   <!-- ===== Models ===== -->
-  <section id="models" class="bg-gray-50 dark:bg-gray-900/50 border-y border-gray-200 dark:border-gray-800">
-    <div class="max-w-7xl mx-auto px-6 py-20 reveal">
+  <section id="models" class="bg-[#F7F8FF] dark:bg-gray-900/50 border-y border-indigo-100/70 dark:border-gray-800">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="models.title">🏛️ Supported Models</h2>
         <p class="text-gray-600 dark:text-gray-400" data-i18n="models.subtitle">From compact SLMs to large-scale MoE
@@ -317,112 +426,137 @@
           <button data-tab="vla" class="tab-btn">Embodied</button>
         </div>
 
-        <div data-panel="llm" class="grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+        <div data-panel="llm" class="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">DeepSeek-V2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">v2-lite</span><span class="chip">v2</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">DeepSeek-V3</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">v3</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">DeepSeek-V3.2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">v3.2</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">DeepSeek-V4</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">v4-flash</span><span class="chip">v4-pro</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LLaMA2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">7B</span><span class="chip">13B</span><span
                 class="chip">70B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LLaMA3</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">8B</span><span class="chip">70B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LLaMA3.1</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">8B</span><span class="chip">70B</span><span
                 class="chip">405B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">1.8B → 72B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen1.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">0.5B → 72B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">0.5B → 72B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen2.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">0.5B → 72B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen3</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">0.6B → 480B-A35B</span><span
                 class="chip">Coder-30B-A3B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen3-Next</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">80B-A3B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">MiniMax</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">m2.1</span><span class="chip">m2.5</span><span
                 class="chip">m2.7</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">MIMO</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">mimo-7b</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">GLM</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">glm5</span></div>
           </div>
         </div>
 
-        <div data-panel="vlm" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+        <div data-panel="vlm" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen2.5-VL</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">3B → 72B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen3-VL</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">30B-A3B</span><span class="chip">235B-A22B</span>
             </div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen3.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">0.8B → 397B-A17B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen3.6</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">27B</span><span class="chip">35B-A3B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Kimi-K2.x</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">k2.5</span><span class="chip">k2.6</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">ERNIE4.5-VL</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">28B-A3B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LLaVA-OneVision-1.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">4B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">InternVL2.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">8B → 78B</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">InternVL3.5</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">8B → 241B-A28B</span></div>
           </div>
@@ -436,43 +570,53 @@
           </div>
         </div>
 
-        <div data-panel="diff" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+        <div data-panel="diff" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Wan2.1</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">wan2-1-i2v</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Wan2.2</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">wan2-2-i2v</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Qwen-Image</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">qwen-image-edit-2511</span></div>
           </div>
         </div>
 
-        <div data-panel="vla" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-4">
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+        <div data-panel="vla" class="hidden grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Pi</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">pi0.5</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">GR00T</h4>
-            <div class="flex flex-wrap gap-1.5"><span class="chip">groot_n1_6</span><span class="chip">groot_n1_7</span></div>
+            <div class="flex flex-wrap gap-1.5"><span class="chip">groot_n1_6</span><span class="chip">groot_n1_7</span>
+            </div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">XVLA</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">xvla</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">FastWAM</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">fastwam</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">LingBot-VA</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">lingbot_va</span></div>
           </div>
-          <div class="rounded-2xl p-5 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          <div
+            class="rounded-[1.25rem] p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
             <h4 class="font-semibold mb-2">Cosmos3</h4>
             <div class="flex flex-wrap gap-1.5"><span class="chip">cosmos3_nano</span></div>
           </div>
@@ -489,209 +633,184 @@
     </div>
   </section>
 
-  <!-- ===== Quick Start (5-step workflow, faithful to docs) ===== -->
-  <section id="quickstart" class="max-w-7xl mx-auto px-6 py-20 reveal">
-    <div class="text-center mb-10">
+  <!-- ===== Quick Start (launchpad by model type) ===== -->
+  <section id="quickstart"
+    class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
+    <div class="text-center mb-12">
       <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="qs.title">🚀 Quick Start</h2>
-      <p class="text-gray-600 dark:text-gray-400" data-i18n="qs.subtitle">YAML-driven — a few steps from install to
-        launch
-      </p>
+      <p class="text-gray-600 dark:text-gray-400 max-w-2xl mx-auto" data-i18n="qs.subtitle">From install to launch —
+        jump straight to the tutorial for your model type</p>
     </div>
 
-    <div id="qs-interactive" class="max-w-6xl mx-auto gradient-border p-6 md:p-8">
-      <!-- Step tabs -->
-      <div class="flex flex-wrap gap-2 mb-5" role="tablist">
-        <button type="button" class="qs-tab active" data-qs-step="1"><span class="qs-tab-num">1</span><span
-            data-i18n="qs.s1.tab">Install</span></button>
-        <button type="button" class="qs-tab" data-qs-step="2"><span class="qs-tab-num">2</span><span
-            data-i18n="qs.s2.tab">Compose</span><span class="qs-opt" data-i18n="qs.s2.opt">optional</span></button>
-        <button type="button" class="qs-tab" data-qs-step="3"><span class="qs-tab-num">3</span><span
-            data-i18n="qs.s3.tab">Weights</span></button>
-        <button type="button" class="qs-tab" data-qs-step="4"><span class="qs-tab-num">4</span><span
-            data-i18n="qs.s4.tab">Data</span></button>
-        <button type="button" class="qs-tab" data-qs-step="5"><span class="qs-tab-num">5</span><span
-            data-i18n="qs.s5.tab">Configure</span></button>
-        <button type="button" class="qs-tab" data-qs-step="6"><span class="qs-tab-num">6</span><span
-            data-i18n="qs.s6.tab">Launch</span></button>
-      </div>
+    <div class="space-y-6">
 
       <!-- Step 1: Install -->
-      <div class="qs-panel active" data-qs-panel="1">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s1.desc">
-          Docker is the recommended path — a single image bundles CUDA/XPU toolchains, the patched Megatron submodule,
-          and TransformerEngine, so every developer and every node trains from the same environment. Source install is
-          also fully supported for advanced setups.
-        </p>
-        <pre
-          class="cmd-block"><span class="prompt">$</span> <span class="cmt"># NVIDIA GPU (Docker)</span>
-<span class="prompt">$</span> git clone <span class="val">--recurse-submodules</span> https://github.com/baidu-baige/LoongForge.git
-<span class="prompt">$</span> docker build <span class="flag">--build-arg</span> <span class="val">COMPILE_ENV=hopper</span> <span class="flag">--build-arg</span> <span class="val">ENABLE_LEROBOT=false</span> <span class="flag">-t</span> <span class="val">loongforge:latest</span> <span class="flag">-f</span> ./LoongForge/docker/Dockerfile .
-
-<span class="prompt">$</span> <span class="cmt"># Kunlun XPU (Docker)</span>
-<span class="prompt">$</span> docker build <span class="flag">--build-arg</span> <span class="val">BASE_IMAGE=loongforge/loongforge_kunlun:py310_torch25</span> <span class="flag">--build-arg</span> <span class="val">ENABLE_LEROBOT=false</span> <span class="flag">-t</span> <span class="val">loongforge-kunlun:latest</span> <span class="flag">-f</span> LoongForge/docker/Dockerfile.xpu .</pre>
+      <div class="lf-card">
+        <div class="flex items-center gap-3 mb-4">
+          <span class="lf-step-num">1</span>
+          <h3 class="text-xl font-bold" data-i18n="qs2.install.t">Install</h3>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4" data-i18n="qs2.install.d">Recommended: one Docker image
+          bundles the CUDA/XPU toolchains, patched Megatron, and TransformerEngine — so every node trains from the same
+          environment. Source build is also supported.</p>
+        <details class="mt-1">
+          <summary
+            class="cursor-pointer select-none text-sm font-semibold text-indigo-600 dark:text-indigo-300 hover:underline"
+            data-i18n="qs2.docker">Show Docker build commands</summary>
+          <div class="grid md:grid-cols-2 gap-4 mt-4">
+            <div class="rounded-xl border border-gray-200 dark:border-gray-800 p-4 bg-gray-50/60 dark:bg-gray-900/40">
+              <div class="flex items-center justify-between mb-2">
+                <div class="text-sm font-bold flex items-center gap-2"><span
+                    class="w-2 h-2 rounded-full bg-emerald-500"></span>NVIDIA GPU</div>
+                <a class="qs-link text-xs font-semibold text-indigo-600 dark:text-indigo-300 hover:underline"
+                  target="_blank" rel="noopener"
+                  data-href-en="https://loongforge.readthedocs.io/en/latest/get_started/installation.html"
+                  data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/get_started/installation.html"
+                  href="https://loongforge.readthedocs.io/en/latest/get_started/installation.html"
+                  data-i18n="qs2.guide">Installation guide ↗</a>
+              </div>
+              <pre class="cmd-block" style="font-size:12px;line-height:1.7;"><span class="prompt">$</span> git clone <span class="val">--recurse-submodules</span> \
+    https://github.com/baidu-baige/LoongForge.git
+<span class="prompt">$</span> docker build <span class="flag">--build-arg</span> <span class="val">COMPILE_ENV=hopper</span> <span class="flag">--build-arg</span> <span class="val">ENABLE_LEROBOT=false</span> \
+    <span class="flag">-t</span> <span class="val">loongforge:latest</span> \
+    <span class="flag">-f</span> ./LoongForge/docker/Dockerfile .</pre>
+            </div>
+            <div class="rounded-xl border border-gray-200 dark:border-gray-800 p-4 bg-gray-50/60 dark:bg-gray-900/40">
+              <div class="flex items-center justify-between mb-2">
+                <div class="text-sm font-bold flex items-center gap-2"><span
+                    class="w-2 h-2 rounded-full bg-indigo-500"></span>Kunlun XPU</div>
+                <a class="qs-link text-xs font-semibold text-indigo-600 dark:text-indigo-300 hover:underline"
+                  target="_blank" rel="noopener"
+                  data-href-en="https://loongforge.readthedocs.io/en/latest/kunlun_tutorial/install_p800.html"
+                  data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/kunlun_tutorial/install_p800.html"
+                  href="https://loongforge.readthedocs.io/en/latest/kunlun_tutorial/install_p800.html"
+                  data-i18n="qs2.guide">Installation guide ↗</a>
+              </div>
+              <pre class="cmd-block" style="font-size:12px;line-height:1.7;"><span class="prompt">$</span> docker build <span class="flag">--build-arg</span> <span class="val">ENABLE_LEROBOT=false</span> \
+    <span class="flag">--build-arg</span> <span class="val">BASE_IMAGE=loongforge/loongforge_kunlun:py310_torch25</span> \
+    <span class="flag">-t</span> <span class="val">loongforge-kunlun:latest</span> \
+    <span class="flag">-f</span> LoongForge/docker/Dockerfile.xpu .</pre>
+            </div>
+          </div>
+        </details>
       </div>
 
-      <!-- Step 2: Compose -->
-      <div class="qs-panel" data-qs-panel="2">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s2.desc">
-          Optional — only needed for custom combinations. LoongForge uses declarative configs to compose different
-          modality components into a full multimodal model. Take <code class="mono">qwen3_vl_30b_a3b</code> as an
-          example: a single YAML assembles the vision encoder, projector, and language backbone. To swap the language
-          backbone to DeepSeek V3, change one line under <code class="mono">model.foundation</code>. Mainstream
-          open-source models are already built in under <code class="mono">configs/models/</code> for you to pick from.
-        </p>
-        <pre class="cmd-block"><span class="cmt"># configs/models/qwen3_vl/qwen3_vl_30b_a3b.yaml</span>
-defaults:
-  - ../../models/image_encoder@model.image_encoder: <span class="val">qwen3_vit</span>
-  - ../../models/image_projector@model.image_projector: <span class="val">qwen_mlp_adapter</span>
-  - ../../models/qwen3@model.foundation: <span class="val">qwen3_30b_a3b</span>
-  - _self_
-
-model:
-  model_type: <span class="val">qwen3_vl</span>
-  ...
-
-<span class="cmt"># Swap the language backbone — one line change:</span>
-<span class="flag">-</span>  - ../../models/qwen3@model.foundation: qwen3_30b_a3b
-<span class="val">+</span>  - ../../models/deepseek3@model.foundation: deepseek_v3</pre>
-      </div>
-
-      <!-- Step 3: Weights -->
-      <div class="qs-panel" data-qs-panel="3">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s3.desc">
-          LoongForge supports offline conversion of HuggingFace weights into the Megatron training format, and also
-          supports loading HuggingFace-format weights directly at startup — skipping the conversion step. On
-          completion, weights can be exported back to HF format with one flag, for seamless hand-off to the downstream
-          community ecosystem.
-        </p>
-        <pre class="cmd-block">TRAINING_ARGS=(
-    <span class="flag">--load</span> <span class="val">$CHECKPOINT_PATH</span>            <span class="cmt"># point directly at the HF model directory</span>
-    <span class="flag">--save</span> <span class="val">$CHECKPOINT_PATH</span>            <span class="cmt"># high-performance training checkpoints</span>
-    <span class="flag">--save-interval</span> <span class="val">40</span>
-    <span class="flag">--save-hf</span> <span class="val">true</span>                     <span class="cmt"># export HF weights on finish</span>
-    <span class="flag">--save-hf-path</span> <span class="val">/path/to/output</span>
-    ...
-)</pre>
-      </div>
-
-      <!-- Step 4: Data -->
-      <div class="qs-panel" data-qs-panel="4">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s4.desc">
-          LoongForge ships a built-in data preprocessing toolchain that converts your raw data into the
-          framework-compatible format. Below is a multimodal data preprocessing example — refer to the per-model-family
-          user guide for details.
-        </p>
-        <pre class="cmd-block"><span class="prompt">$</span> python tools/data_preprocess/vlm/convert_to_webdataset.py \
-    <span class="flag">--output_dir</span> <span class="val">/workspace/wds_data/</span> \
-    <span class="flag">--json_file</span> <span class="val">tests/datasets/vlm/mllm_demo.json</span> \
-    <span class="flag">--image_dir</span> <span class="val">tests/datasets/vlm/</span> \
-    <span class="flag">--video_dir</span> <span class="val">tests/datasets/vlm/</span> \
-    <span class="flag">--media</span> <span class="val">mix</span> \
-    <span class="flag">--columns_messages</span> <span class="val">messages</span> \
-    <span class="flag">--maxcount</span> <span class="val">10000</span> \
-    <span class="flag">--maxsize</span> <span class="val">3000000000</span> \
-    <span class="flag">--sample_type</span> <span class="val">multi_mix_qa</span></pre>
-      </div>
-
-      <!-- Step 5: Configure -->
-      <div class="qs-panel" data-qs-panel="5">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s5.desc.outer">
-          The outer layer is fully Megatron-compatible — familiar training arguments can be reused as-is.
-        </p>
-        <pre class="cmd-block">TRAINING_ARGS=(
-    <span class="flag">--training-phase</span> <span class="val">sft</span>
-    <span class="flag">--seq-length</span> <span class="val">32768</span>
-    <span class="flag">--micro-batch-size</span> <span class="val">1</span>
-    ...
-)
-
-MODEL_PARALLEL_ARGS=(
-    <span class="flag">--tensor-model-parallel-size</span> <span class="val">1</span>
-    <span class="flag">--pipeline-model-parallel-size</span> <span class="val">2</span>
-    <span class="flag">--expert-model-parallel-size</span> <span class="val">8</span>
-    ...
-)</pre>
-        <p class="text-sm text-gray-600 dark:text-gray-400 mt-5 mb-3" data-i18n-html="qs.s5.desc.inner">
-          The inner layer uses Hydra overrides to assign parallelism (TP / PP / EP / DP) and freeze behavior per model
-          component — ideal for heterogeneous VLM training where ViT and LLM backbones have very different compute
-          profiles.
-        </p>
-        <pre class="cmd-block"><span class="cmt"># Per-component overrides (Hydra): different TP / freeze per component</span>
-+model.image_encoder.tensor-model-parallel-size=<span class="val">1</span>
-+model.foundation.tensor-model-parallel-size=<span class="val">4</span>
-+model.image_encoder.freeze=<span class="val">True</span></pre>
-      </div>
-
-      <!-- Step 6: Launch -->
-      <div class="qs-panel" data-qs-panel="6">
-        <p class="text-sm text-gray-600 dark:text-gray-400 mb-3" data-i18n-html="qs.s6.desc">
-          LoongForge ships example launch scripts for open-source models that you can run as-is. Browse
-          <code class="mono">examples/</code> (NVIDIA GPU) and <code class="mono">examples_xpu/</code> (Kunlun XPU). The
-          snippet below shows the common <code class="mono">torchrun</code> launch pattern shared across examples.
-        </p>
-        <pre class="cmd-block"><span class="prompt">$</span> <span class="cmt"># e.g. examples/qwen3_vl/finetuning/sft_qwen3_vl_30b_a3b.sh</span>
-<span class="prompt">$</span> PYTHONPATH=<span class="val">$MEGATRON_PATH:$LOONGFORGE_PATH:$PYTHONPATH</span> \
-    torchrun <span class="flag">--nproc_per_node</span> <span class="val">8</span> <span class="flag">--nnodes</span> <span class="val">$NNODES</span> \
-        <span class="val">$LOONGFORGE_PATH/loongforge/train.py</span> \
-        <span class="flag">--config-file</span> <span class="val">$LOONGFORGE_PATH/configs/models/qwen3_vl/qwen3_vl_30b_a3b.yaml</span> \
-        "${DATA_ARGS[@]}" "${TRAINING_ARGS[@]}" "${MOE_ARGS[@]}" "${MODEL_PARALLEL_ARGS[@]}" \
-        +model.image_encoder.freeze=<span class="val">True</span></pre>
-      </div>
-
-      <!-- Footer: snippets are illustrative — here are the full runnable tutorials -->
-      <div
-        class="qs-footer mt-6 pt-5 border-t border-gray-200 dark:border-gray-800 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3 text-sm">
-        <div class="flex flex-wrap items-center gap-x-4 gap-y-2">
-          <span class="text-gray-500 dark:text-gray-400" data-i18n="qs.footer.label">📖 Full runnable tutorials:</span>
-          <a class="qs-link" target="_blank" rel="noopener"
+      <!-- Step 2: Pick your path -->
+      <div class="lf-card">
+        <div class="flex items-center gap-3 mb-2">
+          <span class="lf-step-num">2</span>
+          <h3 class="text-xl font-bold" data-i18n="qs2.path.t">Pick your path</h3>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-5" data-i18n="qs2.path.d">Choose your model type — each
+          card opens a runnable, step-by-step tutorial.</p>
+        <div class="grid sm:grid-cols-2 lg:grid-cols-4 gap-4">
+          <a class="qs-link group card-hover rounded-[1.25rem] p-5 bg-gray-50/70 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-800 flex flex-col"
+            target="_blank" rel="noopener"
             data-href-en="https://loongforge.readthedocs.io/en/latest/llm_tutorial/quick_start_llm_pretrain.html"
             data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/llm_tutorial/quick_start_llm_pretrain.html"
-            href="https://loongforge.readthedocs.io/en/latest/llm_tutorial/quick_start_llm_pretrain.html">LLM ↗</a>
-          <a class="qs-link" target="_blank" rel="noopener"
+            href="https://loongforge.readthedocs.io/en/latest/llm_tutorial/quick_start_llm_pretrain.html">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <span class="lf-ico">🧠</span>
+                <span class="feat-tag feat-tag-moe">LLM</span>
+              </div>
+              <span class="text-indigo-500 opacity-0 group-hover:opacity-100 transition">→</span>
+            </div>
+            <div class="font-bold text-gray-900 dark:text-white mb-1">Large Language Models</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="qs2.cat.llm.d">Dense &amp; MoE language
+              models — pretrain / SFT / LoRA.</div>
+            <div class="mt-auto pt-4 text-sm font-semibold text-indigo-600 dark:text-indigo-300" data-i18n="qs2.open">
+              Open tutorial ↗</div>
+          </a>
+          <a class="qs-link group card-hover rounded-[1.25rem] p-5 bg-gray-50/70 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-800 flex flex-col"
+            target="_blank" rel="noopener"
             data-href-en="https://loongforge.readthedocs.io/en/latest/vlm_tutorial/quick_start_vlm_pretrain.html"
             data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/vlm_tutorial/quick_start_vlm_pretrain.html"
-            href="https://loongforge.readthedocs.io/en/latest/vlm_tutorial/quick_start_vlm_pretrain.html">VLM ↗</a>
-          <a class="qs-link" target="_blank" rel="noopener"
-            data-href-en="https://loongforge.readthedocs.io/en/latest/vla_tutorial/quick_start_pi05_training.html"
-            data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/vla_tutorial/quick_start_pi05_training.html"
-            href="https://loongforge.readthedocs.io/en/latest/vla_tutorial/quick_start_pi05_training.html">VLA ↗</a>
-          <a class="qs-link" target="_blank" rel="noopener"
+            href="https://loongforge.readthedocs.io/en/latest/vlm_tutorial/quick_start_vlm_pretrain.html">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <span class="lf-ico">🖼️</span>
+                <span class="feat-tag feat-tag-mm">VLM</span>
+              </div>
+              <span class="text-indigo-500 opacity-0 group-hover:opacity-100 transition">→</span>
+            </div>
+            <div class="font-bold text-gray-900 dark:text-white mb-1">Vision-Language Models</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="qs2.cat.vlm.d">Vision-language models —
+              composable ViT × LLM via YAML.</div>
+            <div class="mt-auto pt-4 text-sm font-semibold text-indigo-600 dark:text-indigo-300" data-i18n="qs2.open">
+              Open tutorial ↗</div>
+          </a>
+          <a class="qs-link group card-hover rounded-[1.25rem] p-5 bg-gray-50/70 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-800 flex flex-col"
+            target="_blank" rel="noopener"
             data-href-en="https://loongforge.readthedocs.io/en/latest/wan_tutorial/quick_start_wan_training.html"
             data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/wan_tutorial/quick_start_wan_training.html"
-            href="https://loongforge.readthedocs.io/en/latest/wan_tutorial/quick_start_wan_training.html">Diffusion
-            ↗</a>
-          <a class="qs-link" target="_blank" rel="noopener"
-            data-href-en="https://loongforge.readthedocs.io/en/latest/kunlun_tutorial/README.html"
-            data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/kunlun_tutorial/README.html"
-            href="https://loongforge.readthedocs.io/en/latest/kunlun_tutorial/README.html"
-            data-i18n="qs.footer.xpu">Kunlun XPU ↗</a>
-        </div>
-        <div class="text-xs text-gray-500 dark:text-gray-400" data-i18n-html="qs.footer.browse_html">
-          Browse
-          <a class="underline hover:text-indigo-600"
-            href="https://github.com/baidu-baige/LoongForge/tree/master/configs/models" target="_blank"
-            rel="noopener"><code class="mono">configs/models/</code></a> ·
-          <a class="underline hover:text-indigo-600"
-            href="https://github.com/baidu-baige/LoongForge/tree/master/examples" target="_blank" rel="noopener"><code
-              class="mono">examples/</code></a> ·
-          <a class="underline hover:text-indigo-600"
-            href="https://github.com/baidu-baige/LoongForge/tree/master/examples_xpu" target="_blank"
-            rel="noopener"><code class="mono">examples_xpu/</code></a>
+            href="https://loongforge.readthedocs.io/en/latest/wan_tutorial/quick_start_wan_training.html">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <span class="lf-ico">🎬</span>
+                <span class="feat-tag feat-tag-seq">Diffusion</span>
+              </div>
+              <span class="text-indigo-500 opacity-0 group-hover:opacity-100 transition">→</span>
+            </div>
+            <div class="font-bold text-gray-900 dark:text-white mb-1">Diffusion Models</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="qs2.cat.diff.d">Video &amp; image diffusion
+              (WAN, Qwen-Image).</div>
+            <div class="mt-auto pt-4 text-sm font-semibold text-indigo-600 dark:text-indigo-300" data-i18n="qs2.open">
+              Open tutorial ↗</div>
+          </a>
+          <a class="qs-link group card-hover rounded-[1.25rem] p-5 bg-gray-50/70 dark:bg-gray-800/40 border border-gray-200 dark:border-gray-800 flex flex-col"
+            target="_blank" rel="noopener"
+            data-href-en="https://loongforge.readthedocs.io/en/latest/embodied_tutorial/overview.html"
+            data-href-zh="https://loongforge.readthedocs.io/zh-cn/latest/embodied_tutorial/overview.html"
+            href="https://loongforge.readthedocs.io/en/latest/embodied_tutorial/overview.html">
+            <div class="flex items-center justify-between mb-3">
+              <div class="flex items-center gap-2">
+                <span class="lf-ico">🤖</span>
+                <span class="feat-tag feat-tag-embodied">Embodied</span>
+              </div>
+              <span class="text-indigo-500 opacity-0 group-hover:opacity-100 transition">→</span>
+            </div>
+            <div class="font-bold text-gray-900 dark:text-white mb-1">Embodied (VLA &amp; WAM)</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400" data-i18n="qs2.cat.vla.d">VLA &amp; world-action
+              models
+              — torch-native DDP/FSDP.</div>
+            <div class="mt-auto pt-4 text-sm font-semibold text-indigo-600 dark:text-indigo-300" data-i18n="qs2.open">
+              Open tutorial ↗</div>
+          </a>
         </div>
       </div>
+
+      <!-- Step 3: Explore & launch -->
+      <div class="lf-card">
+        <div class="flex items-center gap-3 mb-3">
+          <span class="lf-step-num">3</span>
+          <h3 class="text-xl font-bold" data-i18n="qs2.explore.t">Explore &amp; launch</h3>
+        </div>
+        <p class="text-sm text-gray-600 dark:text-gray-400 mb-4" data-i18n="qs2.explore.d">Browse ready-to-run configs
+          and example scripts to launch your first run.</p>
+        <div class="flex flex-wrap gap-3">
+          <a class="qs-chip" href="https://github.com/baidu-baige/LoongForge/tree/master/examples" target="_blank"
+            rel="noopener">📂 <code class="mono">examples/</code></a>
+          <a class="qs-chip" href="https://github.com/baidu-baige/LoongForge/tree/master/examples_xpu" target="_blank"
+            rel="noopener">📂 <code class="mono">examples_xpu/</code></a>
+          <a class="qs-chip" href="https://github.com/baidu-baige/LoongForge/tree/master/configs/models" target="_blank"
+            rel="noopener">⚙️ <code class="mono">configs/models/</code></a>
+        </div>
+      </div>
+
     </div>
   </section>
 
   <!-- ===== Powered By ===== -->
-  <section class="bg-amber-50/50 dark:bg-amber-950/15 border-y border-amber-100 dark:border-amber-900/30">
-    <div class="max-w-7xl mx-auto px-6 py-20 reveal">
+  <section class="bg-[#F7F8FF] dark:bg-gray-900/50 border-y border-indigo-100/70 dark:border-gray-800">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
       <h2 class="text-3xl md:text-4xl font-bold text-center mb-3" data-i18n="powered.title">🌟 Powered by LoongForge
       </h2>
       <p class="text-center text-gray-600 dark:text-gray-400 mb-10" data-i18n="powered.subtitle">Open-source models
         trained with LoongForge or its predecessor AIAK-Training-LLM</p>
-      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
         <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2" target="_blank"
-          class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          class="rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="flex items-center gap-2 mb-2">
             <span class="text-2xl">✨</span>
             <span
@@ -703,7 +822,7 @@ MODEL_PARALLEL_ARGS=(
             multimodal model — improved data, training recipe, and scaling.</p>
         </a>
         <a href="https://github.com/InnovatorLM/Innovator-VL/tree/main" target="_blank"
-          class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          class="rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="flex items-center gap-2 mb-2">
             <span class="text-2xl">🧪</span>
             <span
@@ -715,14 +834,14 @@ MODEL_PARALLEL_ARGS=(
             language model for advanced reasoning.</p>
         </a>
         <a href="https://github.com/EvolvingLMMs-Lab/LLaVA-OneVision-2/tree/1.5" target="_blank"
-          class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          class="rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="text-2xl mb-2">🔬</div>
           <h3 class="font-semibold mb-1" data-i18n="powered.3.t">LLaVA-OneVision-1.5</h3>
           <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.3.d">Fully open framework for
             democratized multimodal training.</p>
         </a>
         <a href="https://github.com/baidubce/Qianfan-VL" target="_blank"
-          class="rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
+          class="rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover">
           <div class="text-2xl mb-2">🎯</div>
           <h3 class="font-semibold mb-1" data-i18n="powered.4.t">Qianfan-VL</h3>
           <p class="text-sm text-gray-600 dark:text-gray-400" data-i18n="powered.4.d">Domain-enhanced universal
@@ -733,16 +852,16 @@ MODEL_PARALLEL_ARGS=(
   </section>
 
   <!-- ===== Community ===== -->
-  <section id="community" class="bg-gray-50 dark:bg-gray-900/50 border-y border-gray-200 dark:border-gray-800">
-    <div class="max-w-7xl mx-auto px-6 py-20 reveal">
+  <section id="community" class="bg-[#F7F8FF] dark:bg-gray-900/50 border-y border-indigo-100/70 dark:border-gray-800">
+    <div class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-20 md:py-24 reveal">
       <div class="text-center mb-10">
         <h2 class="text-3xl md:text-4xl font-bold mb-3" data-i18n="comm.title">🤝 Community</h2>
         <p class="text-gray-600 dark:text-gray-400" data-i18n="comm.subtitle">Built in the open — join discussions,
           report issues, and contribute</p>
       </div>
-      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-5">
+      <div class="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
         <a href="https://github.com/baidu-baige/LoongForge/issues" target="_blank"
-          class="group rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
+          class="group rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
           <div class="text-3xl mb-3">🐛</div>
           <h3 class="font-semibold mb-1 group-hover:text-indigo-600 dark:group-hover:text-indigo-300"
             data-i18n="comm.1.t">GitHub Issues</h3>
@@ -751,7 +870,7 @@ MODEL_PARALLEL_ARGS=(
           </p>
         </a>
         <a href="https://github.com/baidu-baige/LoongForge/discussions" target="_blank"
-          class="group rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
+          class="group rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
           <div class="text-3xl mb-3">💬</div>
           <h3 class="font-semibold mb-1 group-hover:text-indigo-600 dark:group-hover:text-indigo-300"
             data-i18n="comm.2.t">Discussions</h3>
@@ -759,7 +878,7 @@ MODEL_PARALLEL_ARGS=(
           </p>
         </a>
         <a href="https://github.com/baidu-baige/LoongForge/blob/master/CONTRIBUTING.md" target="_blank"
-          class="group rounded-2xl p-6 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
+          class="group rounded-[1.25rem] p-7 bg-white dark:bg-gray-900 border border-gray-200 dark:border-gray-800 card-hover block">
           <div class="text-3xl mb-3">🛠️</div>
           <h3 class="font-semibold mb-1 group-hover:text-indigo-600 dark:group-hover:text-indigo-300"
             data-i18n="comm.3.t">Contributing</h3>
@@ -767,8 +886,8 @@ MODEL_PARALLEL_ARGS=(
             PR.
           </p>
         </a>
-        <a href="https://github.com/baidu-baige/LoongForge#contact" target="_blank" rel="noopener"
-          class="group rounded-2xl p-6 bg-gradient-to-br from-emerald-50 to-white dark:from-emerald-950/40 dark:to-gray-900 border border-emerald-200 dark:border-emerald-900/50 card-hover block">
+        <a href="https://github.com/baidu-baige/LoongForge/issues/80" target="_blank" rel="noopener"
+          class="group rounded-[1.25rem] p-7 bg-gradient-to-br from-emerald-50 to-white dark:from-emerald-950/40 dark:to-gray-900 border border-emerald-200 dark:border-emerald-900/50 card-hover block">
           <div class="text-3xl mb-3">💚</div>
           <h3 class="font-semibold mb-1 group-hover:text-emerald-600 dark:group-hover:text-emerald-300"
             data-i18n="comm.4.t">Join us on WeChat</h3>
@@ -781,24 +900,24 @@ MODEL_PARALLEL_ARGS=(
       <!-- Stats strip -->
       <div class="stats-strip mt-10">
         <div data-gh-stars-tile hidden>
-          <div class="text-2xl font-bold text-amber-500">★ <span data-gh-stars>—</span></div>
+          <div class="text-3xl md:text-4xl font-bold text-amber-500">★ <span data-gh-stars>—</span></div>
           <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1" data-i18n="stats.stars">
             GitHub Stars</div>
         </div>
         <div>
           <a href="https://github.com/baidu-baige/LoongForge/graphs/contributors" target="_blank" rel="noopener"
-            class="text-2xl font-bold text-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-300"><span
+            class="text-3xl md:text-4xl font-bold text-indigo-500 hover:text-indigo-600 dark:hover:text-indigo-300"><span
               id="gh-contrib">14+</span></a>
           <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1" data-i18n="stats.contrib">
             Contributors</div>
         </div>
         <div>
-          <div class="text-2xl font-bold text-emerald-500">Apache 2.0</div>
+          <div class="text-3xl md:text-4xl font-bold text-emerald-500">Apache 2.0</div>
           <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1" data-i18n="stats.license">
             License</div>
         </div>
         <div>
-          <div class="text-2xl font-bold text-violet-500">🐉 Loong</div>
+          <div class="text-3xl md:text-4xl font-bold text-violet-500">🐉 Loong</div>
           <div class="text-xs uppercase tracking-wider text-gray-500 dark:text-gray-400 mt-1" data-i18n="stats.series">
             Baige Loong Series</div>
         </div>
@@ -809,7 +928,8 @@ MODEL_PARALLEL_ARGS=(
 
   <!-- ===== Footer ===== -->
   <footer class="border-t border-gray-200 dark:border-gray-800 bg-white dark:bg-gray-950">
-    <div class="max-w-7xl mx-auto px-6 py-12 grid md:grid-cols-4 gap-8 text-sm">
+    <div
+      class="max-w-7xl 2xl:max-w-[1600px] mx-auto px-5 sm:px-8 lg:px-12 xl:px-20 2xl:px-28 py-12 grid md:grid-cols-4 gap-8 text-sm">
       <div>
         <div class="flex items-center gap-2 font-bold mb-3">
           <img src="assets/img/logo.svg" class="w-7 h-7" alt="" />LoongForge
@@ -859,7 +979,7 @@ MODEL_PARALLEL_ARGS=(
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-bash.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-python.min.js"></script>
   <script src="https://cdn.jsdelivr.net/npm/prismjs@1.29.0/components/prism-yaml.min.js"></script>
-  <script src="assets/js/main.js?v=20260612-embodied3"></script>
+  <script src="assets/js/main.js?v=20260728-r17"></script>
   <script src="assets/js/home-news.js"></script>
 </body>
 


### PR DESCRIPTION
- Light hero with wave divider; remove dark top block
- Gradient stat band with animated counters
- Feature cards with icons; unified brand gradient & tokens
- Rebuild Quick Start as launchpad (Install / model-type paths / explore)
- Add Architecture section using official SVGs (light/dark, local assets)
- Enlarge navbar; responsive fluid gutters that scale with screen size
- Widen container to 1600px on 2xl; various copy/layout polish