### PR TITLE
[data] feat: Align PackedMultiMixQASample with multi-turn semantics

### DIFF
--- a/loongforge/data/multimodal/base/task_encoder.py
+++ b/loongforge/data/multimodal/base/task_encoder.py
@@ -448,13 +448,18 @@ def cooker_packed_multi_mix_qa(sample: dict):
             f"{len(captions)} vs {len(prompts)}"
         )
 
-    # answers: List[List[str]]
+    # contexts/answers are List[List[str]]. A single-turn child is a
+    # one-element list; multi-turn BMR children keep all turns.
+    contexts = [
+        [p] if isinstance(p, str)
+        else (list(p) if isinstance(p, (list, tuple)) else [])
+        for p in prompts
+    ]
     answers = [
         [c] if isinstance(c, str)
         else (list(c) if isinstance(c, (list, tuple)) else [])
         for c in captions
     ]
-
     media_files = data.get("media_files", []) or []
     media_type = (data.get("media_type") or "").lower()
 
@@ -515,7 +520,7 @@ def cooker_packed_multi_mix_qa(sample: dict):
             __subflavors__=sample.get("__subflavors__", {}),
             images=images,
             videos=videos,
-            contexts=prompts,
+            contexts=contexts,
             answers=answers,
             answer_weights=None,
         )
@@ -526,7 +531,7 @@ def cooker_packed_multi_mix_qa(sample: dict):
             __subflavors__=sample.get("__subflavors__", {}),
             images=images,
             videos=videos,
-            contexts=prompts,
+            contexts=contexts,
             answers=answers,
             answer_weights=None,
         )

--- a/loongforge/data/multimodal/flavors/packed_multi_mix_qa.py
+++ b/loongforge/data/multimodal/flavors/packed_multi_mix_qa.py
@@ -31,5 +31,5 @@ class PackedMultiMixQASample(Sample):
     images: Optional[List[List[torch.Tensor]]]
     videos: Optional[List[list[AVData]]]
     contexts: List[List[str]]
-    answers: Optional[List[List[str]]] = None
+    answers: List[List[str]]
     answer_weights: Optional[List[torch.Tensor]] = None

--- a/loongforge/data/multimodal/flavors/packed_multi_mix_qa.py
+++ b/loongforge/data/multimodal/flavors/packed_multi_mix_qa.py
@@ -1,7 +1,7 @@
 # Copyright 2026 The LoongForge Authors.
 # SPDX-License-Identifier: Apache-2.0
 
-"""MultiMixQASample"""
+"""PackedMultiMixQASample"""
 
 from dataclasses import dataclass
 from typing import List, Optional
@@ -16,10 +16,20 @@ import torch
 
 @dataclass
 class PackedMultiMixQASample(Sample):
-    """Sample type for packed multi mix qa."""
+    """Packed list of full MultiMixQA child samples.
+
+    Each child sample is represented column-wise:
+    - contexts[i]: user turns of child i
+    - answers[i]: assistant turns of child i
+    - images[i] / videos[i]: media group of child i
+
+    A single-turn QA is represented as one-element lists, for example:
+    contexts[i] = ["<image>\nquestion"]
+    answers[i] = ["answer"]
+    """
 
     images: Optional[List[List[torch.Tensor]]]
     videos: Optional[List[list[AVData]]]
-    contexts: List[str]
+    contexts: List[List[str]]
     answers: Optional[List[List[str]]] = None
     answer_weights: Optional[List[torch.Tensor]] = None

--- a/loongforge/data/multimodal/vlm_task_encoder.py
+++ b/loongforge/data/multimodal/vlm_task_encoder.py
@@ -640,20 +640,35 @@ class VLMTaskEncoder(BaseTaskEncoder):
                 f"!= context count ({n_orig_sample}) for key={sample.__key__}"
             )
         for idx in range(n_orig_sample):
-            context = sample.contexts[idx]  # str
+            contexts = sample.contexts[idx]
             media_group = None if has_text_only else media_list[idx]  # List[Tensor] or List[AVData]
-            answer_group = sample.answers[idx] if sample.answers else []  # List[str]
+            answers = sample.answers[idx]
 
-            if isinstance(answer_group, list):
-                answer = "\n\n".join(answer_group) if answer_group else ""
-            else:
-                answer = answer_group or ""
+            if not isinstance(contexts, (list, tuple)):
+                raise TypeError(
+                    f"encode_packed_multi_mix_qa expects contexts[{idx}] to be List[str], "
+                    f"got {type(contexts).__name__} for key={sample.__key__}"
+                )
+            if not isinstance(answers, (list, tuple)):
+                raise TypeError(
+                    f"encode_packed_multi_mix_qa expects answers[{idx}] to be List[str], "
+                    f"got {type(answers).__name__} for key={sample.__key__}"
+                )
+
+            contexts = list(contexts)
+            answers = list(answers)
+            if len(contexts) != len(answers):
+                raise ValueError(
+                    f"encode_packed_multi_mix_qa: context/answer turn count mismatch "
+                    f"for key={sample.__key__}.q{idx:03d}: "
+                    f"{len(contexts)} vs {len(answers)}"
+                )
 
             system = None
-            messages = [
-                {"role": "user", "content": context},
-                {"role": "assistant", "content": answer},
-            ]
+            messages = []
+            for context, answer in zip(contexts, answers):
+                messages.append({"role": "user", "content": context})
+                messages.append({"role": "assistant", "content": answer})
             if has_images:
                 init_kwargs = {
                     "__key__": f"{sample.__key__}.q{idx:03d}",


### PR DESCRIPTION
## Summary
- treat PackedMultiMixQASample as packed full MultiMixQA child samples
- represent each packed child with aligned context/answer turn lists
- build multi-turn messages directly in encode_packed_multi_mix_qa instead of collapsing answers into one string
- normalize built-in packed multi-mix cooker outputs to List[List[str]] for both single-turn and multi-turn data
- handle media presence per child, allowing image/video packed samples to include text-only children with empty media groups

## Why
The previous PackedMultiMixQASample path effectively treated each packed child as a single user/assistant pair. This loses multi-turn semantics for BMR-style packed SFT data where each child sample can contain multiple aligned context/answer turns.

In addition, media type was previously inferred at the whole packed-sample level. If the packed sample had an images list, every child was treated as an image sample, even when a specific child had an empty image group. The updated logic validates packed-level alignment but decides image/video/text handling per child.

## Behavior
- image child: images[i] is non-empty, video is None
- video child: videos[i] is non-empty, image is None
- text-only child: media group is empty, image and video are None
- the packed artifact still cannot mix image and video media columns in the same packed sample

## Testing
- syntax checked with Python compile()
- not run: full distributed multimodal dataloader/training test is unavailable in this local environment