### PR TITLE
[data] fix: compact invalid-sample warnings to prevent oversized logs

### DIFF
--- a/loongforge/data/sft_format_utils.py
+++ b/loongforge/data/sft_format_utils.py
@@ -181,7 +181,15 @@ def _convert_sharegpt(
 
         for turn_idx, message in enumerate(messages):
             if message[sharegpt_tags.role_tag] not in accept_tags[turn_idx % 2]:
-                logger.warning(f"Invalid role tag in: {messages}, skipping.")
+                # Don't dump `messages`: one line per invalid sample made >100MB logs.
+                logger.warning(
+                    "Invalid role tag at turn %d (role=%r); roles=%s, "
+                    "total_chars=%d, skipping.",
+                    turn_idx,
+                    message[sharegpt_tags.role_tag],
+                    [m.get(sharegpt_tags.role_tag) for m in messages],
+                    sum(len(m.get(sharegpt_tags.content_tag) or "") for m in messages),
+                )
                 invalid_data = True
                 break
 
@@ -193,7 +201,14 @@ def _convert_sharegpt(
             )
 
         if len(aligned_messages) % 2 != 0:
-            logger.warning(f"Invalid number of turns in: {messages}, skipping.")
+            # Compact form — see the "Invalid role tag" warning above.
+            logger.warning(
+                "Invalid number of turns (%d); roles=%s, total_chars=%d, "
+                "skipping.",
+                len(aligned_messages),
+                [m["role"] for m in aligned_messages],
+                sum(len(m["content"]) for m in aligned_messages),
+            )
             invalid_data = True
 
         if invalid_data:

--- a/loongforge/data/sft_supervised_utils.py
+++ b/loongforge/data/sft_supervised_utils.py
@@ -368,9 +368,11 @@ def _preprocess_supervised_dataset(
                 len(samples["prompt"][i]) % 2 != 1
                 or len(samples["response"][i]) != 1
             ):
+                # Compact form: dumping full payloads made >100MB log files.
                 logger.warning(
-                    f"Ignore invalid sample, prompt: {samples['prompt'][i]}, "
-                    f"response: {samples['response'][i]}"
+                    "Ignore invalid sample: %d prompt msgs, %d response msgs.",
+                    len(samples["prompt"][i]),
+                    len(samples["response"][i]),
                 )
                 continue
 


### PR DESCRIPTION
## Summary

- Replace full ShareGPT payload dumps in invalid-role and odd-turn warnings with compact role and character-count metadata.
- Replace invalid legacy supervised-sample payload dumps with prompt and response message counts.
- Preserve the existing validation and sample-skipping behavior.

## Motivation

Malformed samples can contain very large message payloads. Serializing those payloads into warnings can produce oversized log files, while compact metadata keeps the warnings useful without dumping sample content.

## Validation

- Exercised the ShareGPT invalid-role and legacy supervised invalid-sample paths with a 1 MB payload and verified the payload content is omitted from warnings.
- Compiled both changed Python files.
- Built the source distribution and wheel with `uv build`.
- Ran `git diff --check`.
