### PR TITLE
[vla] feat: support all SimplerEnv WidowX tasks and update GR00T-N1.6 inference

### DIFF
--- a/examples/embodied/groot_n1_6/eval/configs/libero/libero_10.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/libero/libero_10.yaml
@@ -1,0 +1,61 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x LIBERO libero_10 task-success -- internal one-click.
+#
+# Full suite (max_tasks: 0 = all 10 tasks) x 10 episodes/task = 100 episodes.
+# max_steps mirrors SUITE_MAX_STEPS in loongforge/embodied/eval/adapters/libero.py
+# (libero_10 = 520); a smaller value would judge in-progress episodes as failures.
+#
+
+benchmark:
+  name: libero
+  suite: libero_10
+  max_tasks: 0              # 0 = all tasks in the suite
+  episodes_per_task: 10
+  max_steps: 520
+  num_steps_wait: 10
+  continuous_gripper: false
+  control_mode: delta        # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: libero_ee_euler
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13511
+  health_port: 13512
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/libero/libero_10/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-LIBERO
+  dataset_statistics_path: /path/to/GR00T-N1.6-LIBERO/experiment_cfg/dataset_statistics.json
+  embodiment_tag: libero_panda
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/libero/libero_10
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/libero/libero_goal.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/libero/libero_goal.yaml
@@ -1,0 +1,61 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x LIBERO libero_goal task-success -- internal one-click.
+#
+# Full suite (max_tasks: 0 = all 10 tasks) x 10 episodes/task = 100 episodes.
+# max_steps mirrors SUITE_MAX_STEPS in loongforge/embodied/eval/adapters/libero.py
+# (libero_goal = 300); a smaller value would judge in-progress episodes as failures.
+#
+
+benchmark:
+  name: libero
+  suite: libero_goal
+  max_tasks: 0              # 0 = all tasks in the suite
+  episodes_per_task: 10
+  max_steps: 300
+  num_steps_wait: 10
+  continuous_gripper: false
+  control_mode: delta        # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: libero_ee_euler
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13501
+  health_port: 13502
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/libero/libero_goal/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-LIBERO
+  dataset_statistics_path: /path/to/GR00T-N1.6-LIBERO/experiment_cfg/dataset_statistics.json
+  embodiment_tag: libero_panda
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/libero/libero_goal
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/libero/libero_object.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/libero/libero_object.yaml
@@ -1,0 +1,61 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x LIBERO libero_object task-success -- internal one-click.
+#
+# Full suite (max_tasks: 0 = all 10 tasks) x 10 episodes/task = 100 episodes.
+# max_steps mirrors SUITE_MAX_STEPS in loongforge/embodied/eval/adapters/libero.py
+# (libero_object = 280); a smaller value would judge in-progress episodes as failures.
+#
+
+benchmark:
+  name: libero
+  suite: libero_object
+  max_tasks: 0              # 0 = all tasks in the suite
+  episodes_per_task: 10
+  max_steps: 280
+  num_steps_wait: 10
+  continuous_gripper: false
+  control_mode: delta        # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: libero_ee_euler
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13481
+  health_port: 13482
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/libero/libero_object/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-LIBERO
+  dataset_statistics_path: /path/to/GR00T-N1.6-LIBERO/experiment_cfg/dataset_statistics.json
+  embodiment_tag: libero_panda
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/libero/libero_object
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/libero/libero_spatial.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/libero/libero_spatial.yaml
@@ -1,0 +1,61 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x LIBERO libero_spatial task-success -- internal one-click.
+#
+# Full suite (max_tasks: 0 = all 10 tasks) x 10 episodes/task = 100 episodes.
+# max_steps mirrors SUITE_MAX_STEPS in loongforge/embodied/eval/adapters/libero.py
+# (libero_spatial = 220); a smaller value would judge in-progress episodes as failures.
+#
+
+benchmark:
+  name: libero
+  suite: libero_spatial
+  max_tasks: 0              # 0 = all tasks in the suite
+  episodes_per_task: 10
+  max_steps: 220
+  num_steps_wait: 10
+  continuous_gripper: false
+  control_mode: delta        # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: libero_ee_euler
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13491
+  health_port: 13492
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/libero/libero_spatial/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-LIBERO
+  dataset_statistics_path: /path/to/GR00T-N1.6-LIBERO/experiment_cfg/dataset_statistics.json
+  embodiment_tag: libero_panda
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/libero/libero_spatial
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
@@ -1,0 +1,81 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_carrot_on_plate
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13431
+  health_port: 13432
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_carrot_on_plate/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_carrot_on_plate
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9 and 20-39 (30 episodes total), each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_close_drawer.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_close_drawer.yaml
@@ -1,0 +1,82 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+# WidowX small-drawer tasks run at control_freq 3 (official bridge drawer setup).
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_close_drawer
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 3
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13471
+  health_port: 13472
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_close_drawer/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_close_drawer
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9, each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_open_drawer.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_open_drawer.yaml
@@ -1,0 +1,82 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+# WidowX small-drawer tasks run at control_freq 3 (official bridge drawer setup).
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_open_drawer
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 3
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13461
+  health_port: 13462
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_open_drawer/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_open_drawer
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9, each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
@@ -1,0 +1,81 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_put_eggplant_in_basket
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13451
+  health_port: 13452
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_put_eggplant_in_basket/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_put_eggplant_in_basket
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9, each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
@@ -1,0 +1,81 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_spoon_on_towel
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13421
+  health_port: 13422
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_spoon_on_towel/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_spoon_on_towel
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9, each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube.yaml
@@ -1,0 +1,81 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+# GR00T-N1.6 x SimplerEnv WidowX (Bridge) task-success -- internal one-click.
+#
+# Official protocol, mirrored from Isaac-GR00T:
+#   gr00t/eval/rollout_policy.py            --max_episode_steps=300 --n_action_steps 4
+#   gr00t/eval/sim/wrapper/multistep_wrapper.py   max_episode_steps counts INNER env steps,
+#                                                 terminate_on_success=True
+#   external_dependencies/SimplerEnv/simpler_env/__init__.py:83
+#                                           simpler_env.make() forces prepackaged_config=True
+# => prepackaged_config: true  +  max_steps: 300  +  chunk_execute_steps: 4.
+#
+# With prepackaged_config the env owns scene / rgb_overlay / robot init and randomizes
+# per episode from its own episode_rng, which is seeded by `run.seed + run.episode_idx`.
+# So the episode variable is `run.episode_idx` (swept below), NOT `run.obj_episode_id`.
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_stack_cube
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d6
+  base_model_path: /path/to/eagle3-processor-groot-n1d6
+  model_name: /path/to/eagle3-processor-groot-n1d6
+  vlm_tokenizer_path: /path/to/eagle3-processor-groot-n1d6
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13441
+  health_port: 13442
+  python: /path/to/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_6/simplerenv/widowx_stack_cube/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.6-bridge
+  dataset_statistics_path: /path/to/GR00T-N1.6-bridge/statistics.json
+  embodiment_tag: oxe_widowx
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+  chunk_execute_steps: 4
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_6/simplerenv/widowx_stack_cube
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: true
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation: `run.episode_idx`
+# below selects it and also seeds the env (reset seed = run.seed + run.episode_idx),
+# which is what varies the object layout under prepackaged_config.
+# The reported success rate was collected by invoking this config once per
+# episode_idx over 0-9, each run with its own run.output_dir.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/pi05/eval/configs/maniskill/pick_cube_smoke.yaml
+++ b/examples/embodied/pi05/eval/configs/maniskill/pick_cube_smoke.yaml
@@ -30,6 +30,7 @@ model:
   state_encoding: passthrough   # ManiSkill 8D Panda qpos from state_raw.joint (needs dataset_statistics_path with observation.state for real weights)
   action_dim: 7
   state_dim: 8   # ManiSkill 8D Panda qpos (7 arm joints + 1 finger mean), matches state_encoding: passthrough
