### PR TITLE
[ckpt] feat: support DeepSeek V4 HF checkpoint loading

### DIFF
--- a/configs/models/deepseek4/ckpt_convert/deepseek_v4_convert.yaml
+++ b/configs/models/deepseek4/ckpt_convert/deepseek_v4_convert.yaml
@@ -200,6 +200,7 @@ name_map:
       extra: true
       fp8: true
       fp8_ignore_tp: true
+      ignore_tp: true
     attention.kv_norm:
       name: self_attention.kv_layernorm
       extra: true
@@ -248,6 +249,7 @@ name_map:
       fp8: true
       extra: true
       fp8_ignore_tp: true
+      ignore_tp: true
     post_attention_layernorm: pre_mlp_layernorm
     moe.gate: mlp.router
     moe.gate.bias:

--- a/tools/convert_checkpoint/huggingface/huggingface_checkpoint.py
+++ b/tools/convert_checkpoint/huggingface/huggingface_checkpoint.py
@@ -602,13 +602,26 @@ class HuggingFaceCheckpoint(AbstractCheckpoint):
         # would reach mcore conversion still as int8 with a stale scale.
         self.dequantize_mxfp4_if_needed()
 
-        # DeepSeek-V4 key preprocessing: add model. prefix, rename FP8 scales,
-        # restructure MTP keys, split hyper-connection scale into alpha_pre/alpha_post/alpha_res
+        # DeepSeek-V4 preprocessing for native and HF-Transformers key layouts.
+        # HF-Transformers checkpoints prefix every key with "model." (e.g.
+        # "model.layers.0...", "model.embed_tokens.weight"); native DSV4
+        # checkpoints don't. Strip that prefix once up front so every rule
+        # below only has to handle the native layout, instead of every rule
+        # separately special-casing an optional "model." prefix.
+        _MODEL_PREFIX = 'model.'
+
+        def _strip_model_prefix(key):
+            if key.startswith(_MODEL_PREFIX):
+                return key[len(_MODEL_PREFIX):]
+            return key
+
         if (is_dsv4_hybrid_config(c_config) and self.state_dict
-                and any(k.startswith('layers.') or k.startswith('mtp.') or k == 'embed.weight' for k in self.state_dict.keys())):
+                and any(_strip_model_prefix(k).startswith(('layers.', 'mtp.'))
+                        or _strip_model_prefix(k) == 'embed.weight'
+                        for k in self.state_dict.keys())):
             new_sd = {}
             for key, value in self.state_dict.items():
-                new_key = key
+                new_key = _strip_model_prefix(key)
                 # Rename FP8 scale keys: *.scale -> *.weight_scale_inv
                 if new_key.endswith('.scale'):
                     new_key = new_key[:-len('.scale')] + '.weight_scale_inv'

--- a/tools/convert_checkpoint/mcore/mcore_base.py
+++ b/tools/convert_checkpoint/mcore/mcore_base.py
@@ -401,6 +401,25 @@ class McoreBase:
                            ignore_tp=False, quant_type=None, clear_source=True):
         if weight is None:
             return None, None
+        # Online loading follows the destination model's parameter storage.
+        # None keeps the standalone converter's YAML-driven behavior.
+        target_uses_fp8_params = getattr(self.args, "fp8_param_gather", None)
+        if target_uses_fp8_params is False:
+            if weight_scale is not None:
+                source_weight = weight
+                source_scale = weight_scale
+                target_dtype = getattr(self.args, "params_dtype", None) or self.dtype
+                weight = convert_fp8_to_bf16(weight, weight_scale, dtype=target_dtype)
+                if clear_source:
+                    source_weight.data = torch.empty(
+                        0, dtype=source_weight.dtype, device=source_weight.device
+                    )
+                    source_scale.data = torch.empty(
+                        0, dtype=source_scale.dtype, device=source_scale.device
+                    )
+                weight_scale = None
+            # Keep plain or dequantized tensors in params_dtype.
+            quant_type = None
         need_transpose = (m_tp > 1 and self.transpose_mlp_dense and \
                 name in [MLP_DENSE_H_TO_4H, MOE_EXPERT_H_TO_4H])
         chunk_dim = self.tensor_parallel_dim.get(f"{name}.{WEIGHT}", None)

--- a/tools/dist_checkpoint/checkpoint/hf_checkpoint_converter.py
+++ b/tools/dist_checkpoint/checkpoint/hf_checkpoint_converter.py
@@ -40,6 +40,8 @@ class HfCheckpointConverter:
         self.args.moe_grouped_gemm = parallel_config.moe_grouped_gemm
         self.args.fp8_force_no_requant = parallel_config.fp8_force_no_requant
         self.args.force_pow_2_scales = parallel_config.force_pow_2_scales
