### PR TITLE
[data] feat: support text-only children in PackedMultiMixQASample

### DIFF
--- a/loongforge/data/multimodal/base/task_encoder.py
+++ b/loongforge/data/multimodal/base/task_encoder.py
@@ -511,37 +511,52 @@ def cooker_packed_multi_mix_qa(sample: dict):
     images = None
     videos = None
 
-
     if media_type == "image":
         images = []
-        for group in media_files:
+        for idx, group in enumerate(media_files):
             image_group = []
             if isinstance(group, (list, tuple)):
                 for name in group:
                     img = sample.get(name)
-                    if img is not None:
-                        image_group.append(img)
+                    if img is None:
+                        raise ValueError(
+                            f"[cooker_packed_multi_mix_qa] missing image media '{name}' "
+                            f"for key={sample['__key__']}.q{idx:03d}"
+                        )
+                    image_group.append(img)
             elif isinstance(group, str):
                 img = sample.get(group)
-                if img is not None:
-                    image_group.append(img)
+                if img is None:
+                    raise ValueError(
+                        f"[cooker_packed_multi_mix_qa] missing image media '{group}' "
+                        f"for key={sample['__key__']}.q{idx:03d}"
+                    )
+                image_group.append(img)
             images.append(image_group)
         if all(len(g) == 0 for g in images):
             images = None
         videos = None
     elif media_type == "video":
         videos = []
-        for group in media_files:
+        for idx, group in enumerate(media_files):
             video_group = []
             if isinstance(group, (list, tuple)):
                 for name in group:
                     vid = sample.get(name)
-                    if vid is not None:
-                        video_group.append(vid)
+                    if vid is None:
+                        raise ValueError(
+                            f"[cooker_packed_multi_mix_qa] missing video media '{name}' "
+                            f"for key={sample['__key__']}.q{idx:03d}"
+                        )
+                    video_group.append(vid)
             elif isinstance(group, str):
                 vid = sample.get(group)
-                if vid is not None:
-                    video_group.append(vid)
+                if vid is None:
+                    raise ValueError(
+                        f"[cooker_packed_multi_mix_qa] missing video media '{group}' "
+                        f"for key={sample['__key__']}.q{idx:03d}"
+                    )
+                video_group.append(vid)
             videos.append(video_group)
 
         if all(len(g) == 0 for g in videos):

--- a/loongforge/data/multimodal/vlm_task_encoder.py
+++ b/loongforge/data/multimodal/vlm_task_encoder.py
@@ -671,25 +671,28 @@ class VLMTaskEncoder(BaseTaskEncoder):
         images = sample.images if sample.images is not None else []
         videos = sample.videos if sample.videos is not None else []
 
-        has_images = len(images) > 0
-        has_videos = len(videos) > 0
-        if has_images and has_videos:
+        if images and videos:
             raise ValueError(
                 f"encode_packed_multi_mix_qa: cannot mix images and videos in same sample for key={sample.__key__}"
             )
-        has_text_only = not has_images and not has_videos
-        media_list = images if has_images else videos
-        media_type = "image" if has_images else ("video" if has_videos else "text")
 
-        if not has_text_only and len(media_list) != n_orig_sample:
+        if images and len(images) != n_orig_sample:
             raise ValueError(
-                f"encode_packed_multi_mix_qa: media count ({len(media_list)}) "
+                f"encode_packed_multi_mix_qa: image count ({len(images)}) "
+                f"!= context count ({n_orig_sample}) for key={sample.__key__}"
+            )
+        if videos and len(videos) != n_orig_sample:
+            raise ValueError(
+                f"encode_packed_multi_mix_qa: video count ({len(videos)}) "
                 f"!= context count ({n_orig_sample}) for key={sample.__key__}"
             )
         for idx in range(n_orig_sample):
             contexts = sample.contexts[idx]
-            media_group = None if has_text_only else media_list[idx]  # List[Tensor] or List[AVData]
+            image_group = images[idx] if images else None
+            video_group = videos[idx] if videos else None
             answers = sample.answers[idx]