+  state_encoding: passthrough
   action_horizon: 50
   max_action_dim: 32
   max_state_dim: 32

--- a/loongforge/embodied/eval/payload_builders/groot_n1_6.py
+++ b/loongforge/embodied/eval/payload_builders/groot_n1_6.py
@@ -19,6 +19,7 @@ the LIBERO adapter's ``action_from_canonical`` consumes as a flat 7D array.
 
 from __future__ import annotations
 
+import logging
 from typing import Any, Dict, Optional
 
 import numpy as np
@@ -26,6 +27,43 @@ import numpy as np
 from loongforge.embodied.eval.payload_builders.base import PayloadBuilder
 from loongforge.embodied.eval.payload_builders.pi05 import _pack_images
 from loongforge.embodied.eval.payload_builders.registry import register_payload_builder
+
+logger = logging.getLogger(__name__)
+
+# WidowX finger joint limits (fixed by the ManiSkill2_real2sim WidowX URDF),
+# used to reproduce ``WidowX.get_gripper_closedness()`` without SAPIEN access.
+# The official agent reads these from ``robot.get_qlimits()`` at runtime; here they
+# are constants, so a URDF change would silently rescale the whole gripper channel.
+# ``_warn_finger_qpos_out_of_limits`` makes that desync loud instead.
+WIDOWX_FINGER_QMIN = 0.015
+WIDOWX_FINGER_QMAX = 0.037
+
+_finger_qpos_warned = False
+
+
+def _warn_finger_qpos_out_of_limits(finger_qpos: np.ndarray) -> None:
+    """Warn once if finger qpos leaves the hardcoded ``[QMIN, QMAX]`` window.
+
+    A small excursion is normal (contact / solver overshoot); a persistent or
+    large one means ``WIDOWX_FINGER_QMIN/QMAX`` no longer match the loaded URDF,
+    which would silently mis-scale the gripper proprio channel.
+    """
+    global _finger_qpos_warned
+    if _finger_qpos_warned:
+        return
+    span = WIDOWX_FINGER_QMAX - WIDOWX_FINGER_QMIN
+    lo = WIDOWX_FINGER_QMIN - 0.1 * span
+    hi = WIDOWX_FINGER_QMAX + 0.1 * span
+    if np.any(finger_qpos < lo) or np.any(finger_qpos > hi):
+        _finger_qpos_warned = True
+        logger.warning(
+            "WidowX finger qpos %s outside hardcoded limits [%.4f, %.4f]; "
+            "check WIDOWX_FINGER_QMIN/QMAX against the loaded URDF "
+            "(gripper proprio would be mis-scaled). Warning shown once.",
+            np.asarray(finger_qpos).tolist(),
+            WIDOWX_FINGER_QMIN,
+            WIDOWX_FINGER_QMAX,
+        )
 
 
 def _encode_libero_ee_euler(state_raw: Dict[str, Any]) -> Optional[np.ndarray]:
