### PR TITLE
[data] fix: avoid duplicate BOS after chat template rendering

### DIFF
--- a/loongforge/data/multimodal/llava_ov_task_encoder.py
+++ b/loongforge/data/multimodal/llava_ov_task_encoder.py
@@ -183,10 +183,10 @@ class LLavaOv15TaskEncoder(VLMTaskEncoder):
             if text[-1] == "\n":
                 text = text[:-1]
             input_ids, _, imgs, image_grid_thw, attn_mask = self._process(
-                sample.image, text
+                sample.image, text, add_special_tokens=False
             )
             target = torch.ones_like(input_ids) * IGNORE_INDEX
-            answers = self.tokenizer.tokenize(sample.answers)
+            answers = self.tokenizer.tokenize(sample.answers, add_special_tokens=False)
             target[-len(answers) - 1 : -1] = torch.tensor(answers)
             target[-1] = input_ids[-1]
             # print(target[-1])

--- a/loongforge/data/multimodal/vlm_task_encoder.py
+++ b/loongforge/data/multimodal/vlm_task_encoder.py
@@ -222,13 +222,14 @@ class VLMTaskEncoder(BaseTaskEncoder):
 
         return image
 
-    def _process(self, image, text):
+    def _process(self, image, text, add_special_tokens=True):
         """ " Process the data to get the model's input"""
         inputs = self.processor(
             text=text,
             images=image,
             padding=True,
             return_tensors="pt",
+            add_special_tokens=add_special_tokens,
         )
         input_ids = inputs["input_ids"][0]
         attn_mask = inputs["attention_mask"][0].logical_not()
@@ -261,9 +262,11 @@ class VLMTaskEncoder(BaseTaskEncoder):
         ).replace("<image>", IMAGE_TOKEN_WITH_TAGS)
         if text[-1] == "\n":
             text = text[:-1]
-        input_ids, _, imgs, image_grid_thw, attn_mask = self._process(image, text)
+        input_ids, _, imgs, image_grid_thw, attn_mask = self._process(
+            image, text, add_special_tokens=False
+        )
         target = torch.ones_like(input_ids) * IGNORE_INDEX
-        answer_ids = self.tokenizer.tokenize(answer)
+        answer_ids = self.tokenizer.tokenize(answer, add_special_tokens=False)
         target[-len(answer_ids) - 1 : -1] = torch.tensor(answer_ids)
         target[-1] = input_ids[-1]
 

--- a/loongforge/embodied/data/datasets/groot_n1_6/transforms/processor_groot_n1_6.py
+++ b/loongforge/embodied/data/datasets/groot_n1_6/transforms/processor_groot_n1_6.py
@@ -561,6 +561,7 @@ class Gr00tN1d6DataCollator:
                     padding="max_length" if self.max_length else True,
                     max_length=self.max_length,
                     truncation=self.max_length is not None,
+                    add_special_tokens=False,
                 )
                 # Detect truncation: if any sample has attention_mask all-1 with
                 # max_length set, it was truncated (no pad tokens added).

--- a/loongforge/embodied/data/datasets/groot_n1_7/transforms/groot_collator.py
+++ b/loongforge/embodied/data/datasets/groot_n1_7/transforms/groot_collator.py
@@ -105,6 +105,7 @@ class Gr00tN1d7DataCollator:
                     padding="max_length" if self.max_length else True,
                     max_length=self.max_length,
                     truncation=self.max_length is not None,
+                    add_special_tokens=False,
                 )
                 for vlm_key, vlm_value in vlm_inputs.items():
                     batch[vlm_key] = vlm_value


### PR DESCRIPTION
## Summary
- avoid adding special tokens twice after HF chat template rendering in VQA SFT encoding paths
- tokenize assistant labels with add_special_tokens=False after template rendering
- apply the same post-template processor behavior to Gr00t N1.6/N1.7 collators

## Why
HF chat templates can render BOS directly when called with tokenize=False, for example through {{- bos_token -}} in the template. Passing that rendered prompt to the processor with default special-token handling can prepend another BOS and produce duplicated <|begin_of_text|> in model inputs.

The assistant answer is also tokenized separately to build labels. If that tokenize call adds special tokens, decoded trainable labels can start with BOS even though the answer is not a new document.

This keeps special-token layout owned by the rendered chat template and matches the existing ChatTemplate.encode_multiturn behavior, where text segments are tokenized with add_special_tokens=False.

## Example
```
[decoded_input | colored by role]
<|begin_of_text|><|begin_of_text|><|im_start|>system
You are a helpful AI assistant.<|im_end|>
<|im_start|>user
Offer a succinct explanation of the picture presented.
<|vision_start|><|image_pad|>... ...<|image_pad|><|vision_end|><|im_end|>
<|im_start|>assistant
<think>

</think>

7.62x39-HP icon.png<|im_end|>
... ...
[decoded_trainable_labels]
<|begin_of_text|><think>

</think>

7.62x39-HP icon.png<|im_end|>... ...

```