### PR TITLE
[data] perf: Improve packed sample overflow error

### DIFF
--- a/loongforge/data/multimodal/base/task_encoder.py
+++ b/loongforge/data/multimodal/base/task_encoder.py
@@ -149,6 +149,51 @@ class BaseTaskBatchPacked(Batch):
     num_tiles: Optional[List[int]]= None
     pixel_values_videos: Optional[torch.Tensor]= None
 
+
+def _format_packed_sample_overflow_error(
+    samples: List[BaseTaskSample],
+    packing_seq_len: int,
+    current_length: int,
+    next_sample: BaseTaskSample,
+    max_items: int = 8,
+) -> str:
+    """Build a compact error without dumping full tensor values."""
+
+    def _shape(value):
+        return tuple(value.shape) if hasattr(value, "shape") else None
+
+    summary = []
+    cumulative_length = 0
+    for sample in samples[:max_items]:
+        cumulative_length += sample.total_len
+        summary.append(
+            {
+                "key": sample.__key__,
+                "total_len": sample.total_len,
+                "cumulative_len": cumulative_length,
+                "tokens_shape": _shape(sample.tokens),
+                "labels_shape": _shape(sample.labels),
+                "attn_mask_shape": _shape(sample.attn_mask),
+                "num_images": len(sample.imgs) if sample.imgs is not None else 0,
+                "num_videos": (
+                    len(sample.pixel_values_videos)
+                    if sample.pixel_values_videos is not None
+                    else 0
+                ),
+            }
+        )
+
+    omitted = max(len(samples) - max_items, 0)
+    omitted_msg = f", omitted_samples={omitted}" if omitted else ""
+    return (
+        "Packed sample exceeds the maximum sequence length of "
+        f"{packing_seq_len}: current_length={current_length}, "
+        f"next_sample_key={next_sample.__key__}, "
+        f"next_sample_len={next_sample.total_len}, "
+        f"would_be_length={current_length + next_sample.total_len}, "
+        f"num_samples={len(samples)}{omitted_msg}, samples_summary={summary}"
+    )
+
 _vlm_tags_cache: Optional[Dict[str, Dict]] = None
 
 _IMAGE_EXTS: Tuple[str, ...] = (".jpg", ".jpeg", ".png", ".webp", ".bmp", ".gif", ".tiff")
@@ -924,7 +969,11 @@ class BaseTaskEncoder(DefaultTaskEncoder[BaseTaskSample, BaseTaskSamplePacked, B
             # This should not happen.
             # The select_samples_to_pack method should have already ensured that the samples fit.
             if current_length + sample_len > packing_seq_len:
-                raise ValueError(f"Packed sample exceeds the maximum sequence length of {packing_seq_len}: {samples}")
+                raise ValueError(
+                    _format_packed_sample_overflow_error(
+                        samples, packing_seq_len, current_length, sample
+                    )
+                )
 
             # Add the sample's tokens and labels
             packed_tokens.append(sample.tokens)

--- a/loongforge/data/multimodal/internvl/internvl_task_encoder.py
+++ b/loongforge/data/multimodal/internvl/internvl_task_encoder.py
@@ -16,6 +16,7 @@ from ..base.task_encoder import (
     BaseTaskSamplePacked,
     BaseTaskBatchPacked,
     BaseTaskEncoder,
+    _format_packed_sample_overflow_error,
 )
 from .internvl_preprocess import InternvlPreprocess, IGNORE_TOKEN_ID, IGNORE_INDEX
 
@@ -142,7 +143,9 @@ class InternVLTaskEncoder(BaseTaskEncoder):
 
             if current_length + sample_len > packing_seq_len:
                 raise ValueError(
-                    f"Packed sample exceeds the maximum sequence length of {packing_seq_len}: {samples}"
+                    _format_packed_sample_overflow_error(
+                        samples, packing_seq_len, current_length, sample
+                    )
                 )
 
             # Add the sample's tokens and labels


### PR DESCRIPTION
## Summary
- avoid dumping full packed sample tensors when a packed multimodal sample exceeds seq_length
- cover both the base multimodal packed encoder and the InternVL packed encoder overflow paths
- replace 5000+ line tensor-heavy ValueError logs with compact metadata: sample key, total length, cumulative length, tensor shapes, and media counts
- keep the error actionable for locating the offending packed sample without overwhelming distributed training logs

## Example
Before, the exception appended the full samples list and expanded tensors over thousands of lines. After this change, the message is compact, for example:

\\\	ext
Packed sample exceeds the maximum sequence length of 16384: current_length=15980, next_sample_key=pretrain-000031.tar/ps_00003613.q000, next_sample_len=721, would_be_length=16701, num_samples=5, samples_summary=[{'key': 'pretrain-000031.tar/ps_00003610.q000', 'total_len': 3821, 'cumulative_len': 3821, 'tokens_shape': (3821,), 'labels_shape': (3821,), 'attn_mask_shape': (3821,), 'num_images': 1, 'num_videos': 0}, {'key': 'pretrain-000031.tar/ps_00003611.q000', 'total_len': 4012, 'cumulative_len': 7833, 'tokens_shape': (4012,), 'labels_shape': (4012,), 'attn_mask_shape': (4012,), 'num_images': 1, 'num_videos': 0}, ...]
\\\`n
## Testing
- syntax checked with Python compile()