@@ -98,14 +136,19 @@ def _encode_simpler_widowx(state_raw: Dict[str, Any]) -> Optional[np.ndarray]:
     except Exception:
         return None
 
-    # Gripper openness proxy from the two WidowX finger qpos (proprio hint only;
-    # bridge was trained with state_dropout_prob 0.8, so this is low-impact).
+    # Gripper openness, matching the official GR00T WidowX wrapper, which reads
+    # ``agent.eef_pos[7] = 1 - get_gripper_closedness()`` (a normalized openness
+    # in [0, 1]; 1.0 = fully open). Upstream ManiSkill2_real2sim does not expose
+    # ``eef_pos``, so reproduce ``WidowX.get_gripper_closedness()`` here from the
+    # two finger qpos against their (fixed) joint limits.
     joint = state_raw.get("joint")
-    grip = 0.05
+    grip = 1.0
     if joint is not None:
-        j = np.asarray(joint, dtype=np.float32).reshape(-1)
+        j = np.asarray(joint, dtype=np.float64).reshape(-1)
         if j.size >= 2:
-            grip = float(np.clip(j[-2:].sum(), 0.046, 1.112))
+            _warn_finger_qpos_out_of_limits(j[-2:])
+            closedness = np.mean((WIDOWX_FINGER_QMAX - j[-2:]) / (WIDOWX_FINGER_QMAX - WIDOWX_FINGER_QMIN))
+            grip = float(1.0 - max(closedness, 0.0))
     return np.array(
         [pos[0], pos[1], pos[2], rpy[0], rpy[1], rpy[2], 0.0, grip],
         dtype=np.float32,
@@ -142,7 +185,10 @@ class GrootN1d6PayloadBuilder(PayloadBuilder):
         """Return the kwargs consumed by ``GrootN1d6Policy.predict_action``."""
         images = _pack_images(canonical["images"])
         if self.state_encoding == "simpler_widowx":
-            # Official WidowXBridgeEnv resizes the view to 256x256 before the model.
+            # Official WidowXBridgeEnv resizes the view to 256x256 before the
+            # model. The remaining letterbox-pad + 95%-center-crop step (matching
+            # Gr00tN1d6Processor.eval_image_transform) is applied inside
+            # GrootN1d6Policy.predict_action, not here — see modeling_groot_n1_6.py.
             import cv2
 
             images = [

--- a/loongforge/embodied/model/groot_n1_6/modeling_groot_n1_6.py
+++ b/loongforge/embodied/model/groot_n1_6/modeling_groot_n1_6.py
@@ -48,6 +48,10 @@ from loongforge.embodied.data.datasets.groot_n1_6.transforms.utils import (
 )
 from loongforge.embodied.model.registry import register_model
 
+from loongforge.embodied.data.datasets.groot_n1_6.transforms.eagle3_model.image_augmentations import (
+    build_image_transformations_albumentations,
+)
+
 from .eagle3_model import EagleBackbone
 from .model_configuration_groot_n1_6 import GrootN1d6ModelConfig
 from .modules.dit import AlternateVLDiT, DiT
@@ -994,6 +998,20 @@ class GrootN1d6Policy(nn.Module):
             model_type=self.config.backbone_model_type,
             transformers_loading_kwargs={"trust_remote_code": True, "local_files_only": True},
         )
+        # Official Gr00tN1d6Processor.eval_image_transform: letterbox-pad to
+        # square -> SmallestMaxSize(shortest_image_edge, INTER_AREA) ->
+        # crop_fraction-center-crop -> SmallestMaxSize. predict_action() applies
+        # this before building vlm_content so callers only need to supply the
+        # env's native camera image (matching Gr00tPolicy.get_action, where the
+        # processor performs this step internally).
+        _, self._predict_action_eval_image_transform = build_image_transformations_albumentations(
+            None,  # image_target_size
+            None,  # image_crop_size
+            None,  # random_rotation_angle
+            None,  # color_jitter_params
+            256,  # shortest_image_edge
+            0.95,  # crop_fraction
+        )
         self._predict_action_initialized = True
         self.eval()
 
@@ -1007,6 +1025,7 @@ class GrootN1d6Policy(nn.Module):
     ) -> np.ndarray:
         """Infer an action chunk for the shared eval ``predict_action`` interface."""
         image_batch = self._normalize_image_batch(images, instructions)
