### PR TITLE
[vla] fix: Add batch drop-last configuration

### DIFF
--- a/examples/embodied/pi05/run_pi05_ddp_finetune.sh
+++ b/examples/embodied/pi05/run_pi05_ddp_finetune.sh
@@ -46,6 +46,7 @@ DATA_ARGS=(
     --tokenizer-path $TOKENIZER_PATH
     --robot-type libero_franka
     --num-workers 16
+    --batch-drop-last
 )
 
 # ── Training params ───────────────────────────────────────────

--- a/examples/embodied/pi05/run_pi05_ddp_zero1_finetune.sh
+++ b/examples/embodied/pi05/run_pi05_ddp_zero1_finetune.sh
@@ -52,6 +52,7 @@ DATA_ARGS=(
     --tokenizer-path $TOKENIZER_PATH
     --robot-type libero_franka
     --num-workers 16
+    --batch-drop-last
 )
 
 # ── Training params (aligned with examples/pi05/finetuning/sft_pi05.sh) ──

--- a/examples/embodied/pi05/run_pi05_fsdp_finetune.sh
+++ b/examples/embodied/pi05/run_pi05_fsdp_finetune.sh
@@ -51,6 +51,7 @@ DATA_ARGS=(
     --tokenizer-path $TOKENIZER_PATH
     --robot-type libero_franka
     --num-workers 16
+    --batch-drop-last
 )
 
 # -- Training params (aligned with examples/pi05/finetuning/sft_pi05.sh) ------

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -49,15 +49,6 @@ _FSDP_DTYPE_BY_NAME = {
 # ---------------------------------------------------------------------------
 
 
-def parse_bool(value: str) -> bool:
-    """Parse bool from CLI text: true|false|1|0|yes|no."""
-    if value.strip().lower() in {"true", "t", "1", "yes"}:
-        return True
-    if value.strip().lower() in {"false", "f", "0", "no"}:
-        return False
-    raise argparse.ArgumentTypeError(f"Expected true/false, got: {value!r}")
-
-
 def parse_reshard_after_forward(value: str):
     """Parse FSDP2 reshard_after_forward from CLI text: true|false|none|int>1."""
     normalized = value.strip().lower()
@@ -667,13 +658,12 @@ class _DataArgs:
         },
     )
     batch_drop_last: bool = field(
-        default=True,
+        default=False,
         metadata={
-            "cli_type": parse_bool,
             "help": (
                 "If True, drop the last incomplete batch so every rank sees the same "
                 "number of full-size batches. Applied to both sampler and DataLoader. "
-                "Default True preserves training stability."
+                "Default False preserves all samples."
             ),
         },
     )


### PR DESCRIPTION

## Summary

This PR makes `batch_drop_last` easier to configure for VLA training.

The option controls whether the final incomplete batch is dropped and is applied consistently to both the sampler and the DataLoader.

## Configuration

### Default behavior

When no option is specified, the final incomplete batch is preserved:


### Enable drop-last

Add the following flag to the training command:

```bash
--batch-drop-last
```

When enabled, the final batch is dropped if it contains fewer samples than the configured batch size.

### Explicitly disable drop-last

The behavior can also be explicitly disabled with:

```bash
--no-batch-drop-last
```


## Behavior

| Configuration | `batch_drop_last` | Behavior |
| --- | --- | --- |
| Option omitted | `False` | Preserve the final incomplete batch |
| `--batch-drop-last` | `True` | Drop the final incomplete batch |
| `--no-batch-drop-last` | `False` | Preserve the final incomplete batch |

This configuration is applied to:

- The distributed sampler
- The DataLoader

For distributed training, enable `--batch-drop-last` when every rank should process the same number of full-sized batches.

## Example Updates

The PI0.5 DDP, ZeRO-1, and FSDP fine-tuning examples now explicitly enable:

```bash
--batch-drop-last
```