+        self.args.fp8_param_gather = parallel_config.fp8_param_gather
+        self.args.params_dtype = parallel_config.params_dtype
         self.args.amax_epsilon = parallel_config.amax_epsilon
         self.args.quant_method = parallel_config.quant_method
         self.args.pretrain_as_fp8 = parallel_config.pretrain_as_fp8

--- a/tools/dist_checkpoint/config/parallel_config.py
+++ b/tools/dist_checkpoint/config/parallel_config.py
@@ -5,6 +5,8 @@
 from dataclasses import dataclass
 from typing import Optional
 
+import torch
+
 
 @dataclass
 class ParallelConfig:
@@ -28,6 +30,9 @@ class ParallelConfig:
     max_workers: int = 1
     fp8_force_no_requant: bool = False
     force_pow_2_scales: bool = False
+    # None preserves standalone converter behavior.
+    fp8_param_gather: Optional[bool] = None
+    params_dtype: Optional[torch.dtype] = None
     amax_epsilon: float = 0.0
     quant_method: str = "te"
     pretrain_as_fp8: bool = False

--- a/tools/dist_checkpoint/core/parser.py
+++ b/tools/dist_checkpoint/core/parser.py
@@ -136,8 +136,11 @@ class Parser:
         param_dict['vpp_scheduler'] = getattr(args, 'vpp_scheduler', None) #
         param_dict['safetensors'] = getattr(args, 'safetensors', True) #
         param_dict['max_workers'] = getattr(args, 'max_workers', 1) #
-        param_dict['fp8_force_no_requant'] = getattr(args, 'fp8_force_no_requant', False) # 
-        param_dict['force_pow_2_scales'] = getattr(args, 'force_pow_2_scales', False) # 
+        param_dict['fp8_force_no_requant'] = getattr(args, 'fp8_force_no_requant', False) #
+        param_dict['force_pow_2_scales'] = getattr(args, 'force_pow_2_scales', False) #
+        # Destination parameter representation for online HF loading.
+        param_dict['fp8_param_gather'] = getattr(args, 'fp8_param_gather', None)
+        param_dict['params_dtype'] = getattr(args, 'params_dtype', None)
         param_dict['amax_epsilon'] = getattr(args, 'amax_epsilon', 0.0) #
         # ============================================================================
 
@@ -147,8 +150,7 @@ class Parser:
         param_dict['hf_dequantize_mxfp4'] = getattr(args, 'hf_dequantize_mxfp4', False)
         param_dict['hf_dequantize_dtype'] = getattr(args, 'hf_dequantize_dtype', 'bfloat16')
         param_dict['hf_quant_config_file'] = getattr(args, 'hf_quant_config_file', None)
-        # fp8 conversion method used by mcore converter (bf16->fp8 during bridge load
-        # when training is fp8). Default 'te' matches TransformerEngine-based training.
+        # Used when destination parameters are FP8.
         param_dict['quant_method'] = getattr(args, 'quant_method', 'te')
         param_dict['pretrain_as_fp8'] = getattr(args, 'pretrain_as_fp8', False)
 
@@ -168,6 +170,7 @@ class Parser:
             'moe_grouped_gemm', 'vpp_scheduler', 'tp_ranks', 'pp_ranks', 'ep_ranks',
             'etp_ranks', 'safetensors', 'custom_pipeline_layers',
             'max_workers', 'fp8_force_no_requant', 'force_pow_2_scales',
+            'fp8_param_gather', 'params_dtype',
             'amax_epsilon', 'mtp_num_layers', 'lora_alpha', 'lora_dim', 'enable_full_hetero_dp',
             'hf_dequantize_int4', 'hf_dequantize_mxfp4', 'hf_dequantize_dtype', 'hf_quant_config_file',
             'quant_method', 'pretrain_as_fp8',


### PR DESCRIPTION
## Summary

- strip the optional `model.` prefix while preprocessing DeepSeek V4 checkpoint keys
- propagate destination FP8/BF16 parameter-storage settings into online HF loading
- dequantize scaled FP8 weights when the destination stores BF16 parameters
- preserve replicated DeepSeek V4 projections for both BF16 and retained-FP8 storage

## Root cause

DeepSeek V4 checkpoints may use either native keys or keys wrapped with `model.`. The online converter also lacked the destination parameter-storage settings, so scaled FP8 weights could follow the retained-FP8 path even when the destination model stored BF16 parameters. Two replicated projections only declared their retained-FP8 tensor-parallel behavior.

## Impact

DeepSeek V4 preprocessing now accepts the optional key wrapper. Standalone conversion remains unchanged because the new storage fields default to `None`; retained-FP8 loading preserves scaled weights, while BF16 loading materializes them in the destination parameter dtype.

## Validation

- `pytest -q -p no:cacheprovider tests/test_qwen_vl_projector_configs.py` (4 passed)
- Python syntax validation for all changed Python files
- YAML parsing for `deepseek_v4_convert.yaml`
- `python -m build --sdist --wheel`
- `git diff --check`