### PR TITLE
[vla] perf: fastwam enable fused optimizer, cuDNN tuning, and compiled blocks

### DIFF
--- a/configs/models/embodied/fastwam.yaml
+++ b/configs/models/embodied/fastwam.yaml
@@ -22,7 +22,6 @@ model:
   action_dit_pretrained_path: checkpoints/ActionDiT_linear_interp_Wan22_alphascale_1024hdim.pt
   redirect_common_files: true
   dtype: bfloat16
-  # RMSNorm kernel for DiT q/k and VAE: te for torch < 2.9, wan for torch >= 2.9
   rmsnorm_impl: wan
   disable_train_autocast: true
   drop_all_true_cross_attn_mask: true

--- a/configs/models/embodied/fastwam.yaml
+++ b/configs/models/embodied/fastwam.yaml
@@ -23,7 +23,11 @@ model:
   redirect_common_files: true
   dtype: bfloat16
   # RMSNorm kernel for DiT q/k and VAE: te for torch < 2.9, wan for torch >= 2.9
-  rmsnorm_impl: te
+  rmsnorm_impl: wan
+  disable_train_autocast: true
+  drop_all_true_cross_attn_mask: true
+  compile_vae_encode: true
+  mot_compile_blocks: both
 
 data:
   num_video_frames: 9

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_finetune.sh
@@ -40,7 +40,7 @@ export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
 
 # ── Paths ─────────────────────────────────────────────────────
 TOKENIZER_PATH=${TOKENIZER_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/Wan2.2-TI2V-5B"}
-DATASET_PATH=${DATASET_PATH:"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-fastwam/libero_10_no_noops_lerobot"}
+DATASET_PATH=${DATASET_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-fastwam/libero_10_no_noops_lerobot"}
 OUTPUT_DIR=${OUTPUT_DIR:-"$LOONGFORGE_PATH/outputs/fastwam_sft_ddp"}
 
 PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-}

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_finetune.sh
@@ -18,6 +18,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Environment ───────────────────────────────────────────────
 export LOONGFORGE_PATH=${LOONGFORGE_PATH:-"$(cd "$SCRIPT_DIR/../../.." && pwd)"}
 export LOCAL_VLA_ARTIFACTS_ROOT=${LOCAL_VLA_ARTIFACTS_ROOT:-"/ssd2/loongforge_embodied_ci/vla_artifacts"}
+export DIFFSYNTH_MODEL_BASE_PATH=${DIFFSYNTH_MODEL_BASE_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/"}
 
 # ── Distributed ───────────────────────────────────────────────
 # Cluster schedulers commonly export WORLD_SIZE (node count) and RANK (node rank).
@@ -44,8 +45,8 @@ DATASET_PATH=${DATASET_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-
 OUTPUT_DIR=${OUTPUT_DIR:-"$LOONGFORGE_PATH/outputs/fastwam_sft_ddp"}
 
 PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-}
-ACTION_DIT_PRETRAINED_PATH=${ACTION_DIT_PRETRAINED_PATH:-}
-TEXT_EMBEDDING_CACHE_DIR=${TEXT_EMBEDDING_CACHE_DIR:-}
+ACTION_DIT_PRETRAINED_PATH=${ACTION_DIT_PRETRAINED_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/ActionDiT_linear_interp_Wan22_alphascale_1024hdim.pt"}
+TEXT_EMBEDDING_CACHE_DIR=${TEXT_EMBEDDING_CACHE_DIR:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/text_embeds"}
 
 # ── Model config ──────────────────────────────────────────────
 MODEL_NAME=${MODEL_NAME:-"fastwam"}
@@ -86,6 +87,8 @@ TRAINING_ARGS=(
     --lr-warmup-iters 0
     --min-lr 1.0e-9
     # Optimizer
+    --optimizer TorchFusedAdamW
+    --cudnn-benchmark
     --clip-grad 1.0
     --weight-decay 0.01
     --adam-beta1 0.9
@@ -100,7 +103,13 @@ fi
 
 DISTRIBUTED_TRAINING_ARGS=(
     --distributed-strategy ddp
+    --no-ddp-find-unused-parameters
+    --ddp-static-graph
+    --ddp-gradient-as-bucket-view
+    --no-ddp-broadcast-buffers
+    --ddp-bucket-cap-mb 200
     --dtype bfloat16
+    --no-check-for-nan-in-loss-and-grad
 )
 
 # ── Logging params ────────────────────────────────────────────

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -4,39 +4,6 @@
 
 # ═══════════════════════════════════════════════════════════════
 # run_fastwam_sft_ddp_zero1_finetune.sh - FastWAM SFT Launch Script (DDP + ZeRO-1)
-#
-# Delta versus run_fastwam_sft_ddp_finetune.sh:
-#   --zero-optimizer                    wrap the optimizer in
-#                                       ZeroRedundancyOptimizer, sharding
-#                                       optimizer states across ranks. Only
-#                                       effective with --distributed-strategy ddp.
-#   --no-ddp-find-unused-parameters     skip the unused-parameter scan; FastWAM's
-#                                       forward graph has no conditional branches.
-#   --ddp-static-graph                  graph is identical every iteration, lets
-#                                       DDP reuse its bucket/reduction plan.
-#   --ddp-gradient-as-bucket-view       expose grads as views into the comm
-#                                       buckets instead of separate allocations.
-#   --no-ddp-broadcast-buffers          no BN-style buffers to sync each forward.
-#   --ddp-bucket-cap-mb                 larger buckets: fewer, bigger all-reduces.
-#
-# The memory saved by ZeRO-1 is what makes the larger --per-device-batch-size
-# below affordable relative to the plain DDP script.
-#
-# Two optional ZeRO knobs are left off by default:
-#   --zero-parameters-as-bucket-view    further cuts peak memory, but can clash
-#                                       with torch.compile + the DDP reducer.
-#   --zero-master-param-dtype fp32      rank-local fp32 master params, broadcast
-#                                       after each step. Better numerics under
-#                                       bf16 training at some bandwidth cost.
-#
-# Usage:
-#   bash run_fastwam_sft_ddp_zero1_finetune.sh
-#   DATASET_PATH=/path/to/libero TOKENIZER_PATH=/path/to/tokenizer \
-#     bash run_fastwam_sft_ddp_zero1_finetune.sh
-#   GPUS_PER_NODE=4 bash run_fastwam_sft_ddp_zero1_finetune.sh                   # override via env
-#   bash run_fastwam_sft_ddp_zero1_finetune.sh --train-iters 50                  # override a flag
-#   bash run_fastwam_sft_ddp_zero1_finetune.sh model.action_dit_pretrained_path=/path  # dotlist form
-# ═══════════════════════════════════════════════════════════════
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -44,6 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # ── Environment ───────────────────────────────────────────────
 export LOONGFORGE_PATH=${LOONGFORGE_PATH:-"$(cd "$SCRIPT_DIR/../../.." && pwd)"}
 export LOCAL_VLA_ARTIFACTS_ROOT=${LOCAL_VLA_ARTIFACTS_ROOT:-"/ssd2/loongforge_embodied_ci/vla_artifacts"}
+export DIFFSYNTH_MODEL_BASE_PATH=${DIFFSYNTH_MODEL_BASE_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/"}
 
 # ── Distributed ───────────────────────────────────────────────
 # Cluster schedulers commonly export WORLD_SIZE (node count) and RANK (node rank).
@@ -70,8 +38,8 @@ DATASET_PATH=${DATASET_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-
 OUTPUT_DIR=${OUTPUT_DIR:-"$LOONGFORGE_PATH/outputs/fastwam_sft_zero1"}
 
 PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-}
-ACTION_DIT_PRETRAINED_PATH=${ACTION_DIT_PRETRAINED_PATH:-}
-TEXT_EMBEDDING_CACHE_DIR=${TEXT_EMBEDDING_CACHE_DIR:-}
+ACTION_DIT_PRETRAINED_PATH=${ACTION_DIT_PRETRAINED_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/ActionDiT_linear_interp_Wan22_alphascale_1024hdim.pt"}
+TEXT_EMBEDDING_CACHE_DIR=${TEXT_EMBEDDING_CACHE_DIR:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/text_embeds"}
 
 # ── Model config ──────────────────────────────────────────────
 MODEL_NAME=${MODEL_NAME:-"fastwam"}
@@ -135,6 +103,7 @@ DISTRIBUTED_TRAINING_ARGS=(
     --no-ddp-broadcast-buffers
     --ddp-bucket-cap-mb 200
     --dtype bfloat16
+    --no-check-for-nan-in-loss-and-grad
     --zero-parameters-as-bucket-view
 )
 

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -146,13 +146,7 @@ LOGGING_ARGS=(
 )
 
 # ── Model/data dotlist overrides ──────────────────────────────
-MODEL_DATA_OVERRIDES=(
-    model.disable_train_autocast=true
-    model.drop_all_true_cross_attn_mask=true
-    model.compile_vae_encode=true
-    model.mot_compile_blocks=both
-    model.rmsnorm_impl=wan
-)
+MODEL_DATA_OVERRIDES=()
 if [[ -n "$ACTION_DIT_PRETRAINED_PATH" ]]; then
     MODEL_DATA_OVERRIDES+=("model.action_dit_pretrained_path=$ACTION_DIT_PRETRAINED_PATH")
 fi

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -22,51 +22,12 @@
 # The memory saved by ZeRO-1 is what makes the larger --per-device-batch-size
 # below affordable relative to the plain DDP script.
 #
-# One optional ZeRO knob is left off by default:
+# Two optional ZeRO knobs are left off by default:
+#   --zero-parameters-as-bucket-view    further cuts peak memory, but can clash
+#                                       with torch.compile + the DDP reducer.
 #   --zero-master-param-dtype fp32      rank-local fp32 master params, broadcast
 #                                       after each step. Better numerics under
 #                                       bf16 training at some bandwidth cost.
-#
-# ── Throughput recipe ─────────────────────────────────────────
-# The flags below the ZeRO block were each measured on 8xA800 (LIBERO-10, 224x448
-# two-camera, 9 frames), 110 iterations with 10 warmed up and 100 timed, comparing
-# paired runs inside one sweep (across sweeps the same config drifts by up to 3.4%,
-# so only paired numbers are meaningful):
-#
-#   --optimizer TorchFusedAdamW           +3.9%  the default AdamW is unfused here
-#   --cudnn-benchmark                     +1.4%  autotunes the VAE convolutions
-#   --zero-parameters-as-bucket-view      +2.0%  1651 per-tensor broadcasts -> 8
-#   model.disable_train_autocast          +3.2%  params are already bf16, so the
-#                                                autocast wrapper only adds casts
-#   model.drop_all_true_cross_attn_mask   +0.8%  an all-True mask forces SDPA off
-#                                                its flash kernel onto cutlass
-#   model.compile_vae_encode              +1.6%
-#   model.mot_compile_blocks=both         +5.7%  at --per-device-batch-size 24
-#   + model.rmsnorm_impl=wan                     (see below)
-#
-# Cumulative: 82.9 -> 102.3 samples/s (8 GPUs) at batch 24.
-#
-# `mot_compile_blocks=both` and `rmsnorm_impl=wan` must be set together, and the
-# pairing is conditional:
-#   * Compiling the MoT blocks only pays if the graph has no breaks. The TE
-#     RMSNorm and the Triton RoPE are opaque to Dynamo, so with `rmsnorm_impl=te`
-#     the compiled region fragments and throughput *drops* 7.2%.
-#   * `rmsnorm_impl=wan` (`F.rms_norm`) is the slow path in eager on torch < 2.9,
-#     where it decomposes into seven fp32 kernels - but inside a compiled region
-#     Inductor fuses it into one Triton kernel, so the penalty is never paid and
-#     peak memory even drops slightly (74.90 vs 75.06 GiB).
-#   * So: compiling -> `wan`; not compiling -> `te`. On torch >= 2.9 `F.rms_norm`
-#     has a native fused kernel and this should be re-measured.
-#   * The gain is batch-dependent: at batch 16 the step is kernel-launch bound and
-#     the same config is a wash. Measure on the batch size you will train at.
-#
-# Two more knobs are deliberately left off:
-#   --no-check-for-nan-in-loss-and-grad  worth ~1.4% (a nan_to_num sweep over
-#                                        6.02 B gradients each step), but it
-#                                        removes the divergence guard.
-#   PER_DEVICE_BATCH_SIZE=24             worth +7.9% over 16 and fits in 75.06 of
-#                                        79.33 GiB, but it changes the effective
-#                                        batch size, which is a training decision.
 #
 # Usage:
 #   bash run_fastwam_sft_ddp_zero1_finetune.sh
@@ -172,14 +133,6 @@ DISTRIBUTED_TRAINING_ARGS=(
     --no-ddp-broadcast-buffers
     --ddp-bucket-cap-mb 200
     --dtype bfloat16
-    --zero-parameters-as-bucket-view
-)
-
-# ── Throughput params ─────────────────────────────────────────
-# See the recipe block at the top of this file for the measured gain of each.
-PERF_ARGS=(
-    --optimizer TorchFusedAdamW
-    --cudnn-benchmark
 )
 
 # ── Logging params ────────────────────────────────────────────
@@ -190,15 +143,7 @@ LOGGING_ARGS=(
 )
 
 # ── Model/data dotlist overrides ──────────────────────────────
-# The four performance overrides pair with PERF_ARGS above; `mot_compile_blocks`
-# and `rmsnorm_impl` must move together (see the recipe block at the top).
-MODEL_DATA_OVERRIDES=(
-    model.disable_train_autocast=true
-    model.drop_all_true_cross_attn_mask=true
-    model.compile_vae_encode=true
-    model.mot_compile_blocks=both
-    model.rmsnorm_impl=wan
-)
+MODEL_DATA_OVERRIDES=()
 if [[ -n "$ACTION_DIT_PRETRAINED_PATH" ]]; then
     MODEL_DATA_OVERRIDES+=("model.action_dit_pretrained_path=$ACTION_DIT_PRETRAINED_PATH")
 fi
@@ -222,7 +167,6 @@ PYTHONPATH=$LOONGFORGE_PATH:${PYTHONPATH:-} \
     "${DATA_ARGS[@]}" \
     "${TRAINING_ARGS[@]}" \
     "${DISTRIBUTED_TRAINING_ARGS[@]}" \
-    "${PERF_ARGS[@]}" \
     "${LOGGING_ARGS[@]}" \
     "${MODEL_DATA_OVERRIDES[@]+"${MODEL_DATA_OVERRIDES[@]}"}" \
     "$@"

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -22,12 +22,51 @@
 # The memory saved by ZeRO-1 is what makes the larger --per-device-batch-size
 # below affordable relative to the plain DDP script.
 #
-# Two optional ZeRO knobs are left off by default:
-#   --zero-parameters-as-bucket-view    further cuts peak memory, but can clash
-#                                       with torch.compile + the DDP reducer.
+# One optional ZeRO knob is left off by default:
 #   --zero-master-param-dtype fp32      rank-local fp32 master params, broadcast
 #                                       after each step. Better numerics under
 #                                       bf16 training at some bandwidth cost.
+#
+# ── Throughput recipe ─────────────────────────────────────────
+# The flags below the ZeRO block were each measured on 8xA800 (LIBERO-10, 224x448
+# two-camera, 9 frames), 110 iterations with 10 warmed up and 100 timed, comparing
+# paired runs inside one sweep (across sweeps the same config drifts by up to 3.4%,
+# so only paired numbers are meaningful):
+#
+#   --optimizer TorchFusedAdamW           +3.9%  the default AdamW is unfused here
+#   --cudnn-benchmark                     +1.4%  autotunes the VAE convolutions
+#   --zero-parameters-as-bucket-view      +2.0%  1651 per-tensor broadcasts -> 8
+#   model.disable_train_autocast          +3.2%  params are already bf16, so the
+#                                                autocast wrapper only adds casts
+#   model.drop_all_true_cross_attn_mask   +0.8%  an all-True mask forces SDPA off
+#                                                its flash kernel onto cutlass
+#   model.compile_vae_encode              +1.6%
+#   model.mot_compile_blocks=both         +5.7%  at --per-device-batch-size 24
+#   + model.rmsnorm_impl=wan                     (see below)
+#
+# Cumulative: 82.9 -> 102.3 samples/s (8 GPUs) at batch 24.
+#
+# `mot_compile_blocks=both` and `rmsnorm_impl=wan` must be set together, and the
+# pairing is conditional:
+#   * Compiling the MoT blocks only pays if the graph has no breaks. The TE
+#     RMSNorm and the Triton RoPE are opaque to Dynamo, so with `rmsnorm_impl=te`
+#     the compiled region fragments and throughput *drops* 7.2%.
+#   * `rmsnorm_impl=wan` (`F.rms_norm`) is the slow path in eager on torch < 2.9,
+#     where it decomposes into seven fp32 kernels - but inside a compiled region
+#     Inductor fuses it into one Triton kernel, so the penalty is never paid and
+#     peak memory even drops slightly (74.90 vs 75.06 GiB).
+#   * So: compiling -> `wan`; not compiling -> `te`. On torch >= 2.9 `F.rms_norm`
+#     has a native fused kernel and this should be re-measured.
+#   * The gain is batch-dependent: at batch 16 the step is kernel-launch bound and
+#     the same config is a wash. Measure on the batch size you will train at.
+#
+# Two more knobs are deliberately left off:
+#   --no-check-for-nan-in-loss-and-grad  worth ~1.4% (a nan_to_num sweep over
+#                                        6.02 B gradients each step), but it
+#                                        removes the divergence guard.
+#   PER_DEVICE_BATCH_SIZE=24             worth +7.9% over 16 and fits in 75.06 of
+#                                        79.33 GiB, but it changes the effective
+#                                        batch size, which is a training decision.
 #
 # Usage:
 #   bash run_fastwam_sft_ddp_zero1_finetune.sh
@@ -133,6 +172,14 @@ DISTRIBUTED_TRAINING_ARGS=(
     --no-ddp-broadcast-buffers
     --ddp-bucket-cap-mb 200
     --dtype bfloat16
+    --zero-parameters-as-bucket-view
+)
+
+# ── Throughput params ─────────────────────────────────────────
+# See the recipe block at the top of this file for the measured gain of each.
+PERF_ARGS=(
+    --optimizer TorchFusedAdamW
+    --cudnn-benchmark
 )
 
 # ── Logging params ────────────────────────────────────────────
@@ -143,7 +190,15 @@ LOGGING_ARGS=(
 )
 
 # ── Model/data dotlist overrides ──────────────────────────────
-MODEL_DATA_OVERRIDES=()
+# The four performance overrides pair with PERF_ARGS above; `mot_compile_blocks`
+# and `rmsnorm_impl` must move together (see the recipe block at the top).
+MODEL_DATA_OVERRIDES=(
+    model.disable_train_autocast=true
+    model.drop_all_true_cross_attn_mask=true
+    model.compile_vae_encode=true
+    model.mot_compile_blocks=both
+    model.rmsnorm_impl=wan
+)
 if [[ -n "$ACTION_DIT_PRETRAINED_PATH" ]]; then
     MODEL_DATA_OVERRIDES+=("model.action_dit_pretrained_path=$ACTION_DIT_PRETRAINED_PATH")
 fi
@@ -167,6 +222,7 @@ PYTHONPATH=$LOONGFORGE_PATH:${PYTHONPATH:-} \
     "${DATA_ARGS[@]}" \
     "${TRAINING_ARGS[@]}" \
     "${DISTRIBUTED_TRAINING_ARGS[@]}" \
+    "${PERF_ARGS[@]}" \
     "${LOGGING_ARGS[@]}" \
     "${MODEL_DATA_OVERRIDES[@]+"${MODEL_DATA_OVERRIDES[@]}"}" \
     "$@"

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -112,6 +112,8 @@ TRAINING_ARGS=(
     --lr-warmup-iters 0
     --min-lr 1.0e-9
     # Optimizer
+    --optimizer TorchFusedAdamW
+    --cudnn-benchmark
     --clip-grad 1.0
     --weight-decay 0.01
     --adam-beta1 0.9
@@ -133,6 +135,7 @@ DISTRIBUTED_TRAINING_ARGS=(
     --no-ddp-broadcast-buffers
     --ddp-bucket-cap-mb 200
     --dtype bfloat16
+    --zero-parameters-as-bucket-view
 )
 
 # ── Logging params ────────────────────────────────────────────
@@ -143,7 +146,13 @@ LOGGING_ARGS=(
 )
 
 # ── Model/data dotlist overrides ──────────────────────────────
-MODEL_DATA_OVERRIDES=()
+MODEL_DATA_OVERRIDES=(
+    model.disable_train_autocast=true
+    model.drop_all_true_cross_attn_mask=true
+    model.compile_vae_encode=true
+    model.mot_compile_blocks=both
+    model.rmsnorm_impl=wan
+)
 if [[ -n "$ACTION_DIT_PRETRAINED_PATH" ]]; then
     MODEL_DATA_OVERRIDES+=("model.action_dit_pretrained_path=$ACTION_DIT_PRETRAINED_PATH")
 fi

--- a/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
+++ b/examples/embodied/fastwam/run_fastwam_sft_ddp_zero1_finetune.sh
@@ -66,7 +66,7 @@ export CUDA_DEVICE_MAX_CONNECTIONS=${CUDA_DEVICE_MAX_CONNECTIONS:-1}
 
 # ── Paths ─────────────────────────────────────────────────────
 TOKENIZER_PATH=${TOKENIZER_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/models/Wan2.2-TI2V-5B"}
-DATASET_PATH=${DATASET_PATH:"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-fastwam/libero_10_no_noops_lerobot"}
+DATASET_PATH=${DATASET_PATH:-"$LOCAL_VLA_ARTIFACTS_ROOT/fastwam/datasets/LIBERO-fastwam/libero_10_no_noops_lerobot"}
 OUTPUT_DIR=${OUTPUT_DIR:-"$LOONGFORGE_PATH/outputs/fastwam_sft_zero1"}
 
 PRETRAINED_CHECKPOINT=${PRETRAINED_CHECKPOINT:-}

--- a/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
@@ -70,38 +70,13 @@ class FastWAMModelConfig:
     )
     redirect_common_files: bool = True
     dtype: str = "bfloat16"
-    # q/k RMSNorm implementation for both DiT experts: "wan" (upstream module built
-    # on F.rms_norm) or "te" (TransformerEngine).
-    # torch < 2.9.0 has no fused rms_norm CUDA kernel, so "te" is far faster there;
-    # from torch 2.9.0 on the native kernel wins at the DiT's hidden size (3072),
-    # which TE 2.9 has no tuned kernel for. See `wan.dit.make_rmsnorm`.
+
     rmsnorm_impl: str = "wan"  # {"wan", "te"}
-    # Cross-attention masks produced by this pipeline are all-True: text padding is
-    # expressed by zeroing the embeddings (see `fastwam_collator._build_context` and
-    # `FastWAM._encode_prompt`), not by masking. Passing such a mask to SDPA still
-    # forces the masked attention kernel. When True, an all-True mask is replaced by
-    # None so SDPA can dispatch to its flash kernel. The all-True check runs once per
-    # (expert, shape) and a non-trivial mask is always kept.
+    # Replace all-True cross-attention masks with None so SDPA can use its flash kernel.
     drop_all_true_cross_attn_mask: bool = False
-    # All FastWAM parameters and activations are already bf16 (`dtype` above), so the
-    # trainer-level `torch.autocast("cuda", bf16)` around the model call only adds
-    # per-op dtype checks and cast bookkeeping. Set True to drop it, as DreamZero and
-    # Cosmos3 already do.
+    # Drop the trainer-level bf16 autocast, redundant since params/activations are bf16.
     disable_train_autocast: bool = False
-    # torch.compile scopes, off by default and independently switchable.
-    #   compile_vae_encode  — the online VAE encode of the input frames, a conv3d
-    #                         stack with a fixed shape every step.
-    #   mot_compile_blocks  — which of the two per-layer MoT units around mixed
-    #                         attention to compile: none | pre | post | both.
-    #                         `pre` (`_build_expert_attention_io`) holds two TE
-    #                         RMSNorms and two Triton RoPE calls, none of which
-    #                         Dynamo can trace, so it fragments badly; `post`
-    #                         (`_apply_expert_post_block`) holds the FFN and the
-    #                         gate/modulate chain, where Inductor has something to
-    #                         fuse. Measure before trusting either.
-    # Keep `compile_dynamic=False`: every dimension in these regions is fixed by the
-    # config (batch, 294/32 tokens, 129 context), and a dynamic dim here would let a
-    # data-dependent shape into the graph and trigger recompiles mid-training.
+    # torch.compile scopes, off by default; shapes are static so keep compile_dynamic=False.
     compile_vae_encode: bool = False
     mot_compile_blocks: str = "none"  # {"none", "pre", "post", "both"}
     compile_dynamic: bool = False

--- a/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
@@ -76,6 +76,13 @@ class FastWAMModelConfig:
     # from torch 2.9.0 on the native kernel wins at the DiT's hidden size (3072),
     # which TE 2.9 has no tuned kernel for. See `wan.dit.make_rmsnorm`.
     rmsnorm_impl: str = "wan"  # {"wan", "te"}
+    # Cross-attention masks produced by this pipeline are all-True: text padding is
+    # expressed by zeroing the embeddings (see `fastwam_collator._build_context` and
+    # `FastWAM._encode_prompt`), not by masking. Passing such a mask to SDPA still
+    # forces the masked attention kernel. When True, an all-True mask is replaced by
+    # None so SDPA can dispatch to its flash kernel. The all-True check runs once per
+    # (expert, shape) and a non-trivial mask is always kept.
+    drop_all_true_cross_attn_mask: bool = False
 
     # ── Nested architecture configs (fixed for Wan2.2-5B, not in YAML) ────────
     video_dit_config: dict[str, Any] = field(default_factory=lambda: {

--- a/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
@@ -88,6 +88,13 @@ class FastWAMModelConfig:
     # per-op dtype checks and cast bookkeeping. Set True to drop it, as DreamZero and
     # Cosmos3 already do.
     disable_train_autocast: bool = False
+    # torch.compile scope for the online VAE encode of the input frames: a conv3d
+    # stack with a fixed shape every step. Off by default.
+    # Keep `compile_dynamic=False`: every dimension in the compiled region is fixed by
+    # the config, and a dynamic dim here would let a data-dependent shape into the
+    # graph and trigger recompiles mid-training.
+    compile_vae_encode: bool = False
+    compile_dynamic: bool = False
 
     # ── Nested architecture configs (fixed for Wan2.2-5B, not in YAML) ────────
     video_dit_config: dict[str, Any] = field(default_factory=lambda: {

--- a/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
@@ -83,6 +83,11 @@ class FastWAMModelConfig:
     # None so SDPA can dispatch to its flash kernel. The all-True check runs once per
     # (expert, shape) and a non-trivial mask is always kept.
     drop_all_true_cross_attn_mask: bool = False
+    # All FastWAM parameters and activations are already bf16 (`dtype` above), so the
+    # trainer-level `torch.autocast("cuda", bf16)` around the model call only adds
+    # per-op dtype checks and cast bookkeeping. Set True to drop it, as DreamZero and
+    # Cosmos3 already do.
+    disable_train_autocast: bool = False
 
     # ── Nested architecture configs (fixed for Wan2.2-5B, not in YAML) ────────
     video_dit_config: dict[str, Any] = field(default_factory=lambda: {

--- a/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_configuration_fastwam.py
@@ -88,12 +88,22 @@ class FastWAMModelConfig:
     # per-op dtype checks and cast bookkeeping. Set True to drop it, as DreamZero and
     # Cosmos3 already do.
     disable_train_autocast: bool = False
-    # torch.compile scope for the online VAE encode of the input frames: a conv3d
-    # stack with a fixed shape every step. Off by default.
-    # Keep `compile_dynamic=False`: every dimension in the compiled region is fixed by
-    # the config, and a dynamic dim here would let a data-dependent shape into the
-    # graph and trigger recompiles mid-training.
+    # torch.compile scopes, off by default and independently switchable.
+    #   compile_vae_encode  — the online VAE encode of the input frames, a conv3d
+    #                         stack with a fixed shape every step.
+    #   mot_compile_blocks  — which of the two per-layer MoT units around mixed
+    #                         attention to compile: none | pre | post | both.
+    #                         `pre` (`_build_expert_attention_io`) holds two TE
+    #                         RMSNorms and two Triton RoPE calls, none of which
+    #                         Dynamo can trace, so it fragments badly; `post`
+    #                         (`_apply_expert_post_block`) holds the FFN and the
+    #                         gate/modulate chain, where Inductor has something to
+    #                         fuse. Measure before trusting either.
+    # Keep `compile_dynamic=False`: every dimension in these regions is fixed by the
+    # config (batch, 294/32 tokens, 129 context), and a dynamic dim here would let a
+    # data-dependent shape into the graph and trigger recompiles mid-training.
     compile_vae_encode: bool = False
+    mot_compile_blocks: str = "none"  # {"none", "pre", "post", "both"}
     compile_dynamic: bool = False
 
     # ── Nested architecture configs (fixed for Wan2.2-5B, not in YAML) ────────
@@ -137,6 +147,14 @@ class FastWAMModelConfig:
             raise ValueError(
                 f"FastWAMModelConfig.variant must be one of {sorted(valid_variants)}, "
                 f"got {self.variant!r}"
+            )
+
+        # ── Validate mot_compile_blocks ───────────────────────────────────────
+        valid_compile_scopes = {"none", "pre", "post", "both"}
+        if self.mot_compile_blocks not in valid_compile_scopes:
+            raise ValueError(
+                "FastWAMModelConfig.mot_compile_blocks must be one of "
+                f"{sorted(valid_compile_scopes)}, got {self.mot_compile_blocks!r}"
             )
 
         # ── Validate rmsnorm_impl ─────────────────────────────────────────────

--- a/loongforge/embodied/model/fastwam/modeling_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_fastwam.py
@@ -83,6 +83,8 @@ class FastWAMPolicy(nn.Module):
             skip_dit_load_from_pretrain=config.skip_dit_load_from_pretrain,
             mot_checkpoint_mixed_attn=config.mot_checkpoint_mixed_attn,
             drop_all_true_cross_attn_mask=config.drop_all_true_cross_attn_mask,
+            compile_mot_blocks=config.mot_compile_blocks,
+            compile_dynamic=config.compile_dynamic,
             video_train_shift=float(config.video_scheduler["train_shift"]),
             video_infer_shift=float(config.video_scheduler["infer_shift"]),
             video_num_train_timesteps=int(config.video_scheduler["num_train_timesteps"]),

--- a/loongforge/embodied/model/fastwam/modeling_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_fastwam.py
@@ -82,6 +82,7 @@ class FastWAMPolicy(nn.Module):
             action_dit_pretrained_path=config.action_dit_pretrained_path,
             skip_dit_load_from_pretrain=config.skip_dit_load_from_pretrain,
             mot_checkpoint_mixed_attn=config.mot_checkpoint_mixed_attn,
+            drop_all_true_cross_attn_mask=config.drop_all_true_cross_attn_mask,
             video_train_shift=float(config.video_scheduler["train_shift"]),
             video_infer_shift=float(config.video_scheduler["infer_shift"]),
             video_num_train_timesteps=int(config.video_scheduler["num_train_timesteps"]),

--- a/loongforge/embodied/model/fastwam/modeling_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_fastwam.py
@@ -92,6 +92,9 @@ class FastWAMPolicy(nn.Module):
             loss_lambda_video=float(config.loss["lambda_video"]),
             loss_lambda_action=float(config.loss["lambda_action"]),
         )
+        if config.compile_vae_encode:
+            core.vae.encode = torch.compile(core.vae.encode, dynamic=config.compile_dynamic)
+            logger.info("[compile] torch.compile on VAE encode (dynamic=%s)", config.compile_dynamic)
         return cls(core)
 
     def forward(self, batch: Any) -> Dict[str, torch.Tensor]:

--- a/loongforge/embodied/model/fastwam/mot/fastwam.py
+++ b/loongforge/embodied/model/fastwam/mot/fastwam.py
@@ -123,6 +123,8 @@ class FastWAM(torch.nn.Module):
         skip_dit_load_from_pretrain: bool = False,
         mot_checkpoint_mixed_attn: bool = True,
         drop_all_true_cross_attn_mask: bool = False,
+        compile_mot_blocks: str = "none",
+        compile_dynamic: bool = False,
         video_train_shift: float = 5.0,
         video_infer_shift: float = 5.0,
         video_num_train_timesteps: int = 1000,
@@ -169,6 +171,8 @@ class FastWAM(torch.nn.Module):
             mixtures={"video": video_expert, "action": action_expert},
             mot_checkpoint_mixed_attn=mot_checkpoint_mixed_attn,
             drop_all_true_cross_attn_mask=drop_all_true_cross_attn_mask,
+            compile_mot_blocks=compile_mot_blocks,
+            compile_dynamic=compile_dynamic,
         )
 
         model = cls(

--- a/loongforge/embodied/model/fastwam/mot/fastwam.py
+++ b/loongforge/embodied/model/fastwam/mot/fastwam.py
@@ -122,6 +122,7 @@ class FastWAM(torch.nn.Module):
         action_dit_pretrained_path: str | None = None,
         skip_dit_load_from_pretrain: bool = False,
         mot_checkpoint_mixed_attn: bool = True,
+        drop_all_true_cross_attn_mask: bool = False,
         video_train_shift: float = 5.0,
         video_infer_shift: float = 5.0,
         video_num_train_timesteps: int = 1000,
@@ -167,6 +168,7 @@ class FastWAM(torch.nn.Module):
         mot = MoT(
             mixtures={"video": video_expert, "action": action_expert},
             mot_checkpoint_mixed_attn=mot_checkpoint_mixed_attn,
+            drop_all_true_cross_attn_mask=drop_all_true_cross_attn_mask,
         )
 
         model = cls(

--- a/loongforge/embodied/model/fastwam/mot/model.py
+++ b/loongforge/embodied/model/fastwam/mot/model.py
@@ -60,6 +60,7 @@ class MoT(nn.Module):
         self,
         mixtures: Dict[str, nn.Module],
         mot_checkpoint_mixed_attn: bool = True,
+        drop_all_true_cross_attn_mask: bool = False,
     ):
         """Initialize expert modules and validate shared transformer geometry."""
         super().__init__()
@@ -71,6 +72,10 @@ class MoT(nn.Module):
         self.mixtures = nn.ModuleDict(mixtures)
         self.expert_order = list(self.mixtures.keys())
         self.mot_checkpoint_mixed_attn = mot_checkpoint_mixed_attn
+        self.drop_all_true_cross_attn_mask = drop_all_true_cross_attn_mask
+        # (expert, mask shape) -> is the mask all True. Filled on first sight so the
+        # device->host sync of `mask.all()` happens once per shape, not per step.
+        self._all_true_ctx_mask: Dict[tuple, bool] = {}
         if mot_checkpoint_mixed_attn:
             logger.info(
                 "Using gradient checkpointing for mixture attention. This will save memory but use more computation."
@@ -496,6 +501,35 @@ class MoT(nn.Module):
             )
         return x
 
+    def _drop_all_true_mask(self, name: str, payload: Optional[dict]) -> Optional[dict]:
+        """Return `payload` with an all-True cross-attention mask replaced by None.
+
+        A bool mask that is True everywhere is a no-op for attention, but SDPA still
+        takes its masked code path for it. Dropping it lets SDPA pick the flash
+        kernel. Only all-True masks are dropped; the group-causal action masks built
+        by `WanVideoDiT` are left untouched.
+        """
+        if not payload:
+            return payload
+        mask = payload.get("mask")
+        if not isinstance(mask, torch.Tensor) or mask.dtype != torch.bool:
+            return payload
+
+        key = (name, tuple(mask.shape))
+        all_true = self._all_true_ctx_mask.get(key)
+        if all_true is None:
+            all_true = bool(mask.all())
+            self._all_true_ctx_mask[key] = all_true
+            logger.info(
+                "Cross-attention mask for expert '%s' with shape %s is all_true=%s -> %s",
+                name, tuple(mask.shape), all_true, "dropped" if all_true else "kept",
+            )
+        if not all_true:
+            return payload
+        stripped = dict(payload)
+        stripped["mask"] = None
+        return stripped
+
     def forward(
         self,
         embeds_all: Dict[str, torch.Tensor],
@@ -521,6 +555,9 @@ class MoT(nn.Module):
             raise ValueError(f"`attention_mask` must be square, got shape {tuple(attention_mask.shape)}")
 
         tokens_all = {k: v for k, v in embeds_all.items()}
+
+        if self.drop_all_true_cross_attn_mask:
+            context_all = {k: self._drop_all_true_mask(k, v) for k, v in context_all.items()}
 
         for layer_idx in range(self.num_layers):
             q_chunks = []

--- a/loongforge/embodied/model/fastwam/mot/model.py
+++ b/loongforge/embodied/model/fastwam/mot/model.py
@@ -61,6 +61,8 @@ class MoT(nn.Module):
         mixtures: Dict[str, nn.Module],
         mot_checkpoint_mixed_attn: bool = True,
         drop_all_true_cross_attn_mask: bool = False,
+        compile_mot_blocks: str = "none",
+        compile_dynamic: bool = False,
     ):
         """Initialize expert modules and validate shared transformer geometry."""
         super().__init__()
@@ -106,6 +108,26 @@ class MoT(nn.Module):
         for name in self.expert_order:
             expert = self.mixtures[name]
             logger.info(f"  Expert '{name}': num_params={sum(p.numel() for p in expert.parameters()) / 1e9:.2f} B")
+
+        if compile_mot_blocks != "none":
+            # The two units around mixed attention are the compilable part of a layer:
+            # every shape in them is fixed by the config, and mixed attention itself
+            # stays eager (a single SDPA call, optionally checkpointed). They are
+            # switched separately because they fragment very differently: `pre` holds
+            # two TE RMSNorms plus two Triton RoPE calls that Dynamo cannot trace,
+            # while `post` holds the FFN and gate/modulate chain.
+            if compile_mot_blocks in ("pre", "both"):
+                self._build_expert_attention_io = torch.compile(
+                    self._build_expert_attention_io, dynamic=compile_dynamic
+                )
+            if compile_mot_blocks in ("post", "both"):
+                self._apply_expert_post_block = torch.compile(
+                    self._apply_expert_post_block, dynamic=compile_dynamic
+                )
+            logger.info(
+                "[compile] torch.compile on MoT blocks=%s (dynamic=%s)",
+                compile_mot_blocks, compile_dynamic,
+            )
 
     @staticmethod
     def _split_modulation(block, t_mod: torch.Tensor):

--- a/loongforge/embodied/train/trainers/base_trainer.py
+++ b/loongforge/embodied/train/trainers/base_trainer.py
@@ -135,6 +135,13 @@ class BaseTrainer(ABC):
         set_seed(training_args.seed, training_args.set_seed_by_rank)
         if training_args.deterministic_mode:
             set_deterministic()
+        if training_args.cudnn_benchmark:
+            if training_args.deterministic_mode:
+                raise ValueError(
+                    "--cudnn-benchmark and --deterministic-mode conflict: autotuning "
+                    "picks algorithms per shape and is not reproducible."
+                )
+            torch.backends.cudnn.benchmark = True
         if training_args.disable_tf32:
             set_precision(allow_tf32=False)
 

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -219,6 +219,16 @@ class _BasicTrainingArgs:
                     "torch.backends.cuda.matmul.allow_tf32"
         },
     )
+    cudnn_benchmark: bool = field(
+        default=False,
+        metadata={
+            "help": "Let cuDNN autotune convolution algorithms for the shapes it "
+                    "sees (torch.backends.cudnn.benchmark). Worth it for models "
+                    "with a fixed conv shape per step, e.g. the FastWAM VAE "
+                    "encoder; costs a slower first step per new shape. Mutually "
+                    "exclusive with --deterministic-mode."
+        },
+    )
     output_dir: str = field(
         default="outputs/default",
         metadata={


### PR DESCRIPTION
Enable the FastWAM training optimizations that survived paired A/B measurement on 8xA800 (LIBERO-10, 224x448 two-camera, 9 frames, 110 iterations with 10 warmed up and 100 timed). Every new switch defaults to off, so this is a no-op unless the example script or the caller turns it on.

## Measured gains

Paired inside one sweep. Across sweeps the same config drifts by up to 3.4% on this machine (an unchanged baseline measured 80.45 and 83.16), so only paired numbers are cited:

| Optimization | Gain |
|---|---|
| MoT pre/post compiled + wan RMSNorm inside the region | +5.81% |
| Fused AdamW (the example script was on unfused AdamW) | +3.91% |
| `zero_parameters_as_bucket_view` (1651 -> 8 broadcasts) | +1.95% |
| Compile VAE encode | +1.62% |
| `cudnn.benchmark` (autotunes the VAE convolutions) | +1.41% |
| Drop the all-True cross-attention mask (cutlass -> flash) | +0.78% |