+            child_has_images = image_group is not None and len(image_group) > 0
+            child_has_videos = video_group is not None and len(video_group) > 0
 
             if not isinstance(contexts, (list, tuple)):
                 raise TypeError(
@@ -716,27 +719,27 @@ class VLMTaskEncoder(BaseTaskEncoder):
             for context, answer in zip(contexts, answers):
                 messages.append({"role": "user", "content": context})
                 messages.append({"role": "assistant", "content": answer})
-            if has_images:
+            if child_has_images:
                 init_kwargs = {
                     "__key__": f"{sample.__key__}.q{idx:03d}",
                     "__restore_key__": sample.__restore_key__,
                     "__subflavors__": sample.__subflavors__,
                     "messages": messages,
-                    "image": media_group,
+                    "image": image_group,
                     "video": None,
                     "system": system,
                 }
                 if _ENERGON_NEEDS_SUBFLAVOR:
                     init_kwargs["__subflavor__"] = None
                 cur_sample = MultiMixQASample(**init_kwargs)
-            elif has_videos:
+            elif child_has_videos:
                 init_kwargs = {
                     "__key__": f"{sample.__key__}.q{idx:03d}",
                     "__restore_key__": sample.__restore_key__,
                     "__subflavors__": sample.__subflavors__,
                     "messages": messages,
                     "image": None,
-                    "video": media_group,  # List[AVData]
+                    "video": video_group,  # List[AVData]
                     "system": system,
                 }
                 if _ENERGON_NEEDS_SUBFLAVOR:

--- a/loongforge/data/multimodal/vlm_task_encoder.py
+++ b/loongforge/data/multimodal/vlm_task_encoder.py
@@ -50,6 +50,12 @@ VIDEO_TOKEN = "<|video_pad|>"
 VISION_TAGS = ["<|vision_start|>", "<|vision_end|>"]
 IMAGE_TOKEN_WITH_TAGS = VISION_TAGS[0] + IMAGE_TOKEN + VISION_TAGS[1]
 VIDEO_TOKEN_WITH_TAGS = VISION_TAGS[0] + VIDEO_TOKEN + VISION_TAGS[1]
+IMAGE_PLACEHOLDERS = ("<image>", IMAGE_TOKEN, IMAGE_TOKEN_WITH_TAGS)
+VIDEO_PLACEHOLDERS = ("<video>", VIDEO_TOKEN, VIDEO_TOKEN_WITH_TAGS)
+
+
+def _contains_any(text: str, needles: Tuple[str, ...]) -> bool:
+    return any(needle in text for needle in needles)
 
 
 @dataclass
@@ -707,11 +713,30 @@ class VLMTaskEncoder(BaseTaskEncoder):
 
             contexts = list(contexts)
             answers = list(answers)
+            if not all(isinstance(context, str) for context in contexts):
+                raise TypeError(
+                    f"encode_packed_multi_mix_qa expects all contexts[{idx}] "
+                    f"turns to be str for key={sample.__key__}"
+                )
             if len(contexts) != len(answers):
                 raise ValueError(
                     f"encode_packed_multi_mix_qa: context/answer turn count mismatch "
                     f"for key={sample.__key__}.q{idx:03d}: "
                     f"{len(contexts)} vs {len(answers)}"
+                )
+            if not child_has_images and any(
+                _contains_any(context, IMAGE_PLACEHOLDERS) for context in contexts
+            ):
+                raise ValueError(
+                    f"encode_packed_multi_mix_qa: image placeholder found without "
+                    f"image tensors for key={sample.__key__}.q{idx:03d}"
+                )
+            if not child_has_videos and any(
+                _contains_any(context, VIDEO_PLACEHOLDERS) for context in contexts
+            ):
+                raise ValueError(
+                    f"encode_packed_multi_mix_qa: video placeholder found without "
+                    f"video tensors for key={sample.__key__}.q{idx:03d}"
                 )
 
             system = None


### PR DESCRIPTION
## Summary
- handle media presence per child in PackedMultiMixQASample
- allow image/video packed samples to include text-only children represented by empty media groups
- keep packed-level validation for image/video column alignment

## Why
After #150, PackedMultiMixQASample represents a packed list of full MultiMixQA child samples. In practice, an offline packed artifact can contain image/video children together with text-only children. The previous implementation inferred the media type at the whole packed-sample level, so if the packed sample had an images list, every child was treated as an image sample, including children whose image group was empty.

This change keeps the packed-level validation but decides image/video/text handling per child.

## Behavior
- image child: images[i] is non-empty, video is None
- video child: videos[i] is non-empty, image is None
- text-only child: media group is empty, image and video are None
- the packed artifact still cannot mix image and video media columns in the same packed sample
