### PR TITLE
[vla, data] perf: pin pyav decoder to single thread

### DIFF
--- a/loongforge/embodied/data/datasets/video_backends.py
+++ b/loongforge/embodied/data/datasets/video_backends.py
@@ -114,6 +114,14 @@ def _decode_pyav(video_path, timestamps=None):
     import av
     container = av.open(str(video_path))
     stream = container.streams.video[0]
+    # Single-threaded decode. CPU parallelism here is owned by --num-workers;
+    # libav slice threading would be a second knob over the same cores, and the
+    # two multiply (num_workers * world_size * threads-per-core). It is also the
+    # worse knob for this access pattern (many small independent seek-and-grab
+    # decodes): processes scale near-linearly, slice threading gives ~1.6x at
+    # best, and thread_count=0 ("auto") pays a per-core thread-pool setup on
+    # every av.open that a few decoded frames never amortize.
+    stream.thread_count = 1
     first_ts = min(timestamps)
     last_ts = max(timestamps)
     seek_pts = int(first_ts / stream.time_base)


### PR DESCRIPTION
## Summary

Pin the PyAV video decoder to single-threaded decode (`stream.thread_count = 1`) in `_decode_pyav`, leaving all CPU parallelism to `--num-workers`.

PyAV defaults to `thread_count=0` ("auto"), which sizes libav's thread pool to the host core count. Because the dataloader already provides process-level parallelism, this is a second parallelism knob layered over the same cores, and the two multiply: at 8 ranks x 16 workers on a 128-core host, 128 loader processes each spinning up ~128 decode threads oversubscribes the machine by orders of magnitude. The pool is also built and torn down on every `av.open()`, a cost that a handful of decoded frames never amortizes.

Thread-level decode is the worse knob for this access pattern in any case. Our workload is many small, independent seek-and-grab decodes; worker processes scale near-linearly across them, while libav slice threading yields ~1.6x at best on a single stream.

## Impact

- **+19% end-to-end training throughput**
- Throughput curve is materially more stable. Previously, at `--num-workers 16`, throughput dipped once every 16 iterations as the dataloader round-robin came back around to a stalled worker; that periodic dip is gone.

<img width="889" height="476" alt="af39e8c72599a94268d4853b959c19b8" src="https://github.com/user-attachments/assets/f383d491-150e-488d-9b48-e1c6c992f4a0" />