+        image_batch = self._apply_eval_image_transform(image_batch)
         batch_size = len(image_batch)
         instruction_batch = self._normalize_instruction_batch(instructions, batch_size)
         processor = self._get_predict_action_processor(dataset_stats)
@@ -1262,6 +1281,24 @@ class GrootN1d6Policy(nn.Module):
             raise TypeError(f"Unsupported GR00T-N1.6 images type: {type(images).__name__}")
 
         return [[_to_pil_image(image) for image in sample] for sample in samples]
+
+    def _apply_eval_image_transform(
+        self, image_batch: list[list[Image.Image]]
+    ) -> list[list[Image.Image]]:
+        """Apply the official ``Gr00tN1d6Processor.eval_image_transform`` (deterministic
+        letterbox-pad + center-crop) so callers only need to supply the env's native
+        camera image, matching ``Gr00tPolicy.get_action`` where the processor performs
+        this step internally."""
+        transform = getattr(self, "_predict_action_eval_image_transform", None)
+        if transform is None:
+            return image_batch
+        return [
+            [
+                Image.fromarray(transform(image=np.asarray(image.convert("RGB")))["image"])
+                for image in sample
+            ]
+            for sample in image_batch
+        ]
 
     @staticmethod
     def _normalize_instruction_batch(instructions: Any, batch_size: int) -> list[str]:


### PR DESCRIPTION
## Summary
- Add GR00T-N1.6 configs for all SimplerEnv WidowX tasks and LIBERO suites
- Update GR00T-N1.6 payload builder and inference interface

## Changes
- New configs: `libero_10/goal/object/spatial`, `widowx_{carrot_on_plate,close_drawer,open_drawer,put_eggplant_in_basket,spoon_on_towel,stack_cube}`
- Update `loongforge/embodied/eval/payload_builders/groot_n1_6.py`
- Update `loongforge/embodied/model/groot_n1_6/modeling_groot_n1_6.py`
- Minor update to `examples/embodied/pi05/eval/configs/maniskill/pick_cube_smoke.yaml`

## Test Plan
- Cherry-picked and rebuilt on top of latest upstream master; verified clean apply