### PR TITLE
[vla] perf: fuse DiT RoPE and MoT LayerNorm modulation

### DIFF
--- a/loongforge/embodied/model/fastwam/action/dit.py
+++ b/loongforge/embodied/model/fastwam/action/dit.py
@@ -28,6 +28,7 @@ from loongforge.embodied.model.fastwam.utils.state_dict import EXTRA_STATE_SUFFI
 from loongforge.embodied.model.fastwam.wan.dit import (
     DiTBlock,
     precompute_freqs_cis,
+    prepare_rope_freqs,
     sinusoidal_embedding_1d,
 )
 
@@ -329,6 +330,7 @@ class ActionDiT(nn.Module):
         context_emb = self.text_embedding(context)
         context_attn_mask = context_mask.unsqueeze(1).expand(-1, seq_len, -1)
         freqs = self.freqs[:seq_len].view(seq_len, 1, -1).to(tokens.device)
+        freqs = prepare_rope_freqs(freqs)
 
         return {
             "tokens": tokens,

--- a/loongforge/embodied/model/fastwam/mot/idm.py
+++ b/loongforge/embodied/model/fastwam/mot/idm.py
@@ -164,7 +164,10 @@ class FastWAMIDM(FastWAMJoint):
 
         # Concatenate [noisy_video, cond_video] as the video expert sequence.
         merged_video_tokens = torch.cat([video_pre_noisy["tokens"], video_pre_cond["tokens"]], dim=1)
-        merged_video_freqs = torch.cat([video_pre_noisy["freqs"], video_pre_cond["freqs"]], dim=0)
+        merged_video_freqs = tuple(
+            torch.cat([noisy_freq, cond_freq], dim=0)
+            for noisy_freq, cond_freq in zip(video_pre_noisy["freqs"], video_pre_cond["freqs"])
+        )
         merged_video_t_mod = torch.cat([video_pre_noisy["t_mod"], video_pre_cond["t_mod"]], dim=1)
         merged_video_context_mask = torch.cat(
             [video_pre_noisy["context_mask"], video_pre_cond["context_mask"]],

--- a/loongforge/embodied/model/fastwam/mot/model.py
+++ b/loongforge/embodied/model/fastwam/mot/model.py
@@ -18,14 +18,39 @@
 from __future__ import annotations
 
 import logging
-from typing import Dict, Optional
+from typing import Dict, Optional, Tuple
 
 import torch
 import torch.nn as nn
 
-from loongforge.embodied.model.fastwam.wan.dit import flash_attention, modulate, rope_apply
+from loongforge.embodied.model.fastwam.utils.norm_modulate import triton_norm_modulate
+from loongforge.embodied.model.fastwam.wan.dit import flash_attention, rope_apply
 
 logger = logging.getLogger(__name__)
+
+
+def _norm_modulate(norm: nn.LayerNorm, x: torch.Tensor, shift: torch.Tensor, scale: torch.Tensor):
+    """Fuse affine-free LayerNorm with timestep scale/shift modulation.
+
+    `_split_modulation` always yields dim-3 modulation: [B, 1, D] for per-block
+    timesteps and [B, S, D] for per-token timesteps.
+
+    Args:
+        norm: Affine-free `nn.LayerNorm` whose epsilon drives the fused kernel.
+        x: Hidden states, shape [B, S, D].
+        shift: Modulation shift, shape [B, 1, D] or [B, S, D].
+        scale: Modulation scale, shape [B, 1, D] or [B, S, D].
+
+    Returns:
+        Normalized and modulated hidden states, shape [B, S, D].
+    """
+    # expand_as is a zero-copy view; stride 0 over sequence broadcasts modulation.
+    return triton_norm_modulate(
+        x,
+        scale.expand_as(x),
+        shift.expand_as(x),
+        float(norm.eps),
+    )
 
 
 class MoT(nn.Module):
@@ -143,7 +168,7 @@ class MoT(nn.Module):
                     context_mask = context_mask.unsqueeze(1)
                 x = x + block.cross_attn(block.norm3(x), context, ctx_mask=context_mask)
 
-        mlp_input = modulate(block.norm2(x), shift_mlp, scale_mlp)
+        mlp_input = _norm_modulate(block.norm2, x, shift_mlp, scale_mlp)
         x = block.gate(x, gate_mlp, block.ffn(mlp_input))
         return x
 
@@ -152,7 +177,7 @@ class MoT(nn.Module):
         expert,
         block,
         x: torch.Tensor,
-        freqs: torch.Tensor,
+        freqs: Tuple[torch.Tensor, torch.Tensor],
         t_mod: torch.Tensor,
     ) -> tuple[
         torch.Tensor,
@@ -172,7 +197,7 @@ class MoT(nn.Module):
                 `use_gradient_checkpointing`.
             block: Transformer block for current layer (`expert.blocks[layer_idx]`).
             x: Current expert tokens, shape [B, S, D].
-            freqs: RoPE frequencies aligned with token sequence, shape [S, 1, rope_dim].
+            freqs: RoPE `(cos, sin)` tables aligned with token sequence, each [S, rope_dim // 2].
             t_mod: Time modulation tensor for this expert/layer.
 
         Returns:
@@ -187,7 +212,7 @@ class MoT(nn.Module):
             use_gradient_checkpointing: Whether this expert enables checkpointing.
         """
         shift_msa, scale_msa, gate_msa, shift_mlp, scale_mlp, gate_mlp = self._split_modulation(block, t_mod)
-        attn_input = modulate(block.norm1(x), shift_msa, scale_msa)
+        attn_input = _norm_modulate(block.norm1, x, shift_msa, scale_msa)
 
         q = block.self_attn.norm_q(block.self_attn.q(attn_input))
         k = block.self_attn.norm_k(block.self_attn.k(attn_input))
@@ -284,7 +309,7 @@ class MoT(nn.Module):
     def prefill_video_cache(
         self,
         video_tokens: torch.Tensor,
-        video_freqs: torch.Tensor,
+        video_freqs: Tuple[torch.Tensor, torch.Tensor],
         video_t_mod: torch.Tensor,
         video_context_payload: Optional[dict],
         video_attention_mask: torch.Tensor,
@@ -293,7 +318,7 @@ class MoT(nn.Module):
 
         Args:
             video_tokens: Video tokens before layer 0, shape [B, Sv, D].
-            video_freqs: Video RoPE frequencies, shape [Sv, 1, rope_dim].
+            video_freqs: Video RoPE `(cos, sin)` tables, each [Sv, rope_dim // 2].
             video_t_mod: Video time modulation tensor.
             video_context_payload: Optional dict for video cross-attention.
                 - `context`: encoder states [B, L, D]
@@ -370,7 +395,7 @@ class MoT(nn.Module):
     def forward_action_with_video_cache(
         self,
         action_tokens: torch.Tensor,
-        action_freqs: torch.Tensor,
+        action_freqs: Tuple[torch.Tensor, torch.Tensor],
         action_t_mod: torch.Tensor,
         action_context_payload: Optional[dict],
         video_kv_cache: list[dict[str, torch.Tensor]],
@@ -381,7 +406,7 @@ class MoT(nn.Module):
 
         Args:
             action_tokens: Action tokens before layer 0, shape [B, Sa, D].
-            action_freqs: Action RoPE frequencies, shape [Sa, 1, rope_dim].
+            action_freqs: Action RoPE `(cos, sin)` tables, each [Sa, rope_dim // 2].
             action_t_mod: Action time modulation tensor.
             action_context_payload: Optional dict for action cross-attention.
                 - `context`: encoder states [B, L, D]
@@ -475,7 +500,7 @@ class MoT(nn.Module):
         self,
         embeds_all: Dict[str, torch.Tensor],
         attention_mask: torch.Tensor,
-        freqs_all: Dict[str, torch.Tensor],
+        freqs_all: Dict[str, Tuple[torch.Tensor, torch.Tensor]],
         context_all: Dict[str, Optional[dict]],
         t_mod_all: Dict[str, torch.Tensor],
     ):

--- a/loongforge/embodied/model/fastwam/utils/norm_modulate.py
+++ b/loongforge/embodied/model/fastwam/utils/norm_modulate.py
@@ -1,0 +1,300 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Adapted from loongforge/embodied/model/dreamzero/modules/block_norm_modulate_triton.py.
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Fused affine-free LayerNorm + timestep modulation Triton kernels for FastWAM."""
+
+from __future__ import annotations
+
+import torch
+import torch.nn.functional as F
+import triton
+import triton.language as tl
+
+
+def _eager_norm_modulate(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float,
+) -> torch.Tensor:
+    """Reference affine-free LayerNorm followed by scale/shift modulation."""
+    normed = F.layer_norm(x, (x.shape[-1],), None, None, eps)
+    return normed * (1 + scale) + shift
+
+
+def _next_power_of_2(value: int) -> int:
+    """Round ``value`` up to the next power of two for the Triton column block."""
+    return 1 << (int(value) - 1).bit_length()
+
+
+@triton.jit
+def _norm_modulate_fwd_kernel(
+    x_ptr,
+    scale_ptr,
+    shift_ptr,
+    out_ptr,
+    mean_ptr,
+    rstd_ptr,
+    scale_stride_b: tl.constexpr,
+    scale_stride_l: tl.constexpr,
+    scale_stride_d: tl.constexpr,
+    shift_stride_b: tl.constexpr,
+    shift_stride_l: tl.constexpr,
+    shift_stride_d: tl.constexpr,
+    seq_len: tl.constexpr,
+    n_cols: tl.constexpr,
+    eps: tl.constexpr,
+    block: tl.constexpr,
+):
+    """Normalize one row of ``x`` and apply its scale/shift in a single pass."""
+    row = tl.program_id(0)
+    batch_idx = row // seq_len
+    seq_idx = row - batch_idx * seq_len
+    offsets = tl.arange(0, block)
+    mask = offsets < n_cols
+    base = row * n_cols + offsets
+    scale_base = (
+        batch_idx * scale_stride_b
+        + seq_idx * scale_stride_l
+        + offsets * scale_stride_d
+    )
+    shift_base = (
+        batch_idx * shift_stride_b
+        + seq_idx * shift_stride_l
+        + offsets * shift_stride_d
+    )
+
+    x = tl.load(x_ptr + base, mask=mask, other=0.0).to(tl.float32)
+    scale = tl.load(scale_ptr + scale_base, mask=mask, other=0.0).to(tl.float32)
+    shift = tl.load(shift_ptr + shift_base, mask=mask, other=0.0).to(tl.float32)
+
+    mean = tl.sum(x, axis=0) / n_cols
+    centered = tl.where(mask, x - mean, 0.0)
+    var = tl.sum(centered * centered, axis=0) / n_cols
+    rstd = tl.rsqrt(var + eps)
+    normed = centered * rstd
+    out = normed * (1.0 + scale) + shift
+
+    tl.store(out_ptr + base, out, mask=mask)
+    tl.store(mean_ptr + row, mean)
+    tl.store(rstd_ptr + row, rstd)
+
+
+@triton.jit
+def _norm_modulate_bwd_kernel(
+    grad_ptr,
+    x_ptr,
+    scale_ptr,
+    mean_ptr,
+    rstd_ptr,
+    grad_x_ptr,
+    grad_scale_ptr,
+    grad_shift_ptr,
+    scale_stride_b: tl.constexpr,
+    scale_stride_l: tl.constexpr,
+    scale_stride_d: tl.constexpr,
+    grad_scale_stride_b: tl.constexpr,
+    grad_scale_stride_l: tl.constexpr,
+    grad_scale_stride_d: tl.constexpr,
+    grad_shift_stride_b: tl.constexpr,
+    grad_shift_stride_l: tl.constexpr,
+    grad_shift_stride_d: tl.constexpr,
+    seq_len: tl.constexpr,
+    n_cols: tl.constexpr,
+    block: tl.constexpr,
+):
+    """Backpropagate one row through the fused LayerNorm + modulation."""
+    row = tl.program_id(0)
+    batch_idx = row // seq_len
+    seq_idx = row - batch_idx * seq_len
+    offsets = tl.arange(0, block)
+    mask = offsets < n_cols
+    base = row * n_cols + offsets
+    scale_base = (
+        batch_idx * scale_stride_b
+        + seq_idx * scale_stride_l
+        + offsets * scale_stride_d
+    )
+    grad_scale_base = (
+        batch_idx * grad_scale_stride_b
+        + seq_idx * grad_scale_stride_l
+        + offsets * grad_scale_stride_d
+    )
+    grad_shift_base = (
+        batch_idx * grad_shift_stride_b
+        + seq_idx * grad_shift_stride_l
+        + offsets * grad_shift_stride_d
+    )
+
+    grad = tl.load(grad_ptr + base, mask=mask, other=0.0).to(tl.float32)
+    x = tl.load(x_ptr + base, mask=mask, other=0.0).to(tl.float32)
+    scale = tl.load(scale_ptr + scale_base, mask=mask, other=0.0).to(tl.float32)
+    mean = tl.load(mean_ptr + row).to(tl.float32)
+    rstd = tl.load(rstd_ptr + row).to(tl.float32)
+
+    normed = (x - mean) * rstd
+    dnorm = tl.where(mask, grad * (1.0 + scale), 0.0)
+    normed = tl.where(mask, normed, 0.0)
+    sum_dnorm = tl.sum(dnorm, axis=0)
+    sum_dnorm_normed = tl.sum(dnorm * normed, axis=0)
+    grad_x = (dnorm - sum_dnorm / n_cols - normed * sum_dnorm_normed / n_cols) * rstd
+    grad_scale = grad * normed
+    grad_shift = grad
+
+    tl.store(grad_x_ptr + base, grad_x, mask=mask)
+    tl.store(grad_scale_ptr + grad_scale_base, grad_scale, mask=mask)
+    tl.store(grad_shift_ptr + grad_shift_base, grad_shift, mask=mask)
+
+
+def _can_use_triton(x: torch.Tensor, scale: torch.Tensor, shift: torch.Tensor) -> bool:
+    """Return whether the fused kernel supports this device/shape/dtype/layout combination."""
+    if not (x.is_cuda and scale.is_cuda and shift.is_cuda):
+        return False
+    if x.dim() != 3 or scale.dim() != 3 or shift.dim() != 3:
+        return False
+    if scale.shape != x.shape or shift.shape != x.shape:
+        return False
+    if x.dtype != scale.dtype or x.dtype != shift.dtype:
+        return False
+    if x.dtype not in {torch.bfloat16, torch.float16, torch.float32}:
+        return False
+    return x.is_contiguous() and scale.stride(-1) == 1 and shift.stride(-1) == 1
+
+
+class _TritonBlockNormModulate(torch.autograd.Function):
+    """Autograd wrapper around the fused LayerNorm + modulation kernels."""
+
+    @staticmethod
+    def forward(
+        ctx,
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        shift: torch.Tensor,
+        eps: float,
+        num_warps: int,
+    ) -> torch.Tensor:
+        """Run fused block normalization and modulation in the forward pass."""
+        if not _can_use_triton(x, scale, shift):
+            ctx.fallback = True
+            ctx.eps = float(eps)
+            ctx.save_for_backward(x, scale, shift)
+            return _eager_norm_modulate(x, scale, shift, eps)
+
+        ctx.fallback = False
+        dim = int(x.shape[-1])
+        seq_len = int(x.shape[-2])
+        rows = int(x.numel() // dim)
+        block = _next_power_of_2(dim)
+        out = torch.empty_like(x)
+        mean = torch.empty((rows,), device=x.device, dtype=torch.float32)
+        rstd = torch.empty((rows,), device=x.device, dtype=torch.float32)
+        _norm_modulate_fwd_kernel[(rows,)](
+            x,
+            scale,
+            shift,
+            out,
+            mean,
+            rstd,
+            int(scale.stride(0)),
+            int(scale.stride(1)),
+            int(scale.stride(2)),
+            int(shift.stride(0)),
+            int(shift.stride(1)),
+            int(shift.stride(2)),
+            seq_len,
+            dim,
+            float(eps),
+            block,
+            num_warps=num_warps,
+        )
+        ctx.save_for_backward(x, scale, mean, rstd)
+        ctx.dim = dim
+        ctx.seq_len = seq_len
+        ctx.block = block
+        ctx.num_warps = int(num_warps)
+        ctx.scale_stride = tuple(scale.stride())
+        return out
+
+    @staticmethod
+    def backward(ctx, grad_out: torch.Tensor):
+        """Compute gradients for fused block normalization and modulation."""
+        if ctx.fallback:
+            x, scale, shift = ctx.saved_tensors
+            with torch.enable_grad():
+                x_ref = x.detach().requires_grad_(ctx.needs_input_grad[0])
+                scale_ref = scale.detach().requires_grad_(ctx.needs_input_grad[1])
+                shift_ref = shift.detach().requires_grad_(ctx.needs_input_grad[2])
+                out_ref = _eager_norm_modulate(x_ref, scale_ref, shift_ref, ctx.eps)
+            grads = torch.autograd.grad(
+                out_ref,
+                (x_ref, scale_ref, shift_ref),
+                grad_out,
+                retain_graph=False,
+                allow_unused=True,
+            )
+            return grads[0], grads[1], grads[2], None, None
+
+        x, scale, mean, rstd = ctx.saved_tensors
+        grad = grad_out.contiguous() if grad_out.stride(-1) != 1 else grad_out
+        grad_x = torch.empty_like(x)
+        grad_scale = torch.empty_like(scale, memory_format=torch.contiguous_format)
+        grad_shift = torch.empty_like(grad, memory_format=torch.contiguous_format)
+        rows = int(x.numel() // int(ctx.dim))
+        _norm_modulate_bwd_kernel[(rows,)](
+            grad,
+            x,
+            scale,
+            mean,
+            rstd,
+            grad_x,
+            grad_scale,
+            grad_shift,
+            int(ctx.scale_stride[0]),
+            int(ctx.scale_stride[1]),
+            int(ctx.scale_stride[2]),
+            int(grad_scale.stride(0)),
+            int(grad_scale.stride(1)),
+            int(grad_scale.stride(2)),
+            int(grad_shift.stride(0)),
+            int(grad_shift.stride(1)),
+            int(grad_shift.stride(2)),
+            int(ctx.seq_len),
+            int(ctx.dim),
+            int(ctx.block),
+            num_warps=ctx.num_warps,
+        )
+        return grad_x, grad_scale, grad_shift, None, None
+
+
+def triton_norm_modulate(
+    x: torch.Tensor,
+    scale: torch.Tensor,
+    shift: torch.Tensor,
+    eps: float,
+    num_warps: int = 8,
+) -> torch.Tensor:
+    """Apply affine-free LayerNorm followed by scale and shift modulation.
+
+    Args:
+        x: Hidden states, shape [B, S, D].
+        scale: Modulation scale broadcast to `x`, shape [B, S, D].
+        shift: Modulation shift broadcast to `x`, shape [B, S, D].
+        eps: LayerNorm epsilon.
+        num_warps: Triton warps per row program.
+
+    Returns:
+        Normalized and modulated hidden states, shape [B, S, D].
+    """
+    return _TritonBlockNormModulate.apply(x, scale, shift, float(eps), int(num_warps))

--- a/loongforge/embodied/model/fastwam/wan/dit.py
+++ b/loongforge/embodied/model/fastwam/wan/dit.py
@@ -24,6 +24,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import transformer_engine.pytorch as te
 from einops import rearrange
+from flash_attn.ops.triton.rotary import apply_rotary
 
 from loongforge.embodied.model.fastwam.utils.gradient import gradient_checkpoint_forward
 
@@ -86,13 +87,62 @@ def precompute_freqs_cis(dim: int, end: int = 1024, theta: float = 10000.0):
     return freqs_cis
 
 
+class _TritonRoPE(torch.autograd.Function):
+    """Autograd wrapper around the FlashAttention Triton rotary kernel.
+
+    The interleaved rotary is a per-pair rotation, so the Jacobian w.r.t. ``x``
+    is the forward kernel evaluated with the rotation conjugated. ``cos``/``sin``
+    are position tables and do not receive gradients.
+    """
+
+    @staticmethod
+    def forward(ctx, x, cos, sin):
+        """Apply interleaved rotary embedding to ``x`` and save cos/sin for backward."""
+        ctx.save_for_backward(cos, sin)
+        return apply_rotary(x, cos, sin, interleaved=True)
+
+    @staticmethod
+    def backward(ctx, grad_output):
+        """Compute the gradient by applying the forward kernel with the rotation conjugated."""
+        cos, sin = ctx.saved_tensors
+        grad_x = apply_rotary(
+            grad_output.contiguous(),
+            cos,
+            sin,
+            interleaved=True,
+            conjugate=True,
+        )
+        return grad_x, None, None
+
+
+def prepare_rope_freqs(freqs: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor]:
+    """Convert complex RoPE frequencies to the contiguous cos/sin pair the kernel expects.
+
+    Args:
+        freqs: Complex RoPE frequencies, shape [S, 1, rope_dim // 2].
+
+    Returns:
+        Tuple of contiguous fp32 `(cos, sin)` tables, each shaped [S, rope_dim // 2].
+    """
+    if freqs.ndim != 3 or freqs.shape[1] != 1:
+        raise ValueError(f"Expected RoPE frequencies shaped [S, 1, D/2], got {tuple(freqs.shape)}")
+    return freqs[:, 0].real.float().contiguous(), freqs[:, 0].imag.float().contiguous()
+
+
 def rope_apply(x, freqs, num_heads):
-    """Apply RoPE frequencies to flattened multi-head hidden states."""
+    """Apply fused interleaved RoPE to flattened multi-head hidden states.
+
+    Args:
+        x: Flattened multi-head projections, shape [B, S, H*Dh].
+        freqs: `(cos, sin)` pair produced by `prepare_rope_freqs`.
+        num_heads: Number of attention heads packed in the last dimension of `x`.
+
+    Returns:
+        Rotated projections in the input layout and dtype, shape [B, S, H*Dh].
+    """
+    cos, sin = freqs
     x = rearrange(x, "b s (n d) -> b s n d", n=num_heads)
-    x_out = torch.view_as_complex(x.to(torch.float64).reshape(x.shape[0], x.shape[1], x.shape[2], -1, 2))
-    freqs = freqs.to(torch.complex64) if freqs.device.type == "npu" else freqs
-    x_out = torch.view_as_real(x_out * freqs).flatten(2)
-    return x_out.to(x.dtype)
+    return _TritonRoPE.apply(x, cos, sin).flatten(2)
 
 
 def create_group_causal_attn_mask(
@@ -792,6 +842,7 @@ class WanVideoDiT(torch.nn.Module):
             ],
             dim=-1,
         ).reshape(f * h * w, 1, -1).to(x_tokens.device)
+        freqs = prepare_rope_freqs(freqs)
 
         return {
             "tokens": x_tokens,


### PR DESCRIPTION
## Summary

Fuse two hot paths in FastWAM DiT / MoT to cut Python/PyTorch kernel launch overhead and expensive intermediate materialization during training:

1. **DiT RoPE** — replace the fp64 complex path (`view_as_complex` → complex multiply → `view_as_real`) with FlashAttention's interleaved Triton rotary kernel (`flash_attn.ops.triton.rotary.apply_rotary`).
2. **MoT LayerNorm + timestep modulate** — fuse affine-free `LayerNorm` with AdaLN-style scale/shift into a single Triton kernel (`triton_norm_modulate`), instead of separate `norm` then `modulate` launches.

These changes preserve the public training API and expert routing layout; only the internal RoPE frequency layout and the MoT pre-attention / pre-MLP norm+modulate path change.

Synced from internal commit `36f791719b47b7b604bf3ca151679ae483d02dac` (`aiak-train-2298`).

## Motivation

On the FastWAM DiT/MoT forward+backward path:

- RoPE previously cast Q/K-like tensors to **fp64**, did a complex multiply against precomputed cis frequencies, then cast back. That is bandwidth-heavy and not fused with the surrounding attention prep.
- Every DiT block applied **LayerNorm** and **scale/shift modulation** as two separate ops for both MSA and MLP. With deep MoT stacks this becomes a large number of small kernels and extra reads/writes of the activation.

Fusing both paths reduces HBM traffic and kernel launches without changing math intent (interleaved RoPE; affine-free LN then `x * (1 + scale) + shift`).

## Changes

### 1. Fused DiT RoPE (`wan/dit.py`, `action/dit.py`, `mot/*`)

One change end-to-end: replace the fp64 complex RoPE path with FlashAttention's interleaved Triton rotary, and thread the new `(cos, sin)` layout through prep → MoT → IDM.

| Piece | Detail |
| --- | --- |
| Before | `rope_apply`: rearrange → `view_as_complex(x.fp64)` → `x * freqs` → `view_as_real` → cast back to input dtype |
| After | `prepare_rope_freqs(freqs)` once per sequence → contiguous fp32 `(cos, sin)` tables `[S, rope_dim // 2]` |
| Kernel | `_TritonRoPE` autograd wrapper around `apply_rotary(..., interleaved=True)`; backward uses the same kernel with `conjugate=True` (cos/sin are position tables, no grad) |
| Call sites | `WanVideoDiT` / `ActionDiT` prep call `prepare_rope_freqs`; MoT takes `Tuple[Tensor, Tensor]` instead of dense complex freqs; IDM merges noisy/cond video freqs with per-table `torch.cat` over the tuple |

```text
freqs [S, 1, D/2] complex
        │
        ▼ prepare_rope_freqs   (video / action prep)
(cos, sin) each [S, D/2] fp32 contiguous
        │
        ▼ rope_apply / _TritonRoPE   (MoT self-attn)
x [B, S, H*Dh]  ──►  rotated x (same layout/dtype)
```

### 2. Fused LayerNorm + modulate (`utils/norm_modulate.py`, `mot/model.py`)

New module adapted from the DreamZero `block_norm_modulate_triton` pattern:

- **Semantics:** affine-free LayerNorm over last dim, then `out = normed * (1 + scale) + shift` (same as existing `modulate`).
- **Forward kernel:** one row program computes mean / rstd / norm / modulate; stores `mean` and `rstd` for backward.
- **Backward kernel:** fused grads for `x`, `scale`, and `shift`.
- **Fallback:** if device/shape/dtype/layout is unsupported (`_can_use_triton`), fall back to eager `F.layer_norm` + modulate (including autograd via `torch.autograd.grad` on the reference path).
- **Integration:** MoT `_norm_modulate(norm, x, shift, scale)` replaces `modulate(block.norm{1,2}(x), ...)` for MSA and MLP. Modulation tensors from `_split_modulation` are `expand_as(x)` (zero-copy broadcast when sequence dim is 1).

## Performance / Correctness

### Loss alignment

Baseline vs fused training loss (same seed / data / hyperparams) remains aligned:

<img width="671" height="541" alt="983a9a8a6a0bb1131e9822db1d2d9317" src="https://github.com/user-attachments/assets/89d1ca2c-792b-43bb-a926-9ccf699a9732" />

### Throughput

End-to-end training throughput improves by **+6.72%** with fused DiT RoPE and MoT LayerNorm+modulate:

<img width="700" height="295" alt="56e820910e9ba4c51f347c4f0ab1afc5" src="https://github.com/user-attachments/assets/cd055f92-947d-43c0-9b7b-51e2ad443f98" />

| Metric | Result |
| --- | ---: |
| Throughput speedup | **+6.72%** |


