### PR TITLE
[vla] feat: add LingBot_VA inference API and eval integration

### DIFF
--- a/examples/embodied/lingbot_va/eval/configs/libero/libero_10.yaml
+++ b/examples/embodied/lingbot_va/eval/configs/libero/libero_10.yaml
@@ -1,0 +1,102 @@
+# LingBot-VA LIBERO task-success template (open-source).
+# Verified suite: libero_10 (LIBERO-Long) with a LingBot-VA libero-long posttrain.
+#
+# ckpt_path is a single checkpoint root holding transformer/ plus the frozen
+# vae/ text_encoder/ tokenizer/ subfolders; there is no separate dataset stats
+# file (the action quantiles live in model.norm_q01 / model.norm_q99 below).
+# Fill /path/to/... below. Do not commit machine-specific absolute paths.
+#
+# The model.* values here are the official inference defaults
+# (wan_va/configs/va_libero_cfg.py) and the benchmark.* values match the
+# official LIBERO eval client. Changing them changes the eval, not just its cost.
+#
+# Optional overrides (edit this file or copy it):
+#   max_tasks / episodes_per_task: raise for multi-task / multi-episode eval
+#   suite: only libero_10 matches a libero-long posttrain checkpoint
+
+benchmark:
+  name: libero
+  suite: libero_10
+  max_tasks: 1          # optional: null or larger for the full suite
+  episodes_per_task: 1  # optional: e.g. 5 / 50 for regression
+  max_steps: 800        # official client loops while timestep < 800
+  num_steps_wait: 5     # official client steps 5 dummy actions before acting
+  render_resolution: 128  # official renders natively at 128, not 256-then-resize
+  continuous_gripper: true
+  # control_mode: auto  # -> delta OSC (identity decoder key), same as official
+
+model:
+  backend: loongforge
+  model_type: lingbot_va
+  name: loongforge-lingbot-va-libero-long
+  # Transformer geometry: must match transformer/config.json in the checkpoint.
+  num_layers: 30
+  hidden_size: 3072
+  ffn_hidden_size: 14336
+  num_attention_heads: 24
+  latent_in_channels: 48
+  latent_out_channels: 48
+  latent_patch_size: [1, 2, 2]
+  action_dim: 30
+  text_dim: 4096
+  freq_dim: 256
+  rope_max_seq_len: 1024
+  cross_attn_norm: true
+  # Flow matching: video and action have independent schedules.
+  snr_shift: 5.0
+  action_snr_shift: 0.05
+  num_inference_steps: 20
+  action_num_inference_steps: 50
+  guidance_scale: 5.0
+  action_guidance_scale: 1.0
+  video_exec_step: -1
+  # Autoregression.
+  frame_chunk_size: 4
+  action_per_frame: 4
+  attn_window: 30
+  # Observation encoding.
+  height: 128
+  width: 128
+  camera_layout: width_concat
+  obs_cam_keys: [primary, wrist]
+  # The shared LIBERO adapter emits raw[::-1, ::-1] (180 deg) while the official
+  # client emits raw[::-1] (vertical only); this undoes the extra horizontal
+  # flip. See loongforge/embodied/eval/adapters/libero.py:80.
+  image_hflip: true
+  # Action space + dataset quantiles (official norm_stat; unused channels are 0).
+  used_action_channel_ids: [0, 1, 2, 3, 4, 5, 6]
+  norm_q01: [-0.6589285731315613,-0.84375,-0.9375,-0.12107142806053162,-0.15964286029338837,-0.26571428775787354,-1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+  norm_q99: [0.8999999761581421,0.8544642925262451,0.9375,0.17142857611179352,0.1842857152223587,0.34392857551574707,1,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0]
+
+server:
+  host: 127.0.0.1
+  port: 12099
+  health_port: 12100
+  python: /path/to/loongforge/bin/python
+  log: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/lingbot_va/libero/libero_10/policy_server.log
+  start_timeout_sec: 1800
+  ckpt_path: /path/to/lingbot-va-posttrain-libero-long
+  loongforge_root: /path/to/LoongForge-VLA
+  use_bf16: true
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/lingbot_va/libero/libero_10
+  seed: 7
+  save_trace: true
+  save_replay: true
+  # save_trace: false   # optional: save disk on large sweeps
+  # save_replay: false
+
+timeouts:
+  # One full diffusion rollout per env step (20 video + 50 action steps), so
+  # budgets are much larger than for a single-forward policy.
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 7200

--- a/examples/embodied/lingbot_va/eval/configs/robotwin/adjust_bottle.yaml
+++ b/examples/embodied/lingbot_va/eval/configs/robotwin/adjust_bottle.yaml
@@ -1,0 +1,102 @@
+# LingBot-VA RoboTwin-2.0 task-success template (open-source).
+# Verified task: adjust_bottle / demo_clean with a LingBot-VA robotwin posttrain.
+#
+# ckpt_path is a single checkpoint root holding transformer/ plus the frozen
+# vae/ text_encoder/ tokenizer/ subfolders; the action quantiles live in
+# model.norm_q01 / model.norm_q99 below, not in a dataset stats file.
+# Fill /path/to/... below. Do not commit machine-specific absolute paths.
+#
+# bridge=lingbot_va_ee_quat_16d: no proprio in, 16D dual-arm ee pose out
+# (relative to the episode's initial endpose, composed back by the decoder and
+# executed via take_action(action, action_type="ee")).
+#
+# The model.* values are the official RoboTwin inference defaults
+# (wan_va/configs/va_robotwin_cfg.py) and differ from the LIBERO config in
+# almost every field -- do not copy from the LIBERO YAML.
+
+benchmark:
+  name: robotwin
+  task_name: adjust_bottle  # optional: other RoboTwin tasks
+  task_config: demo_clean
+  start_seed: 100001
+  episodes_per_task: 1
+  max_steps: 300
+  disable_expert_check: false
+  action_bridge: lingbot_va_ee_quat_16d
+
+model:
+  backend: loongforge
+  model_type: lingbot_va
+  name: loongforge-lingbot-va-robotwin2
+  # Transformer geometry: must match transformer/config.json in the checkpoint.
+  num_layers: 30
+  hidden_size: 3072
+  ffn_hidden_size: 14336
+  num_attention_heads: 24
+  latent_in_channels: 48
+  latent_out_channels: 48
+  latent_patch_size: [1, 2, 2]
+  action_dim: 30
+  text_dim: 4096
+  freq_dim: 256
+  rope_max_seq_len: 1024
+  cross_attn_norm: true
+  # Flow matching. action_snr_shift is 1.0 here, not LIBERO's 0.05.
+  snr_shift: 5.0
+  action_snr_shift: 1.0
+  num_inference_steps: 25
+  action_num_inference_steps: 50
+  guidance_scale: 5.0
+  action_guidance_scale: 1.0
+  video_exec_step: -1
+  # Autoregression: shorter chunks, far longer attention window than LIBERO.
+  frame_chunk_size: 2
+  action_per_frame: 16
+  attn_window: 72
+  # Observation encoding: three cameras stitched in the T layout at 256x320.
+  height: 256
+  width: 320
+  camera_layout: robotwin_tshape
+  obs_cam_keys: [primary, left, right]
+  # RoboTwin's adapter passes camera RGB through untouched, so no compensating
+  # flip here (unlike LIBERO, whose adapter rotates by 180 degrees).
+  image_hflip: false
+  # Action space: [left arm 0..6, left gripper 28, right arm 7..13, right gripper 29].
+  # The order is deliberately not ascending -- it is the official channel order
+  # and the quantiles are indexed by it, so do not sort this list.
+  used_action_channel_ids: [0, 1, 2, 3, 4, 5, 6, 28, 7, 8, 9, 10, 11, 12, 13, 29]
+  norm_q01: [-0.06172713458538055,-3.6716461181640625e-05,-0.08783501386642456,-1.0,-1.0,-1.0,-1.0,-0.3547105032205582,-1.3113021850585938e-06,-0.11975435614585876,-1.0,-1.0,-1.0,-1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0]
+  norm_q99: [0.3462600058317184,0.39966784834861746,0.14745532035827624,1.0,1.0,1.0,1.0,0.034201726913452024,0.39142737388610793,0.1792279863357542,1.0,1.0,1.0,1.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,0.0,1.0,1.0]
+
+server:
+  host: 127.0.0.1
+  port: 12299
+  health_port: 12300
+  python: /path/to/loongforge/bin/python
+  log: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/lingbot_va/robotwin/adjust_bottle/policy_server.log
+  start_timeout_sec: 1800
+  random_init: false
+  ckpt_path: /path/to/lingbot-va-posttrain-robotwin
+  loongforge_root: /path/to/LoongForge-VLA
+  use_bf16: true
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  robotwin_root: /path/to/RoboTwin
+  robotwin_python: /path/to/robotwin/bin/python
+
+run:
+  output_dir: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/lingbot_va/robotwin/adjust_bottle
+  seed: 0
+  ckpt_setting: loongforge_lingbot_va_robotwin
+  worker_local_files: true
+  disable_eval_video_log: true
+  keep_config: true
+  timestamped_output: false
+
+timeouts:
+  # One diffusion rollout per env step (25 video + 50 action steps) at 256x320
+  # over three cameras, so budgets are larger than LIBERO's.
+  policy_call_ms: 900000
+  per_step_sec: 900
+  per_episode_sec: 7200

--- a/examples/embodied/lingbot_va/eval/run_libero_eval.sh
+++ b/examples/embodied/lingbot_va/eval/run_libero_eval.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Public open-source entry: fill /path/to/... in the YAML first.
+# Default (only shipped config): configs/libero/libero_10.yaml
+# Optional suite/episode knobs: see comments in that YAML.
+
+set -euo pipefail
+
+REPO_ROOT=${REPO_ROOT:-/path/to/LoongForge-VLA}
+EXAMPLE_EVAL_ROOT=${EXAMPLE_EVAL_ROOT:-${REPO_ROOT}/examples/embodied/lingbot_va/eval}
+CONFIG=${CONFIG:-${EXAMPLE_EVAL_ROOT}/configs/libero/libero_10.yaml}
+if [[ "${CONFIG}" != /* ]]; then
+  CONFIG=${REPO_ROOT}/${CONFIG}
+fi
+
+export PYTHONPATH=${REPO_ROOT}:${PYTHONPATH:-}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+BENCHMARK_PYTHON=${BENCHMARK_PYTHON:-/path/to/libero/bin/python}
+"${BENCHMARK_PYTHON}" -m loongforge.embodied.eval.orchestrator.run --config "${CONFIG}"

--- a/examples/embodied/lingbot_va/eval/run_robotwin_eval.sh
+++ b/examples/embodied/lingbot_va/eval/run_robotwin_eval.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Public open-source entry: fill /path/to/... in the YAML first.
+# Default (only shipped config): configs/robotwin/adjust_bottle.yaml
+# Optional task/episode knobs: see comments in that YAML.
+
+set -euo pipefail
+
+REPO_ROOT=${REPO_ROOT:-/path/to/LoongForge-VLA}
+EXAMPLE_EVAL_ROOT=${EXAMPLE_EVAL_ROOT:-${REPO_ROOT}/examples/embodied/lingbot_va/eval}
+CONFIG=${CONFIG:-${EXAMPLE_EVAL_ROOT}/configs/robotwin/adjust_bottle.yaml}
+if [[ "${CONFIG}" != /* ]]; then
+  CONFIG=${REPO_ROOT}/${CONFIG}
+fi
+
+export PYTHONPATH=${REPO_ROOT}:${PYTHONPATH:-}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+
+BENCHMARK_PYTHON=${BENCHMARK_PYTHON:-/path/to/robotwin/bin/python}
+"${BENCHMARK_PYTHON}" -m loongforge.embodied.eval.orchestrator.run --config "${CONFIG}"

--- a/loongforge/embodied/eval/action_decoders/base.py
+++ b/loongforge/embodied/eval/action_decoders/base.py
@@ -140,6 +140,7 @@ def _auto_import_decoder_modules() -> None:
     """Import decoder modules so their decorators populate the registry."""
     for mod in (
         "loongforge.embodied.eval.action_decoders.ee6d",
+        "loongforge.embodied.eval.action_decoders.ee_quat",
         "loongforge.embodied.eval.action_decoders.joint",
     ):
         try:

--- a/loongforge/embodied/eval/action_decoders/ee_quat.py
+++ b/loongforge/embodied/eval/action_decoders/ee_quat.py
@@ -1,0 +1,121 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# The RoboTwin composition below is derived from the official LingBot-VA
+# repository (github.com/Robbyant/lingbot-va), Apache-2.0:
+# ``evaluation/robotwin/eval_polict_client_openpi.py`` -> ``add_eef_pose`` /
+# ``add_init_pose``. Where this file and the official client disagree, the
+# official client is authoritative.
+
+"""ActionDecoders for models that emit **per-arm position + quaternion + gripper**.
+
+Currently only LingBot-VA RoboTwin: the model predicts a dual-arm end-effector
+pose *relative to the pose the arms held at episode start*, which the official
+client composes back onto that initial pose before stepping the env.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from loongforge.embodied.eval.action_decoders.base import ActionDecoder, register_action_decoder
+
+# Per arm: xyz(3) + quat(4) + gripper(1); two arms.
+_ARM_DIM = 8
+ROBOTWIN_EE_QUAT_ACTION_DIM = 2 * _ARM_DIM
+
+
+def _compose_arm_pose(relative: np.ndarray, initial: np.ndarray) -> np.ndarray:
+    """Compose one arm's relative pose onto the episode's initial pose.
+
+    Mirrors the official ``add_eef_pose``: translations add, rotations compose as
+    ``init_R * relative_R``, and the gripper passes through untouched. The
+    quaternion slice ``[3:7]`` is fed to ``scipy``'s ``from_quat`` exactly as
+    upstream does, so whatever component order RoboTwin's ``endpose`` uses is
+    preserved rather than reinterpreted here.
+    """
+    from scipy.spatial.transform import Rotation
+
+    rel = np.asarray(relative, dtype=np.float64).reshape(-1)
+    init = np.asarray(initial, dtype=np.float64).reshape(-1)
+    rotation = Rotation.from_quat(init[3:7]) * Rotation.from_quat(rel[3:7])
+    return np.concatenate([rel[:3] + init[:3], rotation.as_quat().reshape(-1), rel[7:8]])
+
+
+def _flatten_endpose(endpose: Any) -> np.ndarray:
+    """Flatten RoboTwin's endpose dict the way the official client builds its anchor.
+
+    Official: ``left_endpose + [left_gripper] + right_endpose + [right_gripper]``.
+    An already-flat 16D array is accepted as-is.
+    """
+    if isinstance(endpose, dict):
+        return np.concatenate(
+            [
+                np.asarray(endpose["left_endpose"], dtype=np.float64).reshape(-1),
+                np.asarray([endpose["left_gripper"]], dtype=np.float64),
+                np.asarray(endpose["right_endpose"], dtype=np.float64).reshape(-1),
+                np.asarray([endpose["right_gripper"]], dtype=np.float64),
+            ]
+        )
+    return np.asarray(endpose, dtype=np.float64).reshape(-1)
+
+
+@register_action_decoder("lingbot_va_robotwin_ee_dual")
+class RoboTwinLingBotVAEeQuatDecoder(ActionDecoder):
+    """LingBot-VA RoboTwin: 16D relative dual-arm ee pose -> 16D absolute env ee action.
+
+    The anchor is the endpose observed on the episode's first step, captured here
+    because the official client captures it from ``TASK_ENV.get_obs()`` before the
+    rollout starts. Stateful -> overrides :meth:`reset`.
+
+    The gripper is passed through as the model produced it (its dataset quantiles
+    are ``q01=0`` / ``q99=1``), unlike the X-VLA RoboTwin decoder which binarizes
+    to ``+/-1``. That difference is upstream's, not a simplification here.
+    """
+
+    def __init__(self) -> None:
+        """Initialize with no episode anchor."""
+        self._initial_endpose: Optional[np.ndarray] = None
+
+    def reset(self) -> None:
+        """Drop the anchor so the next step re-captures it."""
+        self._initial_endpose = None
+
+    def __call__(self, actions: np.ndarray, ctx: Dict[str, Any]) -> np.ndarray:
+        """Compose a relative-pose chunk onto the episode's initial endpose."""
+        chunk = np.asarray(actions, dtype=np.float32).reshape(-1, actions.shape[-1])
+        if chunk.shape[-1] < ROBOTWIN_EE_QUAT_ACTION_DIM:
+            raise ValueError(
+                f"lingbot_va RoboTwin decoder requires {ROBOTWIN_EE_QUAT_ACTION_DIM}D actions, "
+                f"got {chunk.shape[-1]}D"
+            )
+        if self._initial_endpose is None:
+            endpose = ctx.get("endpose")
+            if endpose is None:
+                raise ValueError(
+                    "lingbot_va RoboTwin decoder needs ctx['endpose'] on the first step of an "
+                    "episode: the model predicts a pose relative to where the arms started, so "
+                    "without the anchor the commands would be interpreted as absolute and the "
+                    "arms would jump to near the world origin."
+                )
+            anchor = _flatten_endpose(endpose)
+            if anchor.size != ROBOTWIN_EE_QUAT_ACTION_DIM:
+                raise ValueError(
+                    f"ctx['endpose'] must be {ROBOTWIN_EE_QUAT_ACTION_DIM}D "
+                    f"(left xyz+quat+gripper, then right), got {anchor.size}D"
+                )
+            self._initial_endpose = anchor
+
+        anchor = self._initial_endpose
+        out = [
+            np.concatenate(
+                [
+                    _compose_arm_pose(row[:_ARM_DIM], anchor[:_ARM_DIM]),
+                    _compose_arm_pose(row[_ARM_DIM:ROBOTWIN_EE_QUAT_ACTION_DIM], anchor[_ARM_DIM:]),
+                ]
+            )
+            for row in chunk
+        ]
+        return np.stack(out).astype(np.float32)

--- a/loongforge/embodied/eval/bridges/robotwin_policy.py
+++ b/loongforge/embodied/eval/bridges/robotwin_policy.py
@@ -33,6 +33,9 @@ from loongforge.embodied.eval.payload_builders import build_payload_builder
 _BRIDGE_WIRING = {
     "ee6d_dual": ("xvla", "ee6d_dual", "ee6d_robotwin_ee_dual"),
     "pi05_aloha_14d": ("pi05", "aloha_pi", "pi05_aloha_robotwin"),
+    # LingBot-VA consumes no proprio (images + instruction only) and emits a
+    # dual-arm ee pose relative to the episode's initial endpose.
+    "lingbot_va_ee_quat_16d": ("lingbot_va", "", "lingbot_va_robotwin_ee_dual"),
 }
 
 
@@ -85,6 +88,11 @@ class ModelClient:
         if domain_id is not None:
             yaml_model["domain_id"] = int(domain_id)
         self.payload_builder = build_payload_builder(model_type, yaml_model=yaml_model)
+        # Closed-loop-within-chunk models (PayloadBuilder capability) must be
+        # called every env step or their KV cache never sees the intermediate
+        # frames. The YAML flag can only turn the cache off, never back on.
+        if getattr(self.payload_builder, "disable_action_cache", False):
+            self.disable_action_cache = True
         self.decoder = build_action_decoder(decoder_key)
 
         self.task_description: Optional[str] = None
@@ -141,6 +149,9 @@ class ModelClient:
             # Pi05PayloadBuilder produced (== adapt_to_pi_decode_state(joint)).
             # For ee6d_dual the decoder ignores ctx, so this is harmless.
             "pi_state": model_kwargs.get("state"),
+            # lingbot_va anchors its relative dual-arm ee pose on the endpose of
+            # the episode's first step; the other decoders ignore this key.
+            "endpose": canonical_obs["state_raw"].get("endpose"),
             "is_fresh_chunk": data.get("inference_latency_ms") is not None,
         }
         env_action = np.asarray(self.decoder(raw_chunk, decode_ctx), dtype=np.float32)[0]
@@ -225,6 +236,13 @@ def eval(TASK_ENV: Any, model: ModelClient, observation: Dict[str, Any]) -> None
         # with underscores replaced (e.g. "adjust bottle"), NOT the
         # env-generated natural-language instruction.
         instruction = model.adapter.task_name.replace("_", " ")
+        action = model.step(observation, instruction=instruction, step=TASK_ENV.take_action_cnt)
+        TASK_ENV.take_action(action, action_type="ee")
+    elif model.action_bridge == "lingbot_va_ee_quat_16d":
+        # Official LingBot-VA robotwin client uses the env instruction and
+        # commands absolute ee poses (its 16D output is composed onto the
+        # episode's initial endpose by the decoder).
+        instruction = str(TASK_ENV.get_instruction())
         action = model.step(observation, instruction=instruction, step=TASK_ENV.take_action_cnt)
         TASK_ENV.take_action(action, action_type="ee")
     else:

--- a/loongforge/embodied/eval/factories/lingbot_va_factory.py
+++ b/loongforge/embodied/eval/factories/lingbot_va_factory.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LingBot-VA model factory for the LoongForge eval server.
+
+LingBot-VA serves eval through the inference-side model
+(``modeling_lingbot_va_infer.py``), not the training adapter: the two share only the
+transformer weights. ``LingBotVAInferenceConfig`` doubles as the registered
+``model_config_cls``, so YAML ``model:`` keys map 1:1 onto it with no parallel
+eval-side config dataclass.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from pathlib import Path
+from typing import Any, Dict
+
+from loongforge.embodied.eval.factories.registry import register_factory
+from loongforge.embodied.eval.servers.eval_server_config import EvalServerArgs
+from loongforge.embodied.eval.servers.loongforge_policy import PredictActionModelSpec
+from loongforge.embodied.model.lingbot_va.modeling_lingbot_va_infer import (
+    LingBotVAInferenceConfig,
+    LingBotVAPredictActionModel,
+)
+
+
+@register_factory("lingbot_va")
+class LingBotVAModelFactory:
+    """Build the LingBot-VA inference model behind the shared predict_action contract."""
+
+    model_config_cls = LingBotVAInferenceConfig
+
+    @classmethod
+    def build(
+        cls,
+        model_cfg: LingBotVAInferenceConfig,
+        server_args: EvalServerArgs,
+    ) -> PredictActionModelSpec:
+        """Create the model and return it with metadata for the generic eval policy.
+
+        ``server.ckpt_path`` points at the checkpoint root, which holds the
+        ``transformer/`` weights plus the frozen ``vae/`` / ``text_encoder/`` /
+        ``tokenizer/`` subfolders. Both config paths are derived from it so the YAML
+        only carries one path.
+        """
+        import torch
+
+        ckpt_root = str(Path(server_args.ckpt_path).expanduser()) if server_args.ckpt_path else ""
+        device = (
+            server_args.device
+            if torch.cuda.is_available() or not server_args.device.startswith("cuda")
+            else "cpu"
+        )
+        wan_path = ckpt_root or model_cfg.wan_pretrained_path or ""
+        config = dataclasses.replace(
+            model_cfg,
+            checkpoint_path="" if server_args.random_init else ckpt_root,
+            wan_pretrained_path=wan_path,
+            device=device,
+            dtype="bfloat16" if server_args.use_bf16 else model_cfg.dtype,
+        )
+
+        if server_args.random_init:
+            model = LingBotVAPredictActionModel(config)
+            model.to(device=device, dtype=config.torch_dtype)
+            model.eval()
+        else:
+            model = LingBotVAPredictActionModel.from_pretrained(config)
+
+        metadata: Dict[str, Any] = {
+            "framework": "loongforge",
+            "model_type": "lingbot_va",
+            "ckpt_path": ckpt_root if not server_args.random_init else "random_init://lingbot_va",
+            "random_init": bool(server_args.random_init),
+            "loongforge_root": server_args.loongforge_root,
+            "action_dim": len(config.used_action_channel_ids),
+            # One env step per call: the model owns the action queue, so the eval-side
+            # chunk cache is bypassed (see the PayloadBuilder's disable_action_cache).
+            "action_horizon": 1,
+            "wan_pretrained_path": config.wan_pretrained_path,
+            "camera_layout": config.camera_layout,
+            # Both views are concatenated into one frame, so a single-view
+            # warmup call would be rejected (see loongforge_server._warmup_model).
+            "num_camera_views": len(config.obs_cam_keys),
+            "image_hflip": bool(config.image_hflip),
+            "num_inference_steps": config.num_inference_steps,
+            "action_num_inference_steps": config.action_num_inference_steps,
+            "guidance_scale": config.guidance_scale,
+            "action_guidance_scale": config.action_guidance_scale,
+            "dataset_statistics_path": server_args.dataset_statistics_path,
+        }
+        return PredictActionModelSpec(model=model, metadata=metadata)

--- a/loongforge/embodied/eval/factories/registry.py
+++ b/loongforge/embodied/eval/factories/registry.py
@@ -63,6 +63,7 @@ def _auto_import_factory_modules() -> None:
         "loongforge.embodied.eval.factories.pi05_factory",
         "loongforge.embodied.eval.factories.xvla_factory",
         "loongforge.embodied.eval.factories.groot_n1_6_factory",
+        "loongforge.embodied.eval.factories.lingbot_va_factory",
     ]
     for mod in _FACTORY_MODULES:
         try:

--- a/loongforge/embodied/eval/orchestrator/config.py
+++ b/loongforge/embodied/eval/orchestrator/config.py
@@ -169,6 +169,10 @@ CONFIG_MAPPING = {
     "benchmark.num_steps_wait": "num_steps_wait",
     "benchmark.max_steps": "max_steps",
     "benchmark.continuous_gripper": "continuous_gripper",
+    # Camera render resolution passed to robosuite. Omit to keep the shared
+    # default (LIBERO_ENV_RESOLUTION); set it when the official eval client of
+    # a model renders natively at another size (e.g. LingBot-VA renders 128).
+    "benchmark.render_resolution": "render_resolution",
     # LIBERO OSC: auto | absolute | delta (auto ≈ absolute when the composed
     # action decoder key is non-identity — capability matching drives this).
     "benchmark.control_mode": "control_mode",

--- a/loongforge/embodied/eval/orchestrator/runners/libero_runner.py
+++ b/loongforge/embodied/eval/orchestrator/runners/libero_runner.py
@@ -49,6 +49,18 @@ class EpisodeTimeoutError(TimeoutError):
     pass
 
 
+def _render_resolution(args: argparse.Namespace) -> int:
+    """Camera render size: optional benchmark.render_resolution, else the shared default.
+
+    Some models' official eval clients render LIBERO natively at a size other
+    than ``LIBERO_ENV_RESOLUTION`` (LingBot-VA renders 128), and resizing a
+    256-render down is not the same image. Omitting the knob keeps the previous
+    behaviour for every existing config.
+    """
+    value = int(getattr(args, "render_resolution", 0) or 0)
+    return value if value > 0 else LIBERO_ENV_RESOLUTION
+
+
 def _get_libero_env(task, resolution: int, seed: int):
     """Run _get_libero_env."""
     from libero.libero import get_libero_path
@@ -220,7 +232,7 @@ def run_episode(
 
     try:
         with alarm_timeout(args.per_episode_timeout_sec, EpisodeTimeoutError):
-            env, task_description = _get_libero_env(task, LIBERO_ENV_RESOLUTION, episode_seed)
+            env, task_description = _get_libero_env(task, _render_resolution(args), episode_seed)
             reset_start = time.time()
             client.reset(episode_id)
             payload_builder.reset(episode_id)
@@ -275,7 +287,16 @@ def run_episode(
                 request_start = time.perf_counter()
                 with alarm_timeout(args.policy_call_timeout_ms / 1000.0, TimeoutError):
                     response = client.predict_action(
-                        **_build_rpc_payload(payload_builder, canonical_obs, ctx)
+                        **_build_rpc_payload(
+                            payload_builder,
+                            canonical_obs,
+                            ctx,
+                            # Closed-loop-within-chunk models (PayloadBuilder capability)
+                            # must be called every env step; others keep the chunk cache.
+                            disable_action_cache=bool(
+                                getattr(payload_builder, "disable_action_cache", False)
+                            ),
+                        )
                     )
                 e2e_latency_ms = (time.perf_counter() - request_start) * 1000.0
                 e2e_latencies.append(e2e_latency_ms)
@@ -429,6 +450,7 @@ def run_batch(args: argparse.Namespace) -> Dict[str, Any]:
         suite_name=args.task_suite_name,
         episodes_per_task=args.episodes_per_task,
         continuous_gripper=getattr(args, "continuous_gripper", False),
+        resolution=_render_resolution(args),
     )
     payload_builder, action_decoder_key, action_decoder = _common.build_policy_stack(args, adapter)
     logging.info(

--- a/loongforge/embodied/eval/payload_builders/base.py
+++ b/loongforge/embodied/eval/payload_builders/base.py
@@ -37,6 +37,12 @@ class PayloadBuilder:
     action_encoding: str = ""
     action_dim: int = 0
     action_horizon: int = 1
+    # Set True by models whose inference is closed-loop *within* a chunk, i.e.
+    # they must observe every env step rather than being called once per chunk.
+    # Runners forward this to the RPC so ``GenericPredictActionPolicy`` skips its
+    # chunk cache; the model then owns the action queue. Default False keeps the
+    # existing chunk-cached behaviour for every other model.
+    disable_action_cache: bool = False
 
     def __init__(
         self,

--- a/loongforge/embodied/eval/payload_builders/lingbot_va.py
+++ b/loongforge/embodied/eval/payload_builders/lingbot_va.py
@@ -1,0 +1,45 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LingBot-VA PayloadBuilder.
+
+LingBot-VA conditions on camera images plus the task instruction only — it consumes
+no proprio state, so ``state_encoding`` stays empty. Its action is already LIBERO's
+native 7-D end-effector command (pos + axis-angle + gripper), so ``action_encoding``
+matches the LIBERO adapter's ``action_space`` and the composed ActionDecoder key is
+identity (no decoding).
+
+The one non-default capability is ``disable_action_cache``: LingBot-VA is an
+autoregressive world model whose next chunk is conditioned on the observations
+produced *while* the current chunk executes. Being called once per chunk would hide
+those observations and turn the rollout open-loop, so the model must see every env
+step and owns the action queue itself.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict
+
+from loongforge.embodied.eval.payload_builders.base import PayloadBuilder
+from loongforge.embodied.eval.payload_builders.pi05 import _pack_images
+from loongforge.embodied.eval.payload_builders.registry import register_payload_builder
+
+
+@register_payload_builder("lingbot_va")
+class LingBotVAPayloadBuilder(PayloadBuilder):
+    """LingBot-VA client-side payload assembly."""
+
+    # Capability declarations (YAML-overridable via type annotations).
+    state_encoding: str = ""  # no proprio: images + instruction only
+    action_encoding: str = "axis_angle"  # pos(3) + axis_angle(3) + grip(1), LIBERO-native
+    action_dim: int = 7
+    action_horizon: int = 1  # one env step per call; the model holds the chunk
+    disable_action_cache: bool = True  # closed loop within a chunk — see module docstring
+
+    def build(self, canonical: Dict[str, Any], ctx: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the kwargs consumed by ``LingBotVAPredictActionModel.predict_action``."""
+        return {
+            "images": _pack_images(canonical["images"]),
+            "instructions": [str(canonical["instruction"])],
+            "state": None,
+        }

--- a/loongforge/embodied/eval/payload_builders/registry.py
+++ b/loongforge/embodied/eval/payload_builders/registry.py
@@ -44,6 +44,7 @@ def _auto_import_payload_builder_modules() -> None:
         "loongforge.embodied.eval.payload_builders.pi05",
         "loongforge.embodied.eval.payload_builders.xvla",
         "loongforge.embodied.eval.payload_builders.groot_n1_6",
+        "loongforge.embodied.eval.payload_builders.lingbot_va",
     ]
     for mod in _MODULES:
         try:

--- a/loongforge/embodied/eval/servers/loongforge_policy.py
+++ b/loongforge/embodied/eval/servers/loongforge_policy.py
@@ -41,6 +41,7 @@ class GenericPredictActionPolicy:
         self._dataset_stats = self._load_dataset_stats(dataset_statistics_path)
         self._chunk_cache: Dict[str, tuple[int, np.ndarray]] = {}
         self._request_id_prefix = request_id_prefix
+        self._episode_kwargs = self._supported_episode_kwargs(model)
         self._metadata = {
             "protocol_version": PROTOCOL_VERSION,
             "action_dim": int(action_dim),
@@ -48,6 +49,25 @@ class GenericPredictActionPolicy:
             "supports_preempt": False,
             **metadata,
         }
+
+    @staticmethod
+    def _supported_episode_kwargs(model: PredictActionModel) -> tuple[str, ...]:
+        """Which episode-tracking kwargs this model's ``predict_action`` accepts.
+
+        Streaming models (per-episode KV cache / observation buffer) need to know
+        which episode a call belongs to and whether it is the episode's first step.
+        Models that do not declare these parameters are called exactly as before,
+        so nothing is forwarded to them.
+        """
+        import inspect
+
+        try:
+            params = inspect.signature(model.predict_action).parameters
+        except (TypeError, ValueError):
+            return ()
+        if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+            return ("episode_id", "episode_step")
+        return tuple(name for name in ("episode_id", "episode_step") if name in params)
 
     @property
     def metadata(self) -> Dict[str, Any]:
@@ -92,6 +112,10 @@ class GenericPredictActionPolicy:
                 }
 
         start_time = time.perf_counter()
+        episode_kwargs = {
+            "episode_id": episode_id,
+            "episode_step": episode_step,
+        }
         chunk = call_predict_action(
             self._model,
             images=[images],
@@ -99,6 +123,7 @@ class GenericPredictActionPolicy:
             state=state,
             dataset_stats=self._dataset_stats,
             action_dim=int(self._metadata["action_dim"]),
+            **{k: episode_kwargs[k] for k in self._episode_kwargs},
             **kwargs,
         )
         inference_latency_ms = (time.perf_counter() - start_time) * 1000.0

--- a/loongforge/embodied/eval/servers/loongforge_server.py
+++ b/loongforge/embodied/eval/servers/loongforge_server.py
@@ -50,10 +50,14 @@ def _warmup_model(model_spec: Any) -> None:
     import numpy as np
 
     logging.info("Warming up model to resolve lazy imports...")
+    # Models that need more than one camera view reject the single-view dummy;
+    # the factory reports how many views the model consumes so the warmup can
+    # be shaped correctly instead of failing into the ignored-exception path.
+    n_views = max(1, int(getattr(model_spec, "metadata", {}).get("num_camera_views", 1) or 1))
     try:
         dummy_image = np.zeros((224, 224, 3), dtype=np.uint8)
         model_spec.model.predict_action(
-            images=[[dummy_image]],
+            images=[[dummy_image] * n_views],
             instructions=["warmup"],
             state=None,
             dataset_stats=None,

--- a/loongforge/embodied/model/lingbot_va/modeling_lingbot_va_infer.py
+++ b/loongforge/embodied/model/lingbot_va/modeling_lingbot_va_infer.py
@@ -1,0 +1,768 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified from LingBot-VA under the Apache-2.0 License.
+# Copyright 2024-2025 The Robbyant Team Authors. All rights reserved.
+#
+# The config defaults, dual denoising loops, chunk/keyframe accounting and action
+# de-normalization follow upstream's ``wan_va/wan_va_server.py`` and
+# ``wan_va/configs/va_libero_cfg.py``. Parts were cross-checked against the LingBot-VA
+# port in LeRobot (Apache-2.0, Copyright 2024 The HuggingFace Inc. team); that port is not
+# authoritative and diverges here where it conflicts with upstream (e.g. it duplicates
+# ``grid_id`` for classifier-free guidance, which the native Triton RoPE kernel rejects).
+
+"""Online inference adapter for LingBot-VA behind the shared eval ``predict_action`` contract.
+
+Kept separate from ``modeling_lingbot_va.py`` (training) on purpose: the two share only the
+transformer weights, and inference needs a whole layer training does not have — frozen VAE /
+text encoder, per-episode autoregressive state, sampling schedules and camera layout. The
+training module is not imported here beyond the checkpoint loader.
+
+Reference: the upstream LingBot-VA LIBERO client (``evaluation/libero/client.py``) and its
+LeRobot port.
+"""
+
+from __future__ import annotations
+
+from collections import deque
+from dataclasses import dataclass, field, fields
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import numpy as np
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+from .checkpoint import load_sharded_safetensors
+from .modules.flow_match import LingBotVAFlowMatchScheduler
+from .modules.rollout_state import RolloutStateStore
+from .modules.wan_streaming import (
+    WanStreamingTransformer3DModel,
+    data_seq_to_patch,
+    get_mesh_id_streaming,
+)
+
+
+# Training config keys that mean the same thing under a different name.
+_TRAINING_KEY_ALIASES = {
+    "lingbot_va_snr_shift": "snr_shift",
+    "lingbot_va_action_snr_shift": "action_snr_shift",
+    "lingbot_va_sigma_min": "sigma_min",
+    "lingbot_va_extra_one_step": "extra_one_step",
+    "lingbot_va_num_train_timesteps": "num_train_timesteps",
+    "lingbot_va_chunk_size": "frame_chunk_size",
+    "lingbot_va_diffusers_checkpoint_path": "checkpoint_path",
+}
+
+# Every layout branch is an ``== "robotwin_tshape"`` test with width_concat as the fallback,
+# so an unrecognized value would assemble the wrong canvas, run to completion, and only show
+# up as a degraded success rate. Validated in ``__post_init__``.
+_CAMERA_LAYOUTS = ("width_concat", "robotwin_tshape")
+
+
+@dataclass
+class LingBotVAInferenceConfig:
+    """Config for a closed-loop rollout: transformer geometry plus inference-only settings.
+
+    :meth:`from_mapping` pulls the shared values out of a training YAML so the two cannot
+    drift; the sampling / autoregression / camera / quantile fields have no training
+    counterpart. Defaults match upstream ``wan_va/configs/va_libero_cfg.py``.
+    """
+
+    # Transformer geometry — must match the trained checkpoint.
+    num_layers: int = 30
+    hidden_size: int = 3072
+    ffn_hidden_size: int = 14336
+    num_attention_heads: int = 24
+    latent_in_channels: int = 48
+    latent_out_channels: int = 48
+    latent_patch_size: Tuple[int, int, int] = (1, 2, 2)
+    action_dim: int = 30
+    text_dim: int = 4096
+    freq_dim: int = 256
+    norm_epsilon: float = 1e-6
+    rope_max_seq_len: int = 1024
+    cross_attn_norm: bool = True
+
+    # Flow matching. The streams are deliberately asymmetric: video is shifted towards high
+    # noise and runs few steps, action the other way. ``video_exec_step=-1`` runs the full
+    # video schedule; a positive value truncates it.
+    snr_shift: float = 5.0
+    action_snr_shift: float = 0.05
+    sigma_min: float = 0.0
+    extra_one_step: bool = True
+    num_train_timesteps: int = 1000
+    num_inference_steps: int = 20
+    action_num_inference_steps: int = 50
+    guidance_scale: float = 5.0
+    action_guidance_scale: float = 1.0
+    video_exec_step: int = -1
+
+    # Autoregression.
+    frame_chunk_size: int = 4
+    action_per_frame: int = 4
+    attn_window: int = 30
+
+    # Observation encoding.
+    height: int = 128
+    width: int = 128
+    camera_layout: str = "width_concat"
+    obs_cam_keys: List[str] = field(default_factory=lambda: ["primary", "wrist"])
+    # Undoes an extra horizontal flip applied upstream of the model. Upstream's LIBERO client
+    # hands the model ``raw[::-1]`` (vertical only), while this repo's shared LIBERO adapter
+    # emits ``raw[::-1, ::-1]`` — a 180 degree rotation (``eval/adapters/libero.py:80``). So
+    # LIBERO must set this True; otherwise the model sees mirrored images, which degrades it
+    # silently rather than erroring. Left False by default so every benchmark's adapter gets
+    # checked instead of inheriting a value that only happens to suit LIBERO.
+    image_hflip: bool = False
+
+    # Action space: the model always emits ``action_dim`` channels; only these are real.
+    used_action_channel_ids: List[int] = field(default_factory=lambda: [0, 1, 2, 3, 4, 5, 6])
+    norm_q01: List[float] = field(default_factory=list)
+    norm_q99: List[float] = field(default_factory=list)
+
+    # ``wan_pretrained_path`` holds the frozen VAE / text encoder / tokenizer subfolders;
+    # they are not bundled in the transformer checkpoint.
+    checkpoint_path: Optional[str] = None
+    wan_pretrained_path: Optional[str] = None
+    max_sequence_length: int = 512
+
+    device: str = "cuda"
+    dtype: str = "bfloat16"
+
+    @classmethod
+    def from_mapping(cls, *sections: Optional[Dict[str, Any]], **overrides: Any):
+        """Build a config from training YAML sections (``model``, ``data``, ...).
+
+        Keys matching a field name are taken as-is, ``lingbot_va_*`` keys via
+        :data:`_TRAINING_KEY_ALIASES`; unknown keys are ignored, so whole sections can be
+        passed in directly.
+        """
+        known = {f.name for f in fields(cls)}
+        values: Dict[str, Any] = {}
+        for section in sections:
+            for key, value in (section or {}).items():
+                key = _TRAINING_KEY_ALIASES.get(key, key)
+                if key in known and value is not None:
+                    values[key] = value
+
+        # Upstream builds ``inverse_used_action_channel_ids`` as ``[len(used)] * action_dim``
+        # and overwrites the used positions with their index, so unused slots hold the
+        # sentinel ``len(used)`` — also the maximum. Used channels are those below it.
+        for section in sections:
+            inverse_ids = (section or {}).get("inverse_used_action_channel_ids")
+            if not inverse_ids or "used_action_channel_ids" in overrides:
+                continue
+            sentinel = max(inverse_ids)
+            values["used_action_channel_ids"] = tuple(
+                i for i, channel in enumerate(inverse_ids) if channel < sentinel
+            )
+
+        values.update(overrides)
+        if "latent_patch_size" in values:
+            values["latent_patch_size"] = tuple(values["latent_patch_size"])
+        return cls(**values)
+
+    @property
+    def torch_dtype(self) -> torch.dtype:
+        """Resolve the ``dtype`` string to the matching ``torch`` dtype."""
+        return {"bfloat16": torch.bfloat16, "float16": torch.float16, "float32": torch.float32}[
+            self.dtype
+        ]
+
+    def __post_init__(self) -> None:
+        """Reject an unrecognized camera layout (see :data:`_CAMERA_LAYOUTS`)."""
+        if self.camera_layout not in _CAMERA_LAYOUTS:
+            raise ValueError(
+                f"unknown camera_layout {self.camera_layout!r}; expected one of {sorted(_CAMERA_LAYOUTS)}"
+            )
+
+    @property
+    def attention_head_dim(self) -> int:
+        """Per-head width implied by ``hidden_size`` and the head count."""
+        return self.hidden_size // self.num_attention_heads
+
+    @property
+    def latent_hw(self) -> Tuple[int, int]:
+        """Latent grid of the assembled frame: VAE downsamples 8x, patchify 2x on top."""
+        if self.camera_layout == "robotwin_tshape":
+            # Full-res head at the bottom, two half-res wrists side by side above it.
+            return ((self.height // 16) * 3) // 2, self.width // 16
+        return self.height // 16, (self.width // 16) * len(self.obs_cam_keys)
+
+    @property
+    def keyframe_stride(self) -> int:
+        """Executed sub-steps per buffered keyframe; the VAE temporal downsample is 4."""
+        return max(1, self.action_per_frame // 4)
+
+
+class LingBotVAPredictActionModel(nn.Module):
+    """Closed-loop LingBot-VA inference behind the shared ``predict_action`` contract.
+
+    One ``predict_action`` call returns one action. The chunk queue, the transformer KV cache
+    and the streaming VAE state live per episode in :mod:`.modules.rollout_state`, so eval
+    **must** pass ``disable_action_cache=True``: with the front end's chunk cache enabled the
+    model is called only once per chunk and never observes the intermediate frames the
+    closed-loop feedback depends on.
+
+    Per chunk: feed the buffered keyframes and executed actions back into the KV cache as
+    *real* slots, denoise a fresh video latent, then denoise the action chunk conditioned on
+    the same cache.
+    """
+
+    def __init__(self, config: LingBotVAInferenceConfig):
+        """Build the streaming transformer and the two flow-matching schedulers.
+
+        Weights are not loaded here; use :meth:`from_pretrained`. The frozen VAE and
+        text encoder are loaded lazily on the first rollout.
+        """
+        super().__init__()
+        self.config = config
+        self.dtype = config.torch_dtype
+        self.transformer = WanStreamingTransformer3DModel(
+            patch_size=config.latent_patch_size,
+            num_attention_heads=config.num_attention_heads,
+            attention_head_dim=config.attention_head_dim,
+            in_channels=config.latent_in_channels,
+            out_channels=config.latent_out_channels,
+            action_dim=config.action_dim,
+            text_dim=config.text_dim,
+            freq_dim=config.freq_dim,
+            ffn_dim=config.ffn_hidden_size,
+            num_layers=config.num_layers,
+            cross_attn_norm=config.cross_attn_norm,
+            eps=config.norm_epsilon,
+            rope_max_seq_len=config.rope_max_seq_len,
+            # Training may use flex attention; the streaming KV-cache path is torch-only.
+            attn_mode="torch",
+        )
+
+        self.scheduler = self._build_scheduler(config.snr_shift)
+        self.action_scheduler = self._build_scheduler(config.action_snr_shift)
+        self.scheduler.set_timesteps(config.num_inference_steps)
+        self.action_scheduler.set_timesteps(config.action_num_inference_steps)
+        self.use_cfg = config.guidance_scale > 1 or config.action_guidance_scale > 1
+
+        self._frozen: Dict[str, Any] = {}
+        self._store = RolloutStateStore(on_release=self._release_state)
+
+    def _build_scheduler(self, shift: float) -> LingBotVAFlowMatchScheduler:
+        """Instantiate a scheduler at the given SNR shift.
+
+        The video and action streams denoise on deliberately different schedules, so
+        each gets its own instance built through this helper.
+        """
+        return LingBotVAFlowMatchScheduler(
+            num_train_timesteps=self.config.num_train_timesteps,
+            shift=shift,
+            sigma_min=self.config.sigma_min,
+            extra_one_step=self.config.extra_one_step,
+        )
+
+    # ── construction / weights ───────────────────────────────────────
+    @classmethod
+    def from_pretrained(cls, config: LingBotVAInferenceConfig):
+        """Build the model and load the transformer checkpoint onto the target device."""
+        model = cls(config)
+        if config.checkpoint_path:
+            load_sharded_safetensors(model.transformer, config.checkpoint_path)
+        model.to(device=config.device, dtype=config.torch_dtype)
+        model.eval()
+        return model
+
+    def _ensure_frozen_modules(self) -> None:
+        """Lazily load the frozen VAE / text encoder / tokenizer.
+
+        They live in ``wan_pretrained_path`` subfolders rather than the transformer
+        checkpoint, so loading is deferred to the first rollout instead of being paid for at
+        construction.
+        """
+        if self._frozen:
+            return
+        from .modules import wan_codec
+
+        path = self.config.wan_pretrained_path
+        if not path:
+            raise ValueError(
+                "wan_pretrained_path must be set to load the frozen VAE / text encoder "
+                "(they are not part of the transformer checkpoint)"
+            )
+        self._frozen = {
+            "vae": wan_codec.load_vae(path, self.dtype, self.config.device, subfolder="vae"),
+            "text_encoder": wan_codec.load_text_encoder(
+                path, self.dtype, self.config.device, subfolder="text_encoder"
+            ),
+            "tokenizer": wan_codec.load_tokenizer(path, subfolder="tokenizer"),
+        }
+
+    # ── per-episode state ────────────────────────────────────────────
+    def _release_state(self, state) -> None:
+        """Drop the transformer KV cache when an episode ends.
+
+        The cache belongs to the transformer instance rather than the state object, so it has
+        to be cleared explicitly; the streaming VAE's ``feat_cache`` goes away with the state.
+        """
+        self.transformer.clear_cache("pos")
+
+    def _episode_state(self, episode_id: str, episode_step: int):
+        """Fetch the active episode state, (re)building it and its VAE wrappers as needed.
+
+        Raises when a second episode is interleaved over this model instance; see
+        :meth:`RolloutStateStore.get_or_start`.
+        """
+        from .modules.wan_codec import WanVAEStreamingWrapper
+
+        state = self._store.get_or_start(episode_id, self.config.keyframe_stride, episode_step)
+        if state.streaming_vae is not None:
+            return state
+
+        state.streaming_vae = WanVAEStreamingWrapper(self._frozen["vae"])
+        if self.config.camera_layout == "robotwin_tshape":
+            # The wrists are encoded at half resolution and need their own causal cache: one
+            # ``feat_cache`` cannot span two different spatial shapes.
+            state.streaming_vae_half = WanVAEStreamingWrapper(self._frozen["vae"])
+        return state
+
+    def _init_kv_cache(self) -> None:
+        """Allocate the transformer KV pools for one sliding window of this config.
+
+        Sizes the per-chunk token counts from the latent grid and the action layout; the
+        batch is doubled when classifier-free guidance is active.
+        """
+        cfg = self.config
+        latent_h, latent_w = cfg.latent_hw
+        p = cfg.latent_patch_size
+        self.transformer.create_empty_cache(
+            "pos",
+            cfg.attn_window,
+            (cfg.frame_chunk_size * latent_h * latent_w) // (p[0] * p[1] * p[2]),
+            cfg.frame_chunk_size * cfg.action_per_frame,
+            device=cfg.device,
+            dtype=self.dtype,
+            batch_size=2 if self.use_cfg else 1,
+        )
+
+    @property
+    def _action_mask(self) -> torch.Tensor:
+        """Boolean mask over the model's 30 action channels selecting the used ones."""
+        mask = torch.zeros([self.config.action_dim], dtype=torch.bool)
+        mask[list(self.config.used_action_channel_ids)] = True
+        return mask
+
+    # ── observation / text encoding ──────────────────────────────────
+    def _to_camera_frames(self, views: Sequence[Any]) -> List[torch.Tensor]:
+        """Turn one observation's views into per-camera VAE clips ``[1, C, 1, H, W]``.
+
+        ``views`` is ordered to match ``obs_cam_keys``. Images may arrive as HWC uint8 or as
+        CHW floats in ``[0, 1]``. Under ``robotwin_tshape`` the wrists go in at half
+        resolution.
+        """
+        from .modules.wan_codec import prepare_camera_frame
+
+        cfg = self.config
+        if len(views) < len(cfg.obs_cam_keys):
+            raise ValueError(
+                f"expected {len(cfg.obs_cam_keys)} camera views, got {len(views)}"
+            )
+
+        frames = []
+        for idx in range(len(cfg.obs_cam_keys)):
+            image = views[idx]
+            if not torch.is_tensor(image):
+                image = torch.from_numpy(np.ascontiguousarray(image))
+            if image.ndim == 3 and image.shape[-1] in (1, 3):
+                image = image.permute(2, 0, 1)  # HWC -> CHW
+            image = image.float()
+            if image.max() > 1.5:
+                image = image / 255.0
+            size = (cfg.height, cfg.width)
+            if cfg.camera_layout == "robotwin_tshape" and idx > 0:
+                size = (cfg.height // 2, cfg.width // 2)
+            frames.append(
+                prepare_camera_frame(
+                    image, size, self.dtype, cfg.device, hflip=cfg.image_hflip
+                )
+            )
+        return frames
+
+    @torch.no_grad()
+    def _encode_obs(self, state, obs_frames: List[List[torch.Tensor]]) -> torch.Tensor:
+        """VAE-encode a temporal clip of observations into a normalized video latent.
+
+        ``obs_frames`` is indexed ``[frame][camera]``; the codec wants ``[camera][frame]``.
+        All frames go through one streaming call so the causal ``feat_cache`` carries across
+        chunks and the x4 temporal downsample sees a continuous clip.
+        """
+        from .modules import wan_codec
+
+        if self.config.camera_layout == "robotwin_tshape":
+            return wan_codec.encode_frames_tshape(
+                state.streaming_vae,
+                state.streaming_vae_half,
+                [f[0] for f in obs_frames],
+                [f[1] for f in obs_frames],
+                [f[2] for f in obs_frames],
+                self.config.device,
+            )
+        per_camera = [
+            [frame[cam] for frame in obs_frames]
+            for cam in range(len(self.config.obs_cam_keys))
+        ]
+        return wan_codec.encode_frames_width_concat(
+            state.streaming_vae, per_camera, self.config.device
+        )
+
+    def _encode_prompt(self, state, instruction: str) -> None:
+        """Encode the task prompt once per episode (plus the empty prompt when using CFG)."""
+        from .modules import wan_codec
+
+        if state.prompt_embeds is not None:
+            return
+        cfg = self.config
+        state.prompt = instruction or ""
+        state.prompt_embeds = wan_codec.encode_text(
+            self._frozen["tokenizer"],
+            self._frozen["text_encoder"],
+            state.prompt,
+            cfg.max_sequence_length,
+            self.dtype,
+            cfg.device,
+        )
+        if self.use_cfg:
+            state.negative_prompt_embeds = wan_codec.encode_text(
+                self._frozen["tokenizer"],
+                self._frozen["text_encoder"],
+                "",
+                cfg.max_sequence_length,
+                self.dtype,
+                cfg.device,
+            )
+
+    # ── stream input assembly ────────────────────────────────────────
+    def _prepare_stream_inputs(
+        self,
+        state,
+        latent_input: Optional[torch.Tensor],
+        action_input: Optional[torch.Tensor],
+        latent_t=0,
+        action_t=0,
+        latent_cond: Optional[torch.Tensor] = None,
+        action_cond: Optional[torch.Tensor] = None,
+        frame_st_id: int = 0,
+    ) -> Dict[str, Dict[str, torch.Tensor]]:
+        """Build the per-stream ``input_dict`` the streaming transformer forward expects."""
+        cfg = self.config
+        p = cfg.latent_patch_size
+        device = cfg.device
+        out: Dict[str, Dict[str, torch.Tensor]] = {}
+
+        if latent_input is not None:
+            out["latent_res_lst"] = {
+                "noisy_latents": latent_input,
+                "timesteps": torch.ones(
+                    [latent_input.shape[2]], dtype=torch.float32, device=device
+                )
+                * latent_t,
+                "grid_id": get_mesh_id_streaming(
+                    latent_input.shape[-3] // p[0],
+                    latent_input.shape[-2] // p[1],
+                    latent_input.shape[-1] // p[2],
+                    0,
+                    frame_shift=frame_st_id,
+                ).to(device),
+                "text_emb": state.prompt_embeds.to(self.dtype).clone(),
+            }
+            if latent_cond is not None:
+                # Frame 0 is the observed conditioning frame: keep it clean and mark it as
+                # fully denoised (timestep 0) so the model treats it as known.
+                out["latent_res_lst"]["noisy_latents"][:, :, 0:1] = latent_cond[:, :, 0:1]
+                out["latent_res_lst"]["timesteps"][0:1] *= 0
+
+        if action_input is not None:
+            out["action_res_lst"] = {
+                "noisy_latents": action_input,
+                "timesteps": torch.ones(
+                    [action_input.shape[2]], dtype=torch.float32, device=device
+                )
+                * action_t,
+                "grid_id": get_mesh_id_streaming(
+                    action_input.shape[-3],
+                    action_input.shape[-2],
+                    action_input.shape[-1],
+                    1,
+                    frame_shift=frame_st_id,
+                    action=True,
+                ).to(device),
+                "text_emb": state.prompt_embeds.to(self.dtype).clone(),
+            }
+            if action_cond is not None:
+                out["action_res_lst"]["noisy_latents"][:, :, 0:1] = action_cond[:, :, 0:1]
+                out["action_res_lst"]["timesteps"][0:1] *= 0
+            # Unused embodiment channels must stay exactly zero.
+            out["action_res_lst"]["noisy_latents"][:, ~self._action_mask] *= 0
+        return out
+
+    def _repeat_for_cfg(self, state, stream: Dict[str, torch.Tensor]):
+        """Stack the conditional and unconditional branches into one batch.
+
+        ``grid_id`` is deliberately *not* duplicated: both branches occupy the same token
+        positions, and this backend's rope is the triton kernel in :mod:`.modules.rope`,
+        which requires ``frequencies.shape[0] == 1`` and broadcasts over the value batch
+        anyway (it indexes ``cos``/``sin`` as ``[0, :, 0]``). ``timesteps`` does need the
+        duplicate, since it feeds the per-sample condition embedder.
+        """
+        if self.use_cfg:
+            stream["noisy_latents"] = stream["noisy_latents"].repeat(2, 1, 1, 1, 1)
+            stream["text_emb"] = torch.cat(
+                [
+                    state.prompt_embeds.to(self.dtype).clone(),
+                    state.negative_prompt_embeds.to(self.dtype).clone(),
+                ],
+                dim=0,
+            )
+            stream["grid_id"] = stream["grid_id"][None]
+            stream["timesteps"] = stream["timesteps"][None].repeat(2, 1)
+        else:
+            stream["grid_id"] = stream["grid_id"][None]
+            stream["timesteps"] = stream["timesteps"][None]
+        return stream
+
+    # ── the dual-stream denoising loop (one chunk) ───────────────────
+    @torch.no_grad()
+    def _infer(self, state, init_latent: Optional[torch.Tensor], frame_st_id: int = 0):
+        """Denoise one chunk: video latents first, then actions conditioned on the same cache.
+
+        Both loops append a trailing timestep 0 and treat the final iteration specially: it
+        runs the transformer with ``update_cache=1`` so the fully denoised chunk lands in the
+        KV cache as a *predicted* slot (later dropped by ``clear_pred_cache`` once the real
+        observations arrive), and it does not step the scheduler again.
+        """
+        cfg = self.config
+        device = cfg.device
+        latent_h, latent_w = cfg.latent_hw
+        chunk = cfg.frame_chunk_size
+        cfg_batch = 2 if self.use_cfg else 1
+
+        latents = torch.randn(
+            1, cfg.latent_out_channels, chunk, latent_h, latent_w, device=device, dtype=self.dtype
+        )
+        actions = torch.randn(
+            1, cfg.action_dim, chunk, cfg.action_per_frame, 1, device=device, dtype=self.dtype
+        )
+
+        timesteps = F.pad(self.scheduler.timesteps, (0, 1), mode="constant", value=0)
+        if cfg.video_exec_step != -1:
+            timesteps = timesteps[: cfg.video_exec_step]
+        action_timesteps = F.pad(
+            self.action_scheduler.timesteps, (0, 1), mode="constant", value=0
+        )
+
+        # 1. Video-latent denoising.
+        for i, t in enumerate(timesteps):
+            last_step = i == len(timesteps) - 1
+            latent_cond = (
+                init_latent[:, :, 0:1].to(self.dtype)
+                if frame_st_id == 0 and init_latent is not None
+                else None
+            )
+            streams = self._prepare_stream_inputs(
+                state, latents, None, t, t, latent_cond, None, frame_st_id=frame_st_id
+            )
+            noise_pred = self.transformer(
+                self._repeat_for_cfg(state, streams["latent_res_lst"]),
+                update_cache=1 if last_step else 0,
+                cache_name="pos",
+                action_mode=False,
+            )
+            if not last_step or cfg.video_exec_step != -1:
+                noise_pred = data_seq_to_patch(
+                    cfg.latent_patch_size,
+                    noise_pred,
+                    chunk,
+                    latent_h,
+                    latent_w,
+                    batch_size=cfg_batch,
+                )
+                if cfg.guidance_scale > 1:
+                    noise_pred = noise_pred[1:] + cfg.guidance_scale * (
+                        noise_pred[:1] - noise_pred[1:]
+                    )
+                else:
+                    noise_pred = noise_pred[:1]
+                latents = self.scheduler.step(noise_pred, t, latents)
+            if frame_st_id == 0 and latent_cond is not None:
+                latents[:, :, 0:1] = latent_cond
+
+        # 2. Action denoising, conditioned on the video latents now in the cache.
+        for i, t in enumerate(action_timesteps):
+            last_step = i == len(action_timesteps) - 1
+            action_cond = (
+                torch.zeros(
+                    [1, cfg.action_dim, 1, cfg.action_per_frame, 1],
+                    device=device,
+                    dtype=self.dtype,
+                )
+                if frame_st_id == 0
+                else None
+            )
+            streams = self._prepare_stream_inputs(
+                state, None, actions, t, t, None, action_cond, frame_st_id=frame_st_id
+            )
+            noise_pred = self.transformer(
+                self._repeat_for_cfg(state, streams["action_res_lst"]),
+                update_cache=1 if last_step else 0,
+                cache_name="pos",
+                action_mode=True,
+            )
+            if not last_step:
+                noise_pred = rearrange(
+                    noise_pred, "b (f n) c -> b c f n 1", f=chunk
+                )
+                if cfg.action_guidance_scale > 1:
+                    noise_pred = noise_pred[1:] + cfg.action_guidance_scale * (
+                        noise_pred[:1] - noise_pred[1:]
+                    )
+                else:
+                    noise_pred = noise_pred[:1]
+                actions = self.action_scheduler.step(noise_pred, t, actions)
+            if frame_st_id == 0 and action_cond is not None:
+                actions[:, :, 0:1] = action_cond
+
+        actions[:, ~self._action_mask] *= 0
+        return actions, latents
+
+    @torch.no_grad()
+    def _compute_kv_cache(self, state) -> None:
+        """Feed the observed keyframes and executed actions back in as *real* cache slots."""
+        if not state.obs_buffer or state.executed_actions is None:
+            return
+        # The previous chunk's predicted slots are superseded by what actually happened.
+        self.transformer.clear_pred_cache("pos")
+
+        latent_input = self._encode_obs(state, state.obs_buffer)
+        if state.frame_st_id == 0 and state.init_latent is not None:
+            # Upstream prepends the init latent on the first feedback so the latent and
+            # action frame counts line up.
+            latent_input = torch.cat([state.init_latent, latent_input], dim=2)
+        action_input = state.executed_actions.to(latent_input)
+
+        streams = self._prepare_stream_inputs(
+            state, latent_input, action_input, frame_st_id=state.frame_st_id
+        )
+        self.transformer(
+            self._repeat_for_cfg(state, streams["latent_res_lst"]),
+            update_cache=2,
+            cache_name="pos",
+            action_mode=False,
+        )
+        self.transformer(
+            self._repeat_for_cfg(state, streams["action_res_lst"]),
+            update_cache=2,
+            cache_name="pos",
+            action_mode=True,
+        )
+        state.frame_st_id += latent_input.shape[2]
+
+    # ── action post-processing ───────────────────────────────────────
+    def _denormalize_actions(self, actions: torch.Tensor) -> np.ndarray:
+        """Undo the dataset's quantile normalization on the used channels only.
+
+        Training normalized actions to ``[-1, 1]`` via
+        ``(a - q01) / (q99 - q01 + 1e-6) * 2 - 1``; this is upstream's exact inverse,
+        ``(a + 1) / 2 * (q99 - q01 + 1e-6) + q01``. Unused channels have ``q01 == q99 == 0``
+        (the ``1e-6`` is what keeps upstream from dividing by zero on them), so they are
+        excluded here instead.
+        """
+        cfg = self.config
+        used = list(cfg.used_action_channel_ids)
+        out = actions.float()
+        if not len(cfg.norm_q01) or not len(cfg.norm_q99):
+            raise ValueError(
+                "norm_q01 / norm_q99 are empty: the model would return actions still in the "
+                "normalized [-1, 1] range, which runs to completion but never reaches the "
+                "env's action scale. Set them from the dataset's quantile statistics "
+                "(upstream keeps them in the task config as norm_stat)."
+            )
+        q01 = torch.as_tensor(cfg.norm_q01, dtype=torch.float32, device=out.device)[used]
+        q99 = torch.as_tensor(cfg.norm_q99, dtype=torch.float32, device=out.device)[used]
+        return (((out + 1.0) / 2.0) * (q99 - q01 + 1e-6) + q01).cpu().numpy()
+
+    def _chunk_to_steps(self, actions: torch.Tensor, drop_first_frame: bool) -> np.ndarray:
+        """Flatten a chunk ``[1, action_dim, F, action_per_frame, 1]`` to ``[n_steps, n_used]``.
+
+        On the first chunk frame 0 is the conditioning frame — already "known" — so upstream's
+        LIBERO client starts executing at frame 1 and its actions are dropped here.
+        """
+        a = actions[:, list(self.config.used_action_channel_ids)]
+        if drop_first_frame:
+            a = a[:, :, 1:]
+        a = a.squeeze(-1).flatten(2)  # [1, n_used, n_steps]
+        a = a.transpose(1, 2).contiguous()[0]  # [n_steps, n_used]
+        return self._denormalize_actions(a)
+
+    def _refill_queue(self, state, actions: torch.Tensor, drop_first_frame: bool) -> None:
+        """Replace the queue with a freshly predicted chunk and keep it for the next feedback.
+
+        ``actions`` stays in normalized space on the state because the next chunk feeds it
+        back into the KV cache; only the queued copy is denormalized to env scale.
+        """
+        steps = self._chunk_to_steps(actions, drop_first_frame)
+        state.action_queue = deque(steps)
+        state.executed_actions = actions
+        state.begin_chunk()
+
+    # ── the eval entry point ─────────────────────────────────────────
+    @torch.no_grad()
+    def predict_action(
+        self,
+        images,
+        instructions,
+        state=None,
+        dataset_stats=None,
+        episode_id: str = "default",
+        episode_step: int = 0,
+        **kwargs: Any,
+    ) -> np.ndarray:
+        """Return the action for the current env step as ``[1, n_used]``.
+
+        Requires ``disable_action_cache=True`` on the eval side so this is called once per
+        env step: every observation either conditions the first chunk, or is buffered as a
+        keyframe for the closed-loop feedback.
+
+        ``state`` (proprioception) and ``dataset_stats`` are part of the shared contract but
+        unused here — LingBot-VA conditions on images and text only, and the action quantiles
+        come from the config.
+        """
+        del state, dataset_stats  # unused by this model; see docstring
+        self.eval()
+        self._ensure_frozen_modules()
+
+        rollout = self._episode_state(episode_id, episode_step)
+        views = images[0] if len(images) and isinstance(images[0], (list, tuple)) else images
+        instruction = instructions[0] if isinstance(instructions, (list, tuple)) else instructions
+        self._encode_prompt(rollout, instruction)
+        frames = self._to_camera_frames(views)
+
+        if not rollout.started:
+            # First observation conditions the first chunk; it is not a keyframe.
+            rollout.started = True
+            rollout.init_latent = self._encode_obs(rollout, [frames])
+            self._init_kv_cache()
+            actions, _latents = self._infer(rollout, rollout.init_latent, frame_st_id=0)
+            rollout.first_chunk = False
+            self._refill_queue(rollout, actions, drop_first_frame=True)
+        else:
+            # This observation is the result of the action just executed.
+            if rollout.should_buffer_keyframe():
+                rollout.obs_buffer.append(frames)
+            if not rollout.action_queue:
+                self._compute_kv_cache(rollout)
+                actions, _latents = self._infer(
+                    rollout, None, frame_st_id=rollout.frame_st_id
+                )
+                self._refill_queue(rollout, actions, drop_first_frame=False)
+
+        action = rollout.action_queue.popleft()
+        rollout.advance_exec_step(self.config.action_per_frame)
+        return np.asarray(action, dtype=np.float32).reshape(1, -1)

--- a/loongforge/embodied/model/lingbot_va/modules/flow_match.py
+++ b/loongforge/embodied/model/lingbot_va/modules/flow_match.py
@@ -10,7 +10,12 @@ import torch
 
 
 class LingBotVAFlowMatchScheduler:
-    """Flow-matching schedule used by LingBot-VA training."""
+    """Flow-matching schedule shared by LingBot-VA training and inference.
+
+    ``set_timesteps`` / ``add_noise`` / ``training_target`` / ``training_weight``
+    serve the training path; ``step`` serves the inference denoising loop. Both
+    read the same ``sigmas`` / ``timesteps`` built by ``set_timesteps``.
+    """
 
     def __init__(
         self,
@@ -20,6 +25,7 @@ class LingBotVAFlowMatchScheduler:
         sigma_min: float = 0.003 / 1.002,
         extra_one_step: bool = False,
     ) -> None:
+        """Store the schedule shape and build a default 100-step timestep table."""
         self.num_train_timesteps = num_train_timesteps
         self.shift = shift
         self.sigma_max = sigma_max
@@ -60,6 +66,27 @@ class LingBotVAFlowMatchScheduler:
         shape[t_dim] = ids.numel()
         sigma = self.sigmas[ids].to(sample).view(shape)
         return (1 - sigma) * sample + sigma * noise
+
+    def step(
+        self,
+        model_output: torch.Tensor,
+        timestep: torch.Tensor,
+        sample: torch.Tensor,
+    ) -> torch.Tensor:
+        """Take one inference denoising step (Euler step on the flow-matching ODE).
+
+        Inference-only; the training path uses ``add_noise`` / ``training_target``.
+        """
+        if not torch.is_tensor(timestep):
+            timestep = torch.tensor(timestep)
+        timesteps = self.timesteps.to(timestep.device)
+        index = int(torch.argmin((timesteps - timestep.reshape(-1)[0]).abs()))
+        sigma = self.sigmas[index].to(sample)
+        if index + 1 < len(self.sigmas):
+            sigma_next = self.sigmas[index + 1].to(sample)
+        else:
+            sigma_next = torch.zeros_like(sigma)
+        return sample + model_output * (sigma_next - sigma)
 
     @staticmethod
     def training_target(

--- a/loongforge/embodied/model/lingbot_va/modules/rollout_state.py
+++ b/loongforge/embodied/model/lingbot_va/modules/rollout_state.py
@@ -1,0 +1,175 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified from LingBot-VA under the Apache-2.0 License.
+# Copyright 2024-2025 The Robbyant Team Authors. All rights reserved.
+#
+# The rollout state machine mirrors upstream's ``wan_va/wan_va_server.py`` (``_reset`` /
+# ``_infer`` / ``_compute_kv_cache``), where the same fields are server instance
+# attributes because one server serves one episode. Here they are grouped per episode so
+# the stateless eval front end can key them by ``episode_id``.
+
+"""Per-episode autoregressive rollout state for LingBot-VA inference.
+
+LingBot-VA is a *streaming* world model: within one episode the transformer KV cache,
+the causal VAE ``feat_cache`` and the executed-action history all carry over from step
+to step. The shared eval front end (``GenericPredictActionPolicy``) is stateless and
+keyed only by ``episode_id``, so this module owns that per-episode state on the model
+side.
+
+Two facts about the eval contract shape this design:
+
+* With the default action-chunk cache the model would be called only once per chunk and
+  would never see the intermediate observations the closed-loop feedback needs. Eval
+  must therefore run with ``disable_action_cache=True`` so ``predict_action`` is invoked
+  once per env step; the action queue lives here instead of in the eval layer.
+* The transformer KV cache belongs to the (single) transformer instance and cannot be
+  partitioned per episode, so only one episode may be active at a time. A new episode is
+  recognised by ``episode_step == 0`` and tears the previous state down. An observation
+  for a *different* episode arriving mid-rollout means the caller is interleaving
+  episodes over one model instance, which cannot be served and therefore raises rather
+  than silently resetting the episode that was switched away from.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import deque
+from dataclasses import dataclass, field
+
+import torch
+
+from .wan_codec import WanVAEStreamingWrapper
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class LingBotVARolloutState:
+    """Mutable autoregressive state for exactly one episode."""
+
+    episode_id: str
+    keyframe_stride: int
+
+    # Actions of the current chunk that have not been handed to the env yet.
+    action_queue: deque = field(default_factory=deque)
+    # Raw per-frame camera dicts observed since the last chunk, awaiting VAE encoding.
+    obs_buffer: list = field(default_factory=list)
+    # Previous chunk's actions in model-normalized space, fed back into the KV cache.
+    executed_actions: torch.Tensor | None = None
+    # Latent of the very first observation; conditions the first chunk and is prepended
+    # to the first feedback so latent and action frame counts stay aligned.
+    init_latent: torch.Tensor | None = None
+
+    # Absolute latent-frame offset, used to build rope grid ids across chunks.
+    frame_st_id: int = 0
+    # Index of the action being executed within the current chunk.
+    exec_step: int = 0
+    # Sub-step index (within a predicted frame) of the last executed action.
+    prev_j: int = 0
+    first_chunk: bool = True
+    started: bool = False
+
+    # Text conditioning is constant within an episode, so it is encoded once.
+    prompt: str | None = None
+    prompt_embeds: torch.Tensor | None = None
+    negative_prompt_embeds: torch.Tensor | None = None
+
+    # Streaming VAE wrappers own the causal ``feat_cache``; they are per-episode even
+    # though the underlying VAE weights are shared.
+    streaming_vae: WanVAEStreamingWrapper | None = None
+    streaming_vae_half: WanVAEStreamingWrapper | None = None
+
+    def should_buffer_keyframe(self) -> bool:
+        """Whether the observation arriving now is on a keyframe sub-step boundary.
+
+        One keyframe every ``action_per_frame / 4`` executed sub-steps yields exactly
+        ``frame_chunk_size * 4`` frames per chunk, which the VAE's x4 temporal downsample
+        collapses back into ``frame_chunk_size`` latent frames.
+        """
+        return (self.prev_j + 1) % self.keyframe_stride == 0
+
+    def advance_exec_step(self, action_per_frame: int) -> None:
+        """Record the sub-step index of the action just handed out."""
+        self.prev_j = self.exec_step % action_per_frame
+        self.exec_step += 1
+
+    def begin_chunk(self) -> None:
+        """Clear the per-chunk observation buffer and restart the execution counter."""
+        self.obs_buffer = []
+        self.exec_step = 0
+
+
+class RolloutStateStore:
+    """Owns the single active :class:`LingBotVARolloutState` and its teardown.
+
+    Teardown is a *callback* rather than direct transformer access so this module stays
+    free of model internals: the caller passes whatever needs to happen when an episode
+    ends (clearing the transformer KV cache, dropping the streaming VAE state).
+    """
+
+    def __init__(self, on_release=None) -> None:
+        """Create an empty store; ``on_release`` runs when an episode's state is torn down."""
+        self._state: LingBotVARolloutState | None = None
+        self._on_release = on_release
+
+    @property
+    def active_episode_id(self) -> str | None:
+        """Id of the episode currently holding the state, or ``None`` when idle."""
+        return self._state.episode_id if self._state is not None else None
+
+    def get(self, episode_id: str) -> LingBotVARolloutState | None:
+        """Return the state for ``episode_id``, or ``None`` if it is not the active one."""
+        if self._state is not None and self._state.episode_id == episode_id:
+            return self._state
+        return None
+
+    def start(self, episode_id: str, keyframe_stride: int) -> LingBotVARolloutState:
+        """Release any previous episode and begin a fresh one."""
+        self.release()
+        self._state = LingBotVARolloutState(
+            episode_id=episode_id, keyframe_stride=keyframe_stride
+        )
+        return self._state
+
+    def get_or_start(
+        self, episode_id: str, keyframe_stride: int, episode_step: int
+    ) -> LingBotVARolloutState:
+        """Fetch the active state, starting a new episode when required.
+
+        A new episode begins when ``episode_step == 0``; that also covers a re-run of
+        the same id (the eval runner reuses ids across repeats), where the stale state
+        must go.
+
+        Any other id mismatch means two episodes are being interleaved over one model
+        instance. Since the transformer KV cache cannot be partitioned per episode,
+        silently starting over would reset the other episode mid-rollout and still keep
+        returning actions, i.e. corrupt the eval without failing it. That case raises.
+        """
+        state = self.get(episode_id)
+        if state is not None and episode_step != 0:
+            return state
+        if episode_step != 0:
+            active = self.active_episode_id
+            if active is not None:
+                raise RuntimeError(
+                    f"episode {episode_id!r} arrived at step {episode_step} while episode "
+                    f"{active!r} is still active. Only one episode may be active at a time "
+                    "(the transformer KV cache belongs to the model instance), so the "
+                    "interleaved episodes cannot both be served."
+                )
+            logger.warning(
+                "starting episode %r at step %d with no prior state; treating this "
+                "observation as the episode's first one",
+                episode_id,
+                episode_step,
+            )
+        return self.start(episode_id, keyframe_stride)
+
+    def release(self) -> None:
+        """Tear down the active episode's state, if any."""
+        if self._state is None:
+            return
+        if self._on_release is not None:
+            self._on_release(self._state)
+        self._state = None

--- a/loongforge/embodied/model/lingbot_va/modules/wan_codec.py
+++ b/loongforge/embodied/model/lingbot_va/modules/wan_codec.py
@@ -1,0 +1,333 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified from LingBot-VA under the Apache-2.0 License.
+# Copyright 2024-2025 The Robbyant Team Authors. All rights reserved.
+#
+# ``WanVAEStreamingWrapper`` and ``_vae_patchify`` are transcribed from upstream's
+# ``wan_va/modules/utils.py``; the causal chunk grouping enforced by ``encode_stream`` and
+# the latent normalization follow ``AutoencoderKLWan._encode`` in diffusers (Apache-2.0,
+# Copyright 2024 The HuggingFace Inc. team).
+
+"""Frozen Wan2.2 codec helpers for LingBot-VA: VAE latents and UMT5 text embeddings.
+
+LingBot-VA training consumes an *offline* preprocessed dataset whose VAE latents and
+T5 text embeddings are already materialized, so the training forward never touches
+these sub-models. Online inference has to reproduce that preprocessing, which is what
+this module provides.
+
+Everything here is a plain function or a thin stateful wrapper taking explicit
+arguments (no model config object), so the same code serves both the offline
+preprocessing scripts and the online ``predict_action`` path.
+
+The heavyweight ``diffusers`` / ``transformers`` imports are deferred into the loader
+functions: they are inference-only dependencies and must not be paid for by training,
+which imports this package's siblings.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+
+import torch
+import torch.nn.functional as F
+
+
+# ── frozen sub-model loading ─────────────────────────────────────────
+# The ~20GB LingBot-VA checkpoint does not bundle the VAE / text encoder; they are
+# loaded from ``wan_pretrained_path`` subfolders (``vae``, ``text_encoder``, ``tokenizer``).
+def load_vae(vae_path: str, torch_dtype: torch.dtype, torch_device, subfolder: str | None = None):
+    """Load the frozen Wan2.2 VAE (``AutoencoderKLWan``, ``z_dim=48``)."""
+    from diffusers import AutoencoderKLWan
+
+    vae = AutoencoderKLWan.from_pretrained(vae_path, subfolder=subfolder, torch_dtype=torch_dtype)
+    return vae.to(torch_device).eval()
+
+
+def _retie_input_embeddings(text_encoder) -> None:
+    """Alias ``encoder.embed_tokens`` to ``shared`` when the checkpoint only ships the latter.
+
+    The Wan2.2 ``text_encoder`` checkpoint stores a single ``shared.weight`` and declares
+    ``tie_word_embeddings=False``. ``transformers`` used to alias ``encoder.embed_tokens``
+    onto ``shared`` regardless; newer versions do not, so ``encoder.embed_tokens.weight``
+    loads as zeros and the encoder returns an all-zero hidden state without raising.
+    """
+    shared = getattr(text_encoder, "shared", None)
+    embed_tokens = getattr(getattr(text_encoder, "encoder", None), "embed_tokens", None)
+    if shared is None or embed_tokens is None:
+        return
+    if embed_tokens.weight.abs().sum() == 0 and shared.weight.abs().sum() != 0:
+        embed_tokens.weight = shared.weight
+
+
+def load_text_encoder(
+    text_encoder_path: str, torch_dtype: torch.dtype, torch_device, subfolder: str | None = None
+):
+    """Load the frozen UMT5 text encoder (``d_model=4096``)."""
+    from transformers import UMT5EncoderModel
+
+    text_encoder = UMT5EncoderModel.from_pretrained(
+        text_encoder_path, subfolder=subfolder, torch_dtype=torch_dtype
+    )
+    _retie_input_embeddings(text_encoder)
+    return text_encoder.to(torch_device).eval()
+
+
+def load_tokenizer(tokenizer_path: str, subfolder: str | None = None):
+    """Load the ``T5TokenizerFast`` paired with the UMT5 encoder."""
+    from transformers import T5TokenizerFast
+
+    return T5TokenizerFast.from_pretrained(tokenizer_path, subfolder=subfolder)
+
+
+# ── VAE latent normalization ─────────────────────────────────────────
+def normalize_vae_latent(enc_out: torch.Tensor, latents_mean, latents_std) -> torch.Tensor:
+    """Take the mean of a VAE encoder output and channel-normalize it.
+
+    ``enc_out`` is the raw ``quant_conv`` output holding ``[mu, logvar]`` stacked on the
+    channel axis; only ``mu`` is used (deterministic encoding, matching upstream).
+    """
+    mu, _logvar = torch.chunk(enc_out, 2, dim=1)
+    mean = torch.as_tensor(latents_mean, device=mu.device).view(1, -1, 1, 1, 1)
+    inv_std = 1.0 / torch.as_tensor(latents_std, device=mu.device).view(1, -1, 1, 1, 1)
+    return ((mu.float() - mean) * inv_std).to(mu)
+
+
+def denormalize_latents(
+    latents: torch.Tensor, latents_mean, latents_std, z_dim: int
+) -> torch.Tensor:
+    """Inverse of :func:`normalize_vae_latent`, for VAE-decoding predicted latents."""
+    mean = torch.as_tensor(latents_mean).view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
+    inv_std = (
+        1.0 / torch.as_tensor(latents_std).view(1, z_dim, 1, 1, 1).to(latents.device, latents.dtype)
+    )
+    return latents / inv_std + mean
+
+
+def _vae_patchify(x: torch.Tensor, patch_size: int | None) -> torch.Tensor:
+    """Space-to-channel patchify required by VAE variants that set ``config.patch_size``."""
+    if patch_size is None or patch_size == 1:
+        return x
+    batch_size, channels, frames, height, width = x.shape
+    x = x.view(
+        batch_size, channels, frames, height // patch_size, patch_size, width // patch_size, patch_size
+    )
+    x = x.permute(0, 1, 6, 4, 2, 3, 5).contiguous()
+    return x.view(
+        batch_size, channels * patch_size * patch_size, frames, height // patch_size, width // patch_size
+    )
+
+
+class WanVAEStreamingWrapper:
+    """Causal streaming encoder over an ``AutoencoderKLWan``.
+
+    The VAE's temporal downsample is x4, and its ``WanCausalConv3d`` layers carry a
+    ``feat_cache`` so consecutive chunks encode as if they were one continuous clip.
+    One instance therefore owns the temporal state of *one* video stream and must be
+    reset via :meth:`clear_cache` at every episode boundary — a stale cache silently
+    conditions the first chunk of a new episode on the tail of the previous one.
+    """
+
+    def __init__(self, vae_model):
+        """Wrap a loaded VAE, count its causal convs and start with an empty cache.
+
+        The conv count decides the ``feat_cache`` length, so it is read from the
+        model's precomputed counts when available and otherwise derived by walking
+        the encoder modules.
+        """
+        self.vae = vae_model
+        self.encoder = vae_model.encoder
+        self.quant_conv = vae_model.quant_conv
+
+        cached_counts = getattr(self.vae, "_cached_conv_counts", None)
+        if cached_counts is not None:
+            self.enc_conv_num = cached_counts["encoder"]
+        else:
+            self.enc_conv_num = sum(
+                1 for m in self.encoder.modules() if m.__class__.__name__ == "WanCausalConv3d"
+            )
+        self.clear_cache()
+
+    def clear_cache(self) -> None:
+        """Drop the causal conv state; call once per episode."""
+        self.feat_cache = [None] * self.enc_conv_num
+        self.frames_seen = 0
+
+    @torch.no_grad()
+    def encode_chunk(self, x_chunk: torch.Tensor) -> torch.Tensor:
+        """Encode ``[B, C, F, H, W]`` in ``[-1, 1]`` to a raw ``[mu, logvar]`` latent chunk.
+
+        ``F`` must be one causal group (see :meth:`encode_stream`); prefer that method.
+        """
+        x_chunk = _vae_patchify(x_chunk, getattr(self.vae.config, "patch_size", None))
+        feat_idx = [0]
+        out = self.encoder(x_chunk, feat_cache=self.feat_cache, feat_idx=feat_idx)
+        return self.quant_conv(out)
+
+    @torch.no_grad()
+    def encode_stream(self, x: torch.Tensor) -> torch.Tensor:
+        """Encode ``[B, C, F, H, W]`` as the next ``F`` frames of this stream.
+
+        Wan's causal encoder only accepts one *group* per :meth:`encode_chunk` call: the
+        first group of a stream is exactly 1 frame, every later group exactly 4 (the x4
+        temporal downsample, so each group yields one latent frame). Deviating either
+        crashes inside ``WanResidualDownBlock``'s ``avg_shortcut`` or, for lengths that
+        happen to broadcast, silently returns latents that differ from the reference. This
+        method splits ``x`` along those boundaries, tracking the stream position across
+        calls so consecutive observation chunks stay aligned.
+        """
+        total = x.shape[2]
+        groups = []
+        position = self.frames_seen
+        offset = 0
+        while offset < total:
+            take = 1 if position == 0 else 4 - (position - 1) % 4
+            if offset + take > total:
+                raise ValueError(
+                    f"cannot encode {total} frames from stream position {self.frames_seen}: "
+                    f"the trailing group needs {take} frames but only {total - offset} remain "
+                    "(the first group of a stream is 1 frame, later groups are 4)"
+                )
+            groups.append((offset, take))
+            offset += take
+            position += take
+        outputs = [self.encode_chunk(x[:, :, start : start + size]) for start, size in groups]
+        self.frames_seen = position
+        return outputs[0] if len(outputs) == 1 else torch.cat(outputs, dim=2)
+
+
+# ── image preprocessing ──────────────────────────────────────────────
+def prepare_camera_frame(
+    image: torch.Tensor,
+    size: tuple[int, int],
+    dtype: torch.dtype,
+    device,
+    hflip: bool = False,
+) -> torch.Tensor:
+    """Resize and rescale one camera image to a single-frame VAE clip ``[1, C, 1, H, W]``.
+
+    ``image`` is ``[C, H, W]`` or ``[1, C, H, W]`` float in ``[0, 1]``; the output is
+    scaled to ``[-1, 1]`` as the VAE expects. ``hflip`` undoes an env-side horizontal
+    flip when the eval pipeline applies one.
+    """
+    if image.dim() == 3:
+        image = image.unsqueeze(0)
+    image = image.to(device, torch.float32)
+    if hflip:
+        image = torch.flip(image, dims=[-1])
+    image = F.interpolate(image, size=size, mode="bilinear", align_corners=False)
+    image = image * 2.0 - 1.0
+    return image.unsqueeze(2).to(dtype)  # [1, C, F=1, H, W]
+
+
+@torch.no_grad()
+def encode_frames_width_concat(
+    streaming_vae: WanVAEStreamingWrapper,
+    frames_per_camera: list[list[torch.Tensor]],
+    device,
+) -> torch.Tensor:
+    """``camera_layout="width_concat"``: encode each camera, then concat latents on width.
+
+    ``frames_per_camera[c]`` is the temporal list of ``[1, C, 1, H, W]`` clips for camera
+    ``c`` (all cameras must share ``H``/``W`` and length). Cameras are batched into a
+    single :meth:`WanVAEStreamingWrapper.encode_stream` call so the x4 temporal downsample
+    collapses ``F`` input frames into ``F / 4`` latent frames under one shared
+    ``feat_cache``.
+    """
+    per_cam_videos = [torch.cat(frames, dim=2) for frames in frames_per_camera]
+    videos = torch.cat(per_cam_videos, dim=0)  # [num_cam, C, F, H, W]
+    vae_device = next(streaming_vae.vae.parameters()).device
+    enc_out = streaming_vae.encode_stream(videos.to(vae_device))
+    mu_norm = normalize_vae_latent(
+        enc_out, streaming_vae.vae.config.latents_mean, streaming_vae.vae.config.latents_std
+    )
+    video_latent = torch.cat(mu_norm.split(1, dim=0), dim=-1)
+    return video_latent.to(device)
+
+
+@torch.no_grad()
+def encode_frames_tshape(
+    streaming_vae: WanVAEStreamingWrapper,
+    streaming_vae_half: WanVAEStreamingWrapper,
+    head_frames: list[torch.Tensor],
+    left_frames: list[torch.Tensor],
+    right_frames: list[torch.Tensor],
+    device,
+) -> torch.Tensor:
+    """``camera_layout="robotwin_tshape"``: full-res head latent with half-res wrists above it.
+
+    The two wrist latents go side by side on the width axis and that strip is stacked on
+    the height axis on top of the head latent. The wrists are half resolution, so they
+    need their *own* streaming wrapper (``streaming_vae_half``) — sharing one
+    ``feat_cache`` across two different spatial shapes is invalid.
+    """
+    vae_device = next(streaming_vae.vae.parameters()).device
+    head = torch.cat(head_frames, dim=2)
+    wrists = torch.cat([torch.cat(left_frames, dim=2), torch.cat(right_frames, dim=2)], dim=0)
+    enc_high = streaming_vae.encode_stream(head.to(vae_device))
+    enc_lr = streaming_vae_half.encode_stream(wrists.to(vae_device))
+    enc_out = torch.cat([torch.cat(enc_lr.split(1, dim=0), dim=-1), enc_high], dim=-2)
+    video_latent = normalize_vae_latent(
+        enc_out, streaming_vae.vae.config.latents_mean, streaming_vae.vae.config.latents_std
+    )
+    return video_latent.to(device)
+
+
+# ── text encoding ────────────────────────────────────────────────────
+def clean_prompt(text: str) -> str:
+    """Normalize a task prompt (HTML-unescape + whitespace collapse).
+
+    Mirrors diffusers' Wan ``prompt_clean`` minus ``ftfy.fix_text``, which is a no-op for
+    the ASCII task strings used here, so the extra ``ftfy`` dependency is avoided.
+    """
+    text = html.unescape(html.unescape(text)).strip()
+    return re.sub(r"\s+", " ", text).strip()
+
+
+@torch.no_grad()
+def encode_text(
+    tokenizer,
+    text_encoder,
+    prompts: str | list[str],
+    max_sequence_length: int,
+    dtype: torch.dtype,
+    device,
+) -> torch.Tensor:
+    """Encode task prompts to UMT5 embeddings ``[B, max_sequence_length, 4096]``.
+
+    Padding tokens are zeroed rather than left as encoder output: the embeddings are
+    truncated to each prompt's true length and right-padded with zeros, matching the
+    offline preprocessing so inference sees the same conditioning as training.
+    """
+    if isinstance(prompts, str):
+        prompts = [prompts]
+    prompts = [clean_prompt(p) for p in prompts]
+
+    text_inputs = tokenizer(
+        prompts,
+        padding="max_length",
+        max_length=max_sequence_length,
+        truncation=True,
+        add_special_tokens=True,
+        return_attention_mask=True,
+        return_tensors="pt",
+    )
+    input_ids, mask = text_inputs.input_ids, text_inputs.attention_mask
+    seq_lens = mask.gt(0).sum(dim=1).long()
+
+    te_device = next(text_encoder.parameters()).device
+    embeds = text_encoder(input_ids.to(te_device), mask.to(te_device)).last_hidden_state
+    if not embeds.any():
+        raise RuntimeError(
+            "the text encoder returned an all-zero hidden state; its token embedding was "
+            "most likely left uninitialized (see _retie_input_embeddings). Conditioning on "
+            "zeros would run to completion while ignoring the task instruction."
+        )
+    embeds = embeds.to(dtype=dtype, device=device)
+    embeds = [e[:n] for e, n in zip(embeds, seq_lens, strict=False)]
+    embeds = torch.stack(
+        [torch.cat([e, e.new_zeros(max_sequence_length - e.size(0), e.size(1))]) for e in embeds],
+        dim=0,
+    )
+    return embeds.to(device)

--- a/loongforge/embodied/model/lingbot_va/modules/wan_streaming.py
+++ b/loongforge/embodied/model/lingbot_va/modules/wan_streaming.py
@@ -1,0 +1,455 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Modified from LingBot-VA under the Apache-2.0 License.
+# Copyright 2024-2025 The Robbyant Team Authors. All rights reserved.
+#
+# The KV-cache design (``update_cache`` levels, sliding ``attn_window``, per-chunk token
+# accounting) follows upstream's ``wan_va/modules/model.py``, where cache support is built
+# into the single transformer class shared by training and inference. Parts were
+# cross-checked against the LingBot-VA port in LeRobot (Apache-2.0, Copyright 2024 The
+# HuggingFace Inc. team), which is a third-party port, not the authoritative reference.
+
+"""KV-cache streaming variants of the LingBot-VA Wan transformer.
+
+These subclasses add autoregressive inference capability (single-stream forward
++ sliding-window KV cache) on top of the training-only ``wan_model`` classes,
+*without* touching the training code path. The module/parameter names are kept
+identical to ``WanTransformer3DModel`` so a training checkpoint's ``state_dict``
+loads into ``WanStreamingTransformer3DModel`` directly.
+
+Reference: the upstream LingBot-VA streaming server
+(``wan_va/wan_va_server.py``) and its LeRobot port
+(``lerobot/policies/lingbot_va/utils.py``).
+"""
+
+import math
+
+import torch
+import torch.nn as nn
+import torch.nn.functional as F
+from einops import rearrange
+
+from .flow_match import get_mesh_id
+from .wan_model import WanAttention, WanTransformerBlock, WanTransformer3DModel
+
+
+def get_mesh_id_streaming(
+    frames: int,
+    height: int,
+    width: int,
+    token_type: int,
+    frame_shift: int = 0,
+    action: bool = False,
+):
+    """Grid ids for autoregressive inference: the training grid shifted on the frame axis.
+
+    Each chunk must be placed at its *absolute* frame position within the episode, so rope
+    stays consistent with the frames already held in the KV cache. Training always starts a
+    sample at frame 0 and therefore has no need for the shift.
+
+    Shifting the frame axis after the fact is exactly equivalent to building the grid from
+    ``arange(frame_shift, frames + frame_shift)``: the frame ids are that range, and the
+    action stream's fractional per-sub-step offset is added to the same axis, so a constant
+    commutes with it. Reusing the training helper keeps a single definition of the grid.
+    """
+    grid = get_mesh_id(frames, height, width, token_type, action=action)
+    if frame_shift:
+        grid[0] = grid[0] + frame_shift
+    return grid
+
+
+def data_seq_to_patch(
+    patch_size, data_seq, latent_num_frames, latent_height, latent_width, batch_size=1
+):
+    """Reshape a flattened patch sequence back into a ``[B, C, F, H, W]`` latent grid.
+
+    Inverse of the latent stream's input patchification. Inference needs it to turn the
+    transformer's token-sequence output back into a latent grid the flow-matching
+    scheduler can step on.
+    """
+    p_t, p_h, p_w = patch_size
+    data_patch = data_seq.reshape(
+        batch_size,
+        latent_num_frames // p_t,
+        latent_height // p_h,
+        latent_width // p_w,
+        p_t,
+        p_h,
+        p_w,
+        -1,
+    )
+    data_patch = data_patch.permute(0, 7, 1, 4, 2, 5, 3, 6)
+    return data_patch.flatten(6, 7).flatten(4, 5).flatten(2, 3)
+
+
+class WanStreamingAttention(WanAttention):
+    """``WanAttention`` with a sliding-window KV cache for self-attention.
+
+    The cache lives only on self-attention modules (``cross_attention_dim_head
+    is None``). Cross-attention reuses the base-class behaviour unchanged.
+    ``update_cache`` semantics (mirrors upstream):
+
+    * ``0`` — read-only: the new key/value are temporarily stored, used for the
+      attention, then removed again (``restore_cache``).
+    * ``1`` — write as a *predicted* slot (denoising intermediate): kept in the
+      cache but flagged ``is_pred`` so ``clear_pred_cache`` can drop it later.
+    * ``2`` — write as a *real* slot (observed keyframe / executed action): kept
+      permanently for the closed-loop world-model feedback.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Build the base attention, then attach an empty cache registry for self-attention."""
+        super().__init__(*args, **kwargs)
+        # Only self-attention keeps a KV cache (cross-attention has no cache).
+        self.attn_caches = {} if not self.is_cross else None
+
+    # ── cache management ─────────────────────────────────────────────
+    def clear_pred_cache(self, cache_name: str) -> None:
+        """Invalidate the slots written as denoising intermediates, keeping the real ones."""
+        if self.attn_caches is None:
+            return
+        cache = self.attn_caches[cache_name]
+        if cache is None:
+            return
+        cache["mask"][cache["is_pred"]] = False
+
+    def clear_cache(self, cache_name: str) -> None:
+        """Drop the whole cache entry, releasing its key/value tensors."""
+        if self.attn_caches is None:
+            return
+        self.attn_caches[cache_name] = None
+
+    def init_kv_cache(
+        self,
+        cache_name: str,
+        total_token_len: int,
+        num_head: int,
+        head_dim: int,
+        device,
+        dtype,
+        batch_size: int,
+    ) -> None:
+        """Preallocate a fixed-size key/value pool plus its slot bookkeeping tensors.
+
+        The pool is bounded by ``total_token_len``, which is what makes the sliding
+        window work: slots are recycled rather than appended, so memory stays flat
+        over an arbitrarily long episode.
+        """
+        if self.attn_caches is None:
+            return
+        self.attn_caches[cache_name] = {
+            "k": torch.empty([batch_size, total_token_len, num_head, head_dim], device=device, dtype=dtype),
+            "v": torch.empty([batch_size, total_token_len, num_head, head_dim], device=device, dtype=dtype),
+            "id": torch.full((total_token_len,), -1, device=device),
+            "mask": torch.zeros((total_token_len,), dtype=torch.bool, device=device),
+            "is_pred": torch.zeros((total_token_len,), dtype=torch.bool, device=device),
+        }
+
+    def allocate_slots(self, cache_name: str, key_size: int):
+        """Reserve ``key_size`` free slots, evicting the oldest entries when the pool is full.
+
+        Eviction order is by write id, which is what implements the sliding attention
+        window: the oldest chunks fall out of the cache as new ones arrive.
+        """
+        cache = self.attn_caches[cache_name]
+        mask = cache["mask"]
+        ids = cache["id"]
+        free = (~mask).nonzero(as_tuple=False).squeeze(-1)
+
+        if free.numel() < key_size:
+            # Evict the oldest used slots to make room (ring-buffer behaviour).
+            used = mask.nonzero(as_tuple=False).squeeze(-1)
+            used_ids = ids[used]
+            order = torch.argsort(used_ids)
+            need = key_size - free.numel()
+            to_free = used[order[:need]]
+            mask[to_free] = False
+            ids[to_free] = -1
+            free = (~mask).nonzero(as_tuple=False).squeeze(-1)
+
+        if free.numel() < key_size:
+            raise RuntimeError(f"KV cache exhausted: need {key_size} free slots, have {free.numel()}.")
+        return free[:key_size]
+
+    def _next_cache_id(self, cache_name: str):
+        """Return the write id to stamp on the next batch of slots (monotonic per cache)."""
+        ids = self.attn_caches[cache_name]["id"]
+        mask = self.attn_caches[cache_name]["mask"]
+        if mask.any():
+            return ids[mask].max() + 1
+        return torch.tensor(0, device=ids.device, dtype=ids.dtype)
+
+    def update_cache(self, cache_name: str, key, value, is_pred: bool):
+        """Write one key/value block into the pool and return the slots it occupies.
+
+        ``is_pred`` marks the block as a denoising intermediate so ``clear_pred_cache``
+        can drop it once the chunk's final value is known.
+        """
+        cache = self.attn_caches[cache_name]
+        key_size = key.shape[1]
+        slots = self.allocate_slots(cache_name, key_size)
+        new_id = self._next_cache_id(cache_name)
+        cache["k"][:, slots] = key
+        cache["v"][:, slots] = value
+        cache["mask"][slots] = True
+        cache["id"][slots] = new_id
+        cache["is_pred"][slots] = is_pred
+        return slots
+
+    def restore_cache(self, cache_name: str, slots) -> None:
+        """Release slots written by a read-only call, leaving the cache as it was."""
+        self.attn_caches[cache_name]["mask"][slots] = False
+
+    # ── forward ──────────────────────────────────────────────────────
+    def forward(self, q, k, v, rotary_emb=None, update_cache=0, cache_name="pos"):
+        """Attend over the incoming tokens plus every valid slot in the KV cache.
+
+        See the class docstring for the three ``update_cache`` levels. Cross-attention
+        modules have no cache and degrade to plain attention over ``k`` / ``v``.
+        """
+        kv_cache = (
+            self.attn_caches[cache_name]
+            if (self.attn_caches is not None) and (cache_name in self.attn_caches)
+            else None
+        )
+
+        query = self.norm_q(self.to_q(q)).unflatten(2, (self.heads, -1))
+        key = self.norm_k(self.to_k(k)).unflatten(2, (self.heads, -1))
+        value = self.to_v(v).unflatten(2, (self.heads, -1))
+        if rotary_emb is not None:
+            query = self._apply_rotary(query, rotary_emb)
+            key = self._apply_rotary(key, rotary_emb)
+
+        slots = None
+        if kv_cache is not None and kv_cache["k"] is not None:
+            slots = self.update_cache(cache_name, key, value, is_pred=(update_cache == 1))
+            key_pool = self.attn_caches[cache_name]["k"]
+            value_pool = self.attn_caches[cache_name]["v"]
+            mask = self.attn_caches[cache_name]["mask"]
+            valid = mask.nonzero(as_tuple=False).squeeze(-1)
+            key = key_pool[:, valid]
+            value = value_pool[:, valid]
+
+        hidden_states = F.scaled_dot_product_attention(
+            query.transpose(1, 2), key.transpose(1, 2), value.transpose(1, 2)
+        ).transpose(1, 2)
+
+        if update_cache == 0 and slots is not None:
+            self.restore_cache(cache_name, slots)
+
+        hidden_states = hidden_states.flatten(2)
+        hidden_states = hidden_states.type_as(query)
+        hidden_states = self.to_out[0](hidden_states)
+        hidden_states = self.to_out[1](hidden_states)
+        return hidden_states
+
+
+class WanStreamingTransformerBlock(WanTransformerBlock):
+    """``WanTransformerBlock`` whose self-attention keeps a KV cache."""
+
+    def __init__(self, dim, ffn_dim, num_heads, cross_attn_norm=False, eps=1e-6, attn_mode="torch"):
+        """Build the base block, then swap in the cache-capable self-attention module."""
+        super().__init__(dim, ffn_dim, num_heads, cross_attn_norm, eps, attn_mode)
+        # Replace the base self-attention with the streaming variant; parameter
+        # names are unchanged so a training checkpoint still loads.
+        head_dim = dim // num_heads
+        self.attn1 = WanStreamingAttention(
+            dim, num_heads, head_dim, eps, cross_attention_dim_head=None, attn_mode=attn_mode
+        )
+
+    def forward(
+        self,
+        hidden_states,
+        encoder_hidden_states,
+        temb,
+        rotary_emb,
+        update_cache=0,
+        cache_name="pos",
+    ):
+        """Run the block, forwarding the cache controls to self-attention.
+
+        Identical in arithmetic to the base block; the only additions are the
+        ``update_cache`` / ``cache_name`` passthrough.
+        """
+        # ``temb`` is the [B, L, 6, C] modulation tensor produced by
+        # ``WanTransformer3DModel._time_embed``.
+        modulation = self.scale_shift_table[None] + temb.float()
+        shift, scale, gate, ff_shift, ff_scale, ff_gate = rearrange(
+            modulation, "b l n c -> b n l c"
+        ).chunk(6, dim=1)
+
+        # 1. Self-attention (with KV cache)
+        normed = self.norm1(hidden_states.float())
+        normed = (normed * (1 + scale.squeeze(1)) + shift.squeeze(1)).to(hidden_states.dtype)
+        self_update = self.attn1(
+            normed,
+            normed,
+            normed,
+            rotary_emb,
+            update_cache=update_cache,
+            cache_name=cache_name,
+        )
+        hidden_states = (hidden_states.float() + self_update * gate.squeeze(1)).to(hidden_states.dtype)
+
+        # 2. Cross-attention (no cache)
+        if isinstance(self.norm2, nn.Identity):
+            cross_input = hidden_states
+        else:
+            cross_input = self.norm2(hidden_states.float()).to(hidden_states.dtype)
+        cross_update = self.attn2(cross_input, encoder_hidden_states, encoder_hidden_states)
+        hidden_states = hidden_states + cross_update
+
+        # 3. Feed-forward
+        normed = self.norm3(hidden_states.float())
+        normed = (normed * (1 + ff_scale.squeeze(1)) + ff_shift.squeeze(1)).to(hidden_states.dtype)
+        ffn_update = self.ffn(normed)
+        hidden_states = (hidden_states.float() + ffn_update.float() * ff_gate.squeeze(1)).to(
+            hidden_states.dtype
+        )
+        return hidden_states
+
+
+class WanStreamingTransformer3DModel(WanTransformer3DModel):
+    """Dual-stream Wan transformer with autoregressive KV-cache inference.
+
+    Training still goes through the base class ``forward`` (``train_mode=True``
+    delegates to the inherited dual-stream path). Inference uses the single-stream
+    ``forward`` below, which processes one stream (video latent or action) at a
+    time and updates/reads the KV cache.
+    """
+
+    def __init__(self, *args, **kwargs):
+        """Build the base model, then rebuild its blocks with streaming attention."""
+        super().__init__(*args, **kwargs)
+        # Rebuild the transformer blocks with streaming attention. Parameter
+        # names are unchanged (``blocks.N.attn1.*``) so training checkpoints load.
+        inner_dim = self.config.num_attention_heads * self.config.attention_head_dim
+        self.blocks = nn.ModuleList(
+            [
+                WanStreamingTransformerBlock(
+                    inner_dim,
+                    self.config.ffn_dim,
+                    self.config.num_attention_heads,
+                    self.config.cross_attn_norm,
+                    self.config.eps,
+                    attn_mode=self.config.attn_mode,
+                )
+                for _ in range(self.config.num_layers)
+            ]
+        )
+
+    # ── KV-cache management ──────────────────────────────────────────
+    def clear_cache(self, cache_name: str) -> None:
+        """Release the named cache on every block, e.g. at an episode boundary."""
+        for block in self.blocks:
+            block.attn1.clear_cache(cache_name)
+
+    def clear_pred_cache(self, cache_name: str) -> None:
+        """Drop the denoising intermediates on every block, keeping the real slots."""
+        for block in self.blocks:
+            block.attn1.clear_pred_cache(cache_name)
+
+    def create_empty_cache(
+        self,
+        cache_name: str,
+        attn_window: int,
+        latent_token_per_chunk: int,
+        action_token_per_chunk: int,
+        device,
+        dtype,
+        batch_size: int,
+    ) -> None:
+        """Allocate the per-block KV pools sized for one sliding ``attn_window``.
+
+        The window holds interleaved video-latent and action chunks, hence the split
+        into ``attn_window // 2`` chunks of each kind. This bound is what keeps peak
+        memory flat regardless of episode length.
+        """
+        total_token_len = (attn_window // 2) * latent_token_per_chunk + (
+            attn_window // 2
+        ) * action_token_per_chunk
+        for block in self.blocks:
+            block.attn1.init_kv_cache(
+                cache_name,
+                total_token_len,
+                self.config.num_attention_heads,
+                self.config.attention_head_dim,
+                device,
+                dtype,
+                batch_size,
+            )
+
+    # ── single-stream inference forward ──────────────────────────────
+    def forward(self, input_dict, update_cache=0, cache_name="pos", action_mode=False, train_mode=False):
+        """Run one stream through the transformer, or delegate to the training path.
+
+        ``train_mode=True`` forwards to the base class's dual-stream training path
+        untouched. Otherwise a single stream is processed: ``action_mode`` selects the
+        action embedder / projection, and the video-latent path patchifies its input.
+        ``update_cache`` and ``cache_name`` are handed to self-attention.
+        """
+        if train_mode:
+            # Training dual-stream path (inherited from the base class).
+            return super().forward(input_dict)
+
+        if action_mode:
+            # Action input embedding: [B, C, F, apf, 1] -> [B, F*apf, C]
+            latent_hidden_states = rearrange(input_dict["noisy_latents"], "b c f h w -> b (f h w) c")
+            latent_hidden_states = self.action_embedder(latent_hidden_states)
+        else:
+            # Video-latent input embedding with patchification.
+            latent_hidden_states = rearrange(
+                input_dict["noisy_latents"],
+                "b c (f p1) (h p2) (w p3) -> b (f h w) (c p1 p2 p3)",
+                p1=self.patch_size[0],
+                p2=self.patch_size[1],
+                p3=self.patch_size[2],
+            )
+            latent_hidden_states = self.patch_embedding_mlp(latent_hidden_states)
+
+        text_hidden_states = self.condition_embedder.text_embedder(input_dict["text_emb"])
+
+        latent_grid_id = input_dict["grid_id"]
+        rotary_emb = self.rope(latent_grid_id)[:, :, None]  # [1, L, 1, C]
+        patch_scale_h, patch_scale_w = (1, 1) if action_mode else (self.patch_size[1], self.patch_size[2])
+
+        latent_time_steps = torch.repeat_interleave(
+            input_dict["timesteps"],
+            (input_dict["noisy_latents"].shape[-2] // patch_scale_h)
+            * (input_dict["noisy_latents"].shape[-1] // patch_scale_w),
+            dim=1,
+        )
+        current_condition_embedder = (
+            self.condition_embedder_action if action_mode else self.condition_embedder
+        )
+        temb, timestep_proj = current_condition_embedder(latent_time_steps, dtype=latent_hidden_states.dtype)
+        timestep_proj = timestep_proj.unflatten(2, (6, -1))  # [B, L, 6, C]
+
+        for block in self.blocks:
+            latent_hidden_states = block(
+                latent_hidden_states,
+                text_hidden_states,
+                timestep_proj,
+                rotary_emb,
+                update_cache=update_cache,
+                cache_name=cache_name,
+            )
+
+        temb_scale_shift_table = self.scale_shift_table[None] + temb[:, :, None, ...]
+        shift, scale = rearrange(temb_scale_shift_table, "b l n c -> b n l c").chunk(2, dim=1)
+        shift = shift.to(latent_hidden_states.device).squeeze(1)
+        scale = scale.to(latent_hidden_states.device).squeeze(1)
+        latent_hidden_states = (self.norm_out(latent_hidden_states.float()) * (1.0 + scale) + shift).type_as(
+            latent_hidden_states
+        )
+
+        if action_mode:
+            latent_hidden_states = self.action_proj_out(latent_hidden_states)
+        else:
+            latent_hidden_states = self.proj_out(latent_hidden_states)
+            latent_hidden_states = rearrange(
+                latent_hidden_states, "b l (n c) -> b (l n) c", n=math.prod(self.patch_size)
+            )
+
+        return latent_hidden_states


### PR DESCRIPTION
## Summary
- Add LingBot_VA online inference API (modeling, flow matching, rollout state, WAN codec/streaming)
- Integrate LingBot_VA into the eval framework (factory, payload builder, action decoder, RoboTwin bridge)

## Changes
- **Inference**: new `modeling_lingbot_va_infer.py`, `wan_codec.py`, `wan_streaming.py`, `rollout_state.py`; extend `flow_match.py`
- **Eval integration**: new `lingbot_va_factory.py`, `lingbot_va.py` payload builder, `ee_quat.py` action decoder; extend `registry.py`, `orchestrator/config.py`, `libero_runner.py`, `robotwin_policy.py`, `loongforge_policy.py`, `loongforge_server.py`
- **Examples**: add LIBERO and RoboTwin eval configs/scripts for LingBot_VA

## Test Plan
- Verified via internal eval runs on LIBERO (`libero_10`) and RoboTwin (`adjust_bottle`) benchmarks