### PR TITLE
[vla] feat: support GRoot N1.7 inference and eval integration, update GRoot N1.6 files

### DIFF
--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
@@ -54,6 +54,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_close_drawer.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_close_drawer.yaml
@@ -55,6 +55,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_open_drawer.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_open_drawer.yaml
@@ -55,6 +55,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
@@ -54,6 +54,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
@@ -54,6 +54,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube.yaml
@@ -54,6 +54,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube_smoke.yaml
+++ b/examples/embodied/groot_n1_6/eval/configs/simplerenv/widowx_stack_cube_smoke.yaml
@@ -57,6 +57,11 @@ server:
 
 env:
   eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
   simplerenv_root: /path/to/SimplerEnv
   ld_library_path: /path/to/nvidia_lib
   nvidia_lib_dir: /path/to/nvidia_lib

--- a/examples/embodied/groot_n1_7/eval/configs/libero/libero_10.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/libero/libero_10.yaml
@@ -1,0 +1,83 @@
+# GR00T-N1.7 x LIBERO libero_10 task-success -- public template.
+#
+# Fill in the /path/to placeholders, or use libero_10_internal.yaml for the
+# one-click internal run.
+#
+# Official parity (Isaac-GR00T LIBERO client, examples/LIBERO/README.md):
+#   --max_episode_steps=720  -> benchmark.max_steps: 720
+#   --n_action_steps 8       -> server.chunk_execute_steps: 8
+#   no settle steps          -> benchmark.num_steps_wait: 0
+# The official protocol has no dummy settle phase, so num_steps_wait is 0 here
+# even though the repo's other LIBERO configs use 10.
+#
+# Embodiment: libero_sim (projector id 2). State layout is
+# [x, y, z, axis_angle(3), gripper_qpos(2)] -- axis-angle, NOT euler, matching
+# quat2axisangle(robot0_eef_quat) in the official LiberoEnv. Both cameras are
+# flipped 180 degrees by the LIBERO adapter, as the official client does.
+#
+# Assets:
+#   ckpt    : nvidia/GR00T-N1.7-LIBERO (per-suite subdir, e.g. libero_10/)
+#   backbone: nvidia/Cosmos-Reason2-2B (gated HF repo; supplies both the Qwen3-VL
+#             weights that get overwritten by the ckpt and the Qwen3VLProcessor)
+#   stats   : <ckpt>/statistics.json (libero_sim state/action q01/q99)
+
+benchmark:
+  name: libero
+  suite: libero_10
+  max_tasks: 1              # 0 = all 10 tasks in the suite
+  episodes_per_task: 10
+  max_steps: 720            # official --max_episode_steps
+  num_steps_wait: 0         # official path has no settle steps
+  continuous_gripper: false # official normalize_gripper_action(binarize=True)
+  control_mode: delta       # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: libero_ee_axis_angle
+  action_encoding: axis_angle
+  use_flash_attention: true
+  # Remaining structure fields (select_layer 16, backbone_embedding_dim 2048,
+  # use_alternate_vl_dit, num_inference_timesteps 4, action_horizon 40, ...)
+  # already match the checkpoint's config.json via GrootN1d7Config defaults.
+
+server:
+  host: 127.0.0.1
+  port: 13711
+  health_port: 13712
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 --
+  # the version our own pyproject.toml installs -- libero_10 scores 11/50
+  # against 46/50 on 4.57.3, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/libero/libero_10/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-LIBERO/libero_10
+  dataset_statistics_path: /path/to/GR00T-N1.7-LIBERO/libero_10/statistics.json
+  embodiment_tag: libero_sim
+  chunk_execute_steps: 8    # official --n_action_steps (chunk is 16 long)
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/libero/libero_10
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/libero/libero_goal.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/libero/libero_goal.yaml
@@ -1,0 +1,68 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x LIBERO libero_goal task-success -- official parity.
+#   --max_episode_steps=720  -> benchmark.max_steps: 720
+#   --n_action_steps 8       -> server.chunk_execute_steps: 8
+#   no settle steps          -> benchmark.num_steps_wait: 0
+# Embodiment: libero_sim. State layout [x, y, z, axis_angle(3), gripper_qpos(2)].
+# ckpt: /path/to/GR00T-N1.7-LIBERO/libero_goal
+# backbone: /path/to/Cosmos-Reason2-2B
+
+benchmark:
+  name: libero
+  suite: libero_goal
+  max_tasks: 1              # 0 = all 10 tasks in the suite
+  episodes_per_task: 10
+  max_steps: 720            # official --max_episode_steps
+  num_steps_wait: 0         # official path has no settle steps
+  continuous_gripper: false # official normalize_gripper_action(binarize=True)
+  control_mode: delta       # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: libero_ee_axis_angle
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13721
+  health_port: 13722
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 --
+  # the version our own pyproject.toml installs -- libero_10 scores 11/50
+  # against 46/50 on 4.57.3, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/libero/libero_goal/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-LIBERO/libero_goal
+  dataset_statistics_path: /path/to/GR00T-N1.7-LIBERO/libero_goal/statistics.json
+  embodiment_tag: libero_sim
+  chunk_execute_steps: 8    # official --n_action_steps (chunk is 16 long)
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/libero/libero_goal
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/libero/libero_object.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/libero/libero_object.yaml
@@ -1,0 +1,73 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x LIBERO libero_object task-success -- official parity.
+#   --max_episode_steps=720  -> benchmark.max_steps: 720
+#   --n_action_steps 8       -> server.chunk_execute_steps: 8
+#   no settle steps          -> benchmark.num_steps_wait: 0
+# Embodiment: libero_sim. State layout [x, y, z, axis_angle(3), gripper_qpos(2)].
+# ckpt: /path/to/GR00T-N1.7-LIBERO/libero_object
+# backbone: /path/to/Cosmos-Reason2-2B
+#
+# The benchmark-side interpreter is chosen by BENCHMARK_PYTHON, not by this file;
+# see loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+
+benchmark:
+  name: libero
+  suite: libero_object
+  max_tasks: 1              # 0 = all 10 tasks in the suite
+  episodes_per_task: 10
+  max_steps: 720            # official --max_episode_steps
+  num_steps_wait: 0         # official path has no settle steps
+  continuous_gripper: false # official normalize_gripper_action(binarize=True)
+  control_mode: delta       # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: libero_ee_axis_angle
+  action_encoding: axis_angle
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40), not the decoded chunk length.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13731
+  health_port: 13732
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 --
+  # the version our own pyproject.toml installs -- libero_10 scores 11/50
+  # against 46/50 on 4.57.3, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/libero/libero_object/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-LIBERO/libero_object
+  dataset_statistics_path: /path/to/GR00T-N1.7-LIBERO/libero_object/statistics.json
+  embodiment_tag: libero_sim
+  chunk_execute_steps: 8    # official --n_action_steps (chunk is 16 long)
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/libero/libero_object
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/libero/libero_spatial.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/libero/libero_spatial.yaml
@@ -1,0 +1,68 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x LIBERO libero_spatial task-success -- official parity.
+#   --max_episode_steps=720  -> benchmark.max_steps: 720
+#   --n_action_steps 8       -> server.chunk_execute_steps: 8
+#   no settle steps          -> benchmark.num_steps_wait: 0
+# Embodiment: libero_sim. State layout [x, y, z, axis_angle(3), gripper_qpos(2)].
+# ckpt: /path/to/GR00T-N1.7-LIBERO/libero_spatial
+# backbone: /path/to/Cosmos-Reason2-2B
+
+benchmark:
+  name: libero
+  suite: libero_spatial
+  max_tasks: 1              # 0 = all 10 tasks in the suite
+  episodes_per_task: 10
+  max_steps: 720            # official --max_episode_steps
+  num_steps_wait: 0         # official path has no settle steps
+  continuous_gripper: false # official normalize_gripper_action(binarize=True)
+  control_mode: delta       # GR00T outputs delta EE (pos + axis-angle) + gripper
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: libero_ee_axis_angle
+  action_encoding: axis_angle
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13741
+  health_port: 13742
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 --
+  # the version our own pyproject.toml installs -- libero_10 scores 11/50
+  # against 46/50 on 4.57.3, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/libero/libero_spatial/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-LIBERO/libero_spatial
+  dataset_statistics_path: /path/to/GR00T-N1.7-LIBERO/libero_spatial/statistics.json
+  embodiment_tag: libero_sim
+  chunk_execute_steps: 8    # official --n_action_steps (chunk is 16 long)
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/libero/libero_spatial
+  seed: 7
+  save_trace: false
+  save_replay: false
+  timestamped_output: false
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_carrot_on_plate.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_carrot_on_plate, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_carrot_on_plate
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13775
+  health_port: 13776
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_carrot_on_plate/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_carrot_on_plate
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_close_drawer.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_close_drawer.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_close_drawer, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_close_drawer
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13779
+  health_port: 13780
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_close_drawer/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_close_drawer
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_open_drawer.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_open_drawer.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_open_drawer, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_open_drawer
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13781
+  health_port: 13782
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_open_drawer/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_open_drawer
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_put_eggplant_in_basket.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_put_eggplant_in_basket, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_put_eggplant_in_basket
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13771
+  health_port: 13772
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_put_eggplant_in_basket/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_put_eggplant_in_basket
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_put_eggplant_in_sink.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_put_eggplant_in_sink.yaml
@@ -1,0 +1,92 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_put_eggplant_in_sink, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+# NOTE: upstream SimplerEnv marks this task incomplete (the target is an
+# invisible dummy plane with a single xy_configs grid point), so its success
+# rate measures the task definition rather than the policy.
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_put_eggplant_in_sink
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13801
+  health_port: 13802
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_put_eggplant_in_sink/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_put_eggplant_in_sink
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_spoon_on_towel.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_spoon_on_towel, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_spoon_on_towel
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13773
+  health_port: 13774
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_spoon_on_towel/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_spoon_on_towel
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_stack_cube.yaml
+++ b/examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_stack_cube.yaml
@@ -1,0 +1,89 @@
+# Public template: replace every /path/to/... placeholder before use.
+# The internal counterpart (same name + _internal) holds the machine-specific paths.
+#
+# GR00T-N1.7 x SimplerEnv WidowX (Bridge) -- widowx_stack_cube, official parity.
+#   --max_episode_steps 300 -> benchmark.max_steps (counts INNER env steps)
+#   --n_action_steps 4      -> server.chunk_execute_steps
+#   simpler_env.make() forces prepackaged_config=True
+#
+
+benchmark:
+  name: simplerenv
+  task_name: widowx_stack_cube
+  robot_setup: widowx
+  prepackaged_config: true
+  sim_freq: 500
+  control_freq: 5
+  control_mode: arm_pd_ee_target_delta_pose_align2_gripper_pd_joint_pos
+  action_scale: 1.0
+  rotation_mode: axis_angle    # pass roll/pitch/yaw through unchanged
+  max_steps: 300
+  success_settle_steps: 0
+
+model:
+  backend: loongforge
+  model_type: Gr00tN1d7
+  base_model_path: /path/to/Cosmos-Reason2-2B
+  model_name: /path/to/Cosmos-Reason2-2B
+  state_encoding: simpler_widowx
+  action_encoding: simpler_abs_euler
+  # Do NOT set model.action_horizon: it is the DiT flow-matching sequence length
+  # fixed by the weights (40). The decoded 8-step chunk comes from the
+  # simpler_env_widowx embodiment's action delta_indices.
+  use_flash_attention: true
+
+server:
+  host: 127.0.0.1
+  port: 13777
+  health_port: 13778
+  # To reproduce the reported success rates this env must have transformers
+  # 4.57.3. The 5.x series diverges inside the Qwen3-VL backbone: on 5.3.0 -- the
+  # version our own pyproject.toml installs -- the six-task WidowX total
+  # drops from 85/120 to 35/120, and nothing in the run warns about it. See
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+  python: /path/to/conda/envs/loongforge/bin/python
+  log: /path/to/reports/groot_n1_7/simplerenv/widowx_stack_cube/policy_server.log
+  start_timeout_sec: 2400
+  random_init: false
+  ckpt_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge
+  dataset_statistics_path: /path/to/GR00T-N1.7-SimplerEnv-Bridge/statistics.json
+  embodiment_tag: simpler_env_widowx
+  chunk_execute_steps: 4       # official --n_action_steps
+  use_bf16: true
+  loongforge_root: /path/to/LoongForge-VLA
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  # SimplerEnv checkout: use the fork that NVIDIA/Isaac-GR00T pins as its
+  # `external_dependencies/SimplerEnv` submodule (github.com/squarefk/SimplerEnv,
+  # see that repo's .gitmodules). Upstream simpler-env/SimplerEnv registers
+  # neither widowx drawer task and does not expose `agent.eef_pos`. Details:
+  # loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_6.md.
+  simplerenv_root: /path/to/SimplerEnv
+  ld_library_path: /path/to/nvidia_lib
+  nvidia_lib_dir: /path/to/nvidia_lib
+  nvidia_icd_json: /path/to/nvidia_lib/10_nvidia.json
+
+run:
+  output_dir: /path/to/reports/groot_n1_7/simplerenv/widowx_stack_cube
+  seed: 0
+  episode_idx: 0
+  obj_episode_id: 0
+  save_trace: false
+  save_replay: false
+  disable_action_cache: false
+  timestamped_output: false
+
+# The SimplerEnv runner evaluates ONE episode per invocation. Under
+# prepackaged_config the env randomizes the layout from its own episode_rng,
+# seeded by `run.seed + run.episode_idx`, so `run.episode_idx` above is the
+# episode variable (not run.obj_episode_id).
+#
+# For a success rate, invoke this config once per episode (episode_idx 0, 1, 2,
+# ... 9 for the reported 10-episode numbers), giving each run its own
+# run.output_dir, then pool the per-run summaries.
+
+timeouts:
+  policy_call_ms: 600000
+  per_step_sec: 600
+  per_episode_sec: 3600

--- a/examples/embodied/groot_n1_7/eval/run_libero_eval.sh
+++ b/examples/embodied/groot_n1_7/eval/run_libero_eval.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Public: GR00T-N1.7 LIBERO libero_10 task-success.
+# Default config: configs/libero/libero_10.yaml (fill in the /path/to assets).
+#
+# To reproduce the reported success rates, the policy env named in server.python
+# must have transformers 4.57.3 installed; the 5.x series diverges inside the
+# Qwen3-VL backbone and takes libero_10 from 46/50 down to 11/50 on 5.3.0 (the
+# version our own pyproject.toml installs). For the per-task comparison
+# and where the divergence comes from, see
+# loongforge/embodied/eval/docs/patches/libero/groot_n1_7.md.
+
+set -euo pipefail
+
+REPO_ROOT=${REPO_ROOT:-/workspace/LoongForge-VLA}
+EXAMPLE_EVAL_ROOT=${EXAMPLE_EVAL_ROOT:-${REPO_ROOT}/examples/embodied/groot_n1_7/eval}
+CONFIG=${CONFIG:-${EXAMPLE_EVAL_ROOT}/configs/libero/libero_10.yaml}
+if [[ "${CONFIG}" != /* ]]; then
+  CONFIG=${REPO_ROOT}/${CONFIG}
+fi
+
+export PYTHONPATH=${REPO_ROOT}:${PYTHONPATH:-}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+# libcuda.so.<driver> lives here; without it torch silently falls back to CPU
+# and the 3B backbone appears to hang instead of failing.
+export LD_LIBRARY_PATH=${NVIDIA_LIB_DIR:-/path/to/nvidia_lib}:/usr/lib64:${LD_LIBRARY_PATH:-}
+export MUJOCO_GL=${MUJOCO_GL:-osmesa}
+export PYOPENGL_PLATFORM=${PYOPENGL_PLATFORM:-osmesa}
+# Load the Qwen3-VL / Cosmos-Reason2 backbone and its Qwen3VLProcessor from a
+# local dir instead of the gated HF repo. model.model_name in the YAML already
+# points there; this env is the override hook used when it does not.
+export COSMOS_LOCAL_PATH=${COSMOS_LOCAL_PATH:-/path/to/Cosmos-Reason2-2B}
+export HF_HUB_OFFLINE=${HF_HUB_OFFLINE:-1}
+export TRANSFORMERS_OFFLINE=${TRANSFORMERS_OFFLINE:-1}
+
+${BENCHMARK_PYTHON:-/path/to/conda/envs/libero/bin/python} -m loongforge.embodied.eval.orchestrator.run --config "${CONFIG}"

--- a/examples/embodied/groot_n1_7/eval/run_simplerenv_eval.sh
+++ b/examples/embodied/groot_n1_7/eval/run_simplerenv_eval.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Public: GR00T-N1.7 SimplerEnv WidowX (Bridge) task-success.
+# Default config: configs/simplerenv/widowx_put_eggplant_in_basket.yaml
+# (fill in the /path/to assets first).
+#
+# Pick another task with e.g.
+#   CONFIG=examples/embodied/groot_n1_7/eval/configs/simplerenv/widowx_carrot_on_plate.yaml \
+#   bash examples/embodied/groot_n1_7/eval/run_simplerenv_eval.sh
+#
+# To reproduce the reported success rates, the policy env named in server.python
+# must have transformers 4.57.3 installed; the 5.x series diverges inside the
+# Qwen3-VL backbone and drops the six-task WidowX total from 85/120 to 35/120 on
+# 5.3.0 (the version our own pyproject.toml installs). For the per-task
+# comparison and where the divergence comes from, see
+# loongforge/embodied/eval/docs/patches/simplerenv/groot_n1_7.md.
+
+set -euo pipefail
+
+REPO_ROOT=${REPO_ROOT:-/workspace/LoongForge-VLA}
+EXAMPLE_EVAL_ROOT=${EXAMPLE_EVAL_ROOT:-${REPO_ROOT}/examples/embodied/groot_n1_7/eval}
+CONFIG=${CONFIG:-${EXAMPLE_EVAL_ROOT}/configs/simplerenv/widowx_put_eggplant_in_basket.yaml}
+if [[ "${CONFIG}" != /* ]]; then
+  CONFIG=${REPO_ROOT}/${CONFIG}
+fi
+
+export PYTHONPATH=${REPO_ROOT}:${PYTHONPATH:-}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+# libcuda.so.<driver> lives here; without it torch silently falls back to CPU
+# and the 3B backbone appears to hang instead of failing.
+export LD_LIBRARY_PATH=${NVIDIA_LIB_DIR:-/path/to/nvidia_lib}:/usr/lib64:${LD_LIBRARY_PATH:-}
+# SAPIEN renders through Vulkan; point it at the driver ICD.
+export VK_ICD_FILENAMES=${VK_ICD_FILENAMES:-/path/to/nvidia_lib/10_nvidia.json}
+
+${BENCHMARK_PYTHON:-/path/to/conda/envs/simplerenv/bin/python} -m loongforge.embodied.eval.orchestrator.run --config "${CONFIG}"

--- a/loongforge/embodied/data/datasets/groot_n1_7/transforms/groot_transform.py
+++ b/loongforge/embodied/data/datasets/groot_n1_7/transforms/groot_transform.py
@@ -71,7 +71,10 @@ LIBERO_SIM_MODALITY_META = {
         "roll": {"start": 3, "end": 4},
         "pitch": {"start": 4, "end": 5},
         "yaw": {"start": 5, "end": 6},
-        "gripper": {"start": 7, "end": 8},
+        # robot0_gripper_qpos is 2D (both finger joints); the official
+        # LiberoEnv declares state.gripper with shape (2,) and the released
+        # checkpoint statistics carry 2 values per stat for this group.
+        "gripper": {"start": 6, "end": 8},
     },
     "action": {
         "x": {"start": 0, "end": 1},
@@ -93,6 +96,63 @@ LIBERO_SIM_MODALITY_CONFIG = {
     ),
     "action": ModalityConfig(
         delta_indices=list(range(16)),
+        modality_keys=["x", "y", "z", "roll", "pitch", "yaw", "gripper"],
+        action_configs=[
+            ActionConfig(
+                rep=ActionRepresentation.ABSOLUTE,
+                type=ActionType.NON_EEF,
+                format=ActionFormat.DEFAULT,
+            )
+        ]
+        * 7,
+    ),
+    "language": ModalityConfig(
+        delta_indices=[0],
+        modality_keys=["annotation.human.action.task_description"],
+    ),
+}
+
+
+SIMPLER_ENV_WIDOWX_MODALITY_META = {
+    "state": {
+        "x": {"start": 0, "end": 1},
+        "y": {"start": 1, "end": 2},
+        "z": {"start": 2, "end": 3},
+        "roll": {"start": 3, "end": 4},
+        "pitch": {"start": 4, "end": 5},
+        "yaw": {"start": 5, "end": 6},
+        # Dead channel: the Bridge statistics carry q01 == q99 == 0.0 for
+        # ``pad`` and the official ``WidowXBridgeEnv`` always feeds 0. It still
+        # has to occupy index 6 so ``gripper`` lands on index 7.
+        "pad": {"start": 6, "end": 7},
+        # 1D normalized openness in [0, 1] (1.0 = fully open), unlike
+        # ``libero_sim`` whose gripper slot is the 2D finger qpos.
+        "gripper": {"start": 7, "end": 8},
+    },
+    "action": {
+        "x": {"start": 0, "end": 1},
+        "y": {"start": 1, "end": 2},
+        "z": {"start": 2, "end": 3},
+        "roll": {"start": 3, "end": 4},
+        "pitch": {"start": 4, "end": 5},
+        "yaw": {"start": 5, "end": 6},
+        "gripper": {"start": 6, "end": 7},
+    },
+}
+
+
+# Transcribed from ``processor_config.json`` of
+# ``nvidia/GR00T-N1.7-SimplerEnv-Bridge`` (``processor_kwargs.modality_configs
+# ["simpler_env_widowx"]``): a single exterior view, an 8D state whose 7th slot
+# is a dead pad channel, and an 8-step absolute action chunk.
+SIMPLER_ENV_WIDOWX_MODALITY_CONFIG = {
+    "video": ModalityConfig(delta_indices=[0], modality_keys=["image_0"]),
+    "state": ModalityConfig(
+        delta_indices=[0],
+        modality_keys=["x", "y", "z", "roll", "pitch", "yaw", "pad", "gripper"],
+    ),
+    "action": ModalityConfig(
+        delta_indices=list(range(8)),
         modality_keys=["x", "y", "z", "roll", "pitch", "yaw", "gripper"],
         action_configs=[
             ActionConfig(
@@ -156,6 +216,7 @@ NEW_EMBODIMENT_MODALITY_CONFIG = {
 
 MODALITY_CONFIGS = {
     "libero_sim": LIBERO_SIM_MODALITY_CONFIG,
+    "simpler_env_widowx": SIMPLER_ENV_WIDOWX_MODALITY_CONFIG,
     "new_embodiment": NEW_EMBODIMENT_MODALITY_CONFIG,
 }
 
@@ -164,6 +225,10 @@ EMBODIMENT_STAT_CONFIGS = {
     "libero_sim": {
         "modality_meta": LIBERO_SIM_MODALITY_META,
         "modality_config": LIBERO_SIM_MODALITY_CONFIG,
+    },
+    "simpler_env_widowx": {
+        "modality_meta": SIMPLER_ENV_WIDOWX_MODALITY_META,
+        "modality_config": SIMPLER_ENV_WIDOWX_MODALITY_CONFIG,
     },
     "new_embodiment": {
         "modality_meta": NEW_EMBODIMENT_MODALITY_META,

--- a/loongforge/embodied/eval/README.md
+++ b/loongforge/embodied/eval/README.md
@@ -55,12 +55,14 @@ The LIBERO simulator runs in the benchmark environment; the policy server is lau
 |---|---|---|---|---|---|
 | **pi05** | ✅ task success ([lerobot/pi05_libero_finetuned_v044](https://huggingface.co/lerobot/pi05_libero_finetuned_v044)) | connectivity only | connectivity only | ✅ task success ([motus-robotics/pi0.5_robotwin2](https://huggingface.co/motus-robotics/pi0.5_robotwin2)) | connectivity only |
 | **xvla** | ✅ task success ([2toINF/X-VLA-LIBERO](https://huggingface.co/2toINF/X-VLA-LIBERO)) | connectivity only | ✅ task success ([2toINF/X-VLA-WidowX](https://huggingface.co/2toINF/X-VLA-WidowX)) | ✅ task success ([2toINF/X-VLA-RoboTwin2](https://huggingface.co/2toINF/X-VLA-RoboTwin2)) | connectivity only |
-| **GR00T-N1.6** | — | — | ✅ task success ([nvidia/GR00T-N1.6-bridge](https://huggingface.co/nvidia/GR00T-N1.6-bridge)) | — | — |
+| **GR00T-N1.6** | ✅ task success ([0xAnkitSingh/GR00T-N1.6-LIBERO](https://huggingface.co/0xAnkitSingh/GR00T-N1.6-LIBERO)) | — | ✅ task success ([nvidia/GR00T-N1.6-bridge](https://huggingface.co/nvidia/GR00T-N1.6-bridge)) | — | — |
+| **GR00T-N1.7** | ✅ task success ([nvidia/GR00T-N1.7-LIBERO](https://huggingface.co/nvidia/GR00T-N1.7-LIBERO)) | — | ✅ task success ([nvidia/GR00T-N1.7-SimplerEnv-Bridge](https://huggingface.co/nvidia/GR00T-N1.7-SimplerEnv-Bridge)) | — | — |
 
 - **Task success**: at least one episode passed the benchmark's official success criterion.
 - **Weights**: parentheses show the Hugging Face weight (`org/name`) that achieved the run.
 - **Connectivity only**: the pipeline runs with `random_init: true` and no score — either no domain weights are released, or the benchmark assets block a full run (e.g. xvla CALVIN: the weights are public, but the official online rollout needs the original-format validation dataset).
 - **—**: not supported yet — coming soon.
+- **GR00T-N1.7** additionally needs `transformers 4.57.3` in the policy env, the version Isaac-GR00T declares. The 5.3.0 our own `pyproject.toml` installs silently degrades every benchmark (`libero_10` 46/50 → 11/50, WidowX 85/120 → 35/120). See the [LIBERO](docs/patches/libero/groot_n1_7.md) / [SimplerEnv](docs/patches/simplerenv/groot_n1_7.md) guides.
 - **Detailed results**: see the per-benchmark [benchmark pages](docs/benchmarks/libero.md).
 
 ## Model Interface

--- a/loongforge/embodied/eval/adapters/simplerenv.py
+++ b/loongforge/embodied/eval/adapters/simplerenv.py
@@ -39,7 +39,13 @@ TASK_TO_ENV_NAME = {
     "widowx_carrot_on_plate": "PutCarrotOnPlateInScene-v0",
     "widowx_stack_cube": "StackGreenCubeOnYellowCubeBakedTexInScene-v0",
     "widowx_put_eggplant_in_basket": "PutEggplantInBasketScene-v0",
-    # WidowX small-drawer tasks (ported from NVIDIA's pinned SimplerEnv fork).
+    # Registered by the official GR00T env list too, but upstream marks it
+    # incomplete (TODO in both simpler_env/__init__.py and put_on_in_scene.py):
+    # the target is an invisible dummy plane and xy_configs has a single grid
+    # point, so object init is effectively fixed across episodes.
+    "widowx_put_eggplant_in_sink": "PutEggplantInSinkScene-v0",
+    # WidowX small-drawer tasks: registered only by NVIDIA's pinned SimplerEnv
+    # fork, not by upstream simpler-env/SimplerEnv.
     "widowx_open_drawer": "OpenSmallDrawerCustomInScene-v0",
     "widowx_close_drawer": "CloseSmallDrawerCustomInScene-v0",
 }

--- a/loongforge/embodied/eval/factories/groot_n1_7_factory.py
+++ b/loongforge/embodied/eval/factories/groot_n1_7_factory.py
@@ -1,0 +1,190 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GR00T-N1.7 model factory for the LoongForge eval server.
+
+GR00T-N1.7 is a multi-embodiment model. Its training-side
+``GrootN1d7Policy.predict_action(images, instructions, state=None,
+dataset_stats=None)`` already matches the shared eval contract, so this factory
+only:
+
+1. builds the policy (loading the Qwen3-VL/Cosmos backbone from
+   ``model.model_name``),
+2. optionally loads a fine-tuned checkpoint (skipped for ``random_init``),
+3. calls ``configure_predict_action(...)`` to switch the active embodiment
+   (e.g. ``libero_sim`` for LIBERO) and load statistics + the Qwen3VL processor.
+
+Unlike N1.6 there is no ``eagle_assets_path``: the Qwen3-VL processor is loaded
+from ``model.model_name`` by ``Gr00tN1d7DataCollator``, so the same local backbone
+dir serves both the weights and the tokenizer/image processor.
+
+All inference logic (state normalization, flow-matching sampling, action
+unnormalization) lives inside the training-side ``predict_action`` and is
+consumed as-is.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict
+
+import numpy as np
+
+from loongforge.embodied.eval.factories.registry import register_factory
+from loongforge.embodied.eval.servers.eval_server_config import EvalServerArgs
+from loongforge.embodied.eval.servers.loongforge_policy import PredictActionModelSpec
+from loongforge.embodied.model.groot_n1_7.model_configuration_groot_n1_7 import (
+    GrootN1d7Config,
+)
+from loongforge.embodied.model.registry import build_model
+
+
+def _load_statistics(path: str) -> Dict[str, Any]:
+    """Load the statistics JSON required by ``configure_predict_action``.
+
+    GR00T-N1.7 cannot run without statistics even under ``random_init``: the
+    embodiment's state/action normalization parameters are needed to build the
+    ``StateActionProcessor``. Accepts either checkpoint-style
+    ``{embodiment: {state, action, relative_action}}`` or raw LeRobot
+    ``{observation.state, action, ...}`` stats — the model coerces both.
+    """
+    if not path:
+        raise ValueError(
+            "GR00T-N1.7 eval requires server.dataset_statistics_path (state/action "
+            "normalization stats for the target embodiment). Provide the checkpoint's "
+            "statistics.json even for a random_init link smoke."
+        )
+    stats_path = Path(path).expanduser()
+    if not stats_path.exists():
+        raise FileNotFoundError(f"GR00T-N1.7 dataset statistics not found: {path}")
+    with stats_path.open("r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def _load_processor_kwargs(ckpt_path: str) -> Dict[str, Any]:
+    """Read the checkpoint's ``processor_config.json`` ``processor_kwargs``.
+
+    This is the serialized eval-time processor spec — the same file the official
+    Isaac-GR00T server loads — and it is the only trustworthy source for the
+    image pipeline: ``crop_fraction`` is 0.95 (not the 0.898 you get from
+    ``image_crop_size / image_target_size``) and ``letter_box_transform`` is
+    False (the training launch ``conf.yaml`` says true, and its backbone dims
+    disagree with the released weights, so it is a stale template).
+
+    Returns an empty dict when the file is absent (e.g. ``random_init`` against a
+    bare dir), letting the model fall back to the released defaults.
+    """
+    if not ckpt_path:
+        return {}
+    config_path = Path(ckpt_path).expanduser() / "processor_config.json"
+    if not config_path.exists():
+        return {}
+    with config_path.open("r", encoding="utf-8") as f:
+        return json.load(f).get("processor_kwargs") or {}
+
+
+@register_factory("gr00tn1d7")
+class GrootN1d7ModelFactory:
+    """Build a GR00T-N1.7 policy exposing the shared predict_action interface."""
+
+    model_config_cls = GrootN1d7Config
+
+    @classmethod
+    def build(
+        cls,
+        model_cfg: GrootN1d7Config,
+        server_args: EvalServerArgs,
+    ) -> PredictActionModelSpec:
+        """Create GrootN1d7Policy and return it with eval metadata.
+
+        Args:
+            model_cfg: Typed GrootN1d7Config resolved from the YAML ``model:``.
+            server_args: Typed EvalServerArgs with runtime/infra options.
+        """
+        import os
+
+        import torch
+
+        pretrained_path = (
+            str(Path(server_args.ckpt_path).expanduser()) if server_args.ckpt_path else ""
+        )
+        resolved_device = torch.device(
+            server_args.device
+            if torch.cuda.is_available() or not server_args.device.startswith("cuda")
+            else "cpu"
+        )
+
+        # Builds GrootN1d7Policy (loads the Qwen3-VL backbone from model_cfg.model_name).
+        model = build_model(model_cfg)
+        if not server_args.random_init:
+            # Load on CPU first: the backbone is already materialized on CPU here,
+            # and the checkpoint carries every backbone tensor, so a GPU-side load
+            # would double-allocate the 3B backbone before the .to(device) below.
+            model.load_pretrained(pretrained_path, device=torch.device("cpu"))
+
+        # Switch the active embodiment + load statistics / Qwen3VL processor.
+        statistics = _load_statistics(server_args.dataset_statistics_path)
+        embodiment_tag = server_args.embodiment_tag
+        model.configure_predict_action(
+            checkpoint_statistics=statistics,
+            embodiment_tag=embodiment_tag,
+            use_bf16=server_args.use_bf16,
+            # Mirror the checkpoint's own processor spec (image crop/resize) verbatim
+            # instead of re-deriving it; see _load_processor_kwargs.
+            processor_kwargs=_load_processor_kwargs(pretrained_path),
+            # Allow the startup warmup (state=None) to run; real eval steps always
+            # pass an encoded state from the PayloadBuilder.
+            validation_zero_state=True,
+        )
+
+        model = model.to(resolved_device)
+        model.eval()
+        if server_args.use_bf16 and resolved_device.type == "cuda":
+            # Eval runs the whole model in bf16 like the official server. Without
+            # this flag, GrootN1d7Policy._restore_precision_after_apply would cast
+            # the trainable action head back to fp32 right after .to(bf16) below,
+            # which is the training-side precision policy, not the eval behavior.
+            os.environ.setdefault("GROOT_ALLOW_TRAINABLE_PARAM_BF16", "1")
+            model = model.to(dtype=torch.bfloat16)
+
+        # Open-loop execution horizon: keep only the first N steps of each
+        # predicted chunk before the policy replans (official Isaac-GR00T LIBERO
+        # client uses --n_action_steps 8). 0 -> no truncation (full chunk). The
+        # generic policy then caches the truncated chunk and steps through it.
+        _chunk_execute_steps = int(getattr(server_args, "chunk_execute_steps", 0) or 0)
+        if _chunk_execute_steps > 0:
+            _orig_predict_action = model.predict_action
+
+            def _predict_action_truncate(images, instructions, state=None, dataset_stats=None, **kwargs):
+                # Extra eval payload keys (cfg_scale, unnorm_key, ...) are swallowed
+                # here and NOT forwarded: GrootN1d7Policy.predict_action does not
+                # consume them.
+                result = _orig_predict_action(
+                    images, instructions, state=state, dataset_stats=dataset_stats
+                )
+                arr = np.asarray(result)
+                if arr.ndim == 3 and arr.shape[1] > _chunk_execute_steps:
+                    arr = arr[:, :_chunk_execute_steps]
+                elif arr.ndim == 2 and arr.shape[0] > _chunk_execute_steps:
+                    arr = arr[:_chunk_execute_steps]
+                return arr
+
+            model.predict_action = _predict_action_truncate
+
+        metadata: Dict[str, Any] = {
+            "framework": "loongforge",
+            "model_type": "gr00tn1d7",
+            "embodiment_tag": embodiment_tag,
+            "ckpt_path": pretrained_path if not server_args.random_init else "random_init://gr00tn1d7",
+            "random_init": bool(server_args.random_init),
+            "loongforge_root": server_args.loongforge_root,
+            # Decoded LIBERO action dim (x, y, z, axis-angle x3, gripper).
+            "action_dim": int(model.action_dim),
+            # Per-embodiment decoded horizon (len(action delta_indices)), not the
+            # model's DiT action_horizon.
+            "action_horizon": int(model.action_horizon),
+            "chunk_execute_steps": _chunk_execute_steps if _chunk_execute_steps > 0 else None,
+            "dataset_statistics_path": server_args.dataset_statistics_path,
+        }
+        return PredictActionModelSpec(model=model, metadata=metadata)

--- a/loongforge/embodied/eval/factories/registry.py
+++ b/loongforge/embodied/eval/factories/registry.py
@@ -63,6 +63,7 @@ def _auto_import_factory_modules() -> None:
         "loongforge.embodied.eval.factories.pi05_factory",
         "loongforge.embodied.eval.factories.xvla_factory",
         "loongforge.embodied.eval.factories.groot_n1_6_factory",
+        "loongforge.embodied.eval.factories.groot_n1_7_factory",
         "loongforge.embodied.eval.factories.lingbot_va_factory",
     ]
     for mod in _FACTORY_MODULES:

--- a/loongforge/embodied/eval/orchestrator/runners/libero_runner.py
+++ b/loongforge/embodied/eval/orchestrator/runners/libero_runner.py
@@ -239,6 +239,12 @@ def run_episode(
             action_decoder.reset()
             env.reset()
             obs = env.set_init_state(initial_state)
+            # set_init_state teleports the sim but robosuite OSC controllers only
+            # refresh ee_pos/ee_ori_mat inside step(); force a sync so the first
+            # observation does not mix the pre-reset controller pose with the
+            # init-state quaternion.
+            for robot in env.env.robots:
+                robot.controller.update(force=True)
             reset_time_sec = time.time() - reset_start
 
             # Explicit benchmark.max_steps takes priority over the suite

--- a/loongforge/embodied/eval/payload_builders/groot_n1_7.py
+++ b/loongforge/embodied/eval/payload_builders/groot_n1_7.py
@@ -1,0 +1,177 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""GR00T-N1.7 PayloadBuilder.
+
+GR00T-N1.7 consumes a per-embodiment *raw* proprio state (its own
+``StateActionProcessor`` normalizes it inside ``predict_action``) plus the
+benchmark camera views.
+
+The ``libero_sim`` embodiment layout differs from N1.6's ``libero_panda`` in two
+ways that were verified against the official Isaac-GR00T LIBERO client
+(``gr00t/eval/sim/LIBERO/libero_env.py::_process_observation``) and against the
+checkpoint's own ``statistics.json``:
+
+* rotation is **axis-angle** (``quat2axisangle(robot0_eef_quat)``), not
+  intrinsic-xyz Euler as N1.6 uses;
+* the gripper slot carries the raw 2-DoF ``robot0_gripper_qpos`` at ``[6:8]``
+  (the checkpoint's ``libero_sim.state.gripper`` statistics have 2 values per
+  stat, and the official env declares ``state.gripper`` with ``shape=(2,)``).
+
+Images are packed as ``[primary, wrist]`` — the two ``libero_sim`` video views
+``image`` / ``wrist_image``. The 180-degree flip the official client applies to
+both cameras is already done by the LIBERO adapter, and the crop/resize
+pipeline runs inside ``predict_action``, so nothing image-side happens here.
+
+Action encoding is ``axis_angle``, matching the LIBERO adapter's ``axis_angle``
+action space, so the orchestrator composes an identity ActionDecoder: the
+decoded chunk ``[x, y, z, rx, ry, rz, gripper]`` is already what
+``LiberoAdapter.action_from_canonical`` consumes as a flat 7D array.
+
+The ``simpler_env_widowx`` embodiment (SimplerEnv Bridge) uses a **single**
+exterior view and an 8D state whose index 6 is a dead ``pad`` channel and whose
+index 7 is a 1D gripper openness in ``[0, 1]``; set ``state_encoding:
+simpler_widowx`` plus ``action_encoding: simpler_abs_euler`` in the YAML for that
+path. Do **not** set ``action_horizon`` there: YAML ``model:`` keys are also
+merged into ``GrootN1d7Config``, whose ``action_horizon`` is the DiT
+flow-matching sequence length (40 in the released checkpoints), and shortening it
+changes every DiT output. The decoded chunk length comes from the embodiment's
+action ``delta_indices``, not from this field.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, Optional
+
+import numpy as np
+
+from loongforge.embodied.eval.payload_builders.base import PayloadBuilder
+from loongforge.embodied.eval.payload_builders.groot_n1_6 import _encode_simpler_widowx
+from loongforge.embodied.eval.payload_builders.pi05 import _pack_images
+from loongforge.embodied.eval.payload_builders.registry import register_payload_builder
+
+logger = logging.getLogger(__name__)
+
+
+def _quat2axisangle(quat: np.ndarray) -> np.ndarray:
+    """Convert an xyzw quaternion to a 3D axis-angle vector.
+
+    Mirrors ``quat2axisangle`` in the official Isaac-GR00T LIBERO env (which is
+    robosuite's implementation): the returned vector is the rotation axis scaled
+    by the rotation angle in radians. Uses the same near-identity early return so
+    a numerically degenerate quaternion cannot produce NaNs.
+    """
+    import math
+
+    quat = np.asarray(quat, dtype=np.float64).reshape(-1)[:4]
+    # clip to guard against |w| slightly above 1 from float error
+    w = float(np.clip(quat[3], -1.0, 1.0))
+    den = math.sqrt(max(1.0 - w * w, 0.0))
+    if math.isclose(den, 0.0):
+        return np.zeros(3, dtype=np.float32)
+    return ((quat[:3] * 2.0 * math.acos(w)) / den).astype(np.float32)
+
+
+def _encode_libero_ee_axis_angle(state_raw: Dict[str, Any]) -> Optional[np.ndarray]:
+    """Build the 8D ``libero_sim`` raw state from LIBERO ee fields.
+
+    Layout (matches ``LIBERO_SIM_MODALITY_META``):
+    ``[x, y, z, rx, ry, rz, gripper_finger0, gripper_finger1]``, where the
+    rotation triple is the axis-angle of ``eef_quat`` and the gripper slot is the
+    native 2-DoF finger qpos. Returns ``None`` when the adapter did not provide
+    the ee pose, so the caller can surface a missing-proprio failure instead of
+    silently sending a zero state.
+    """
+    eef_pos = state_raw.get("eef_pos")
+    eef_quat = state_raw.get("eef_quat")
+    if eef_pos is None or eef_quat is None:
+        return None
+
+    pos = np.asarray(eef_pos, dtype=np.float32).reshape(-1)[:3]
+    axis_angle = _quat2axisangle(eef_quat)
+
+    gripper_qpos = state_raw.get("gripper_qpos")
+    if gripper_qpos is not None:
+        finger = np.asarray(gripper_qpos, dtype=np.float32).reshape(-1)
+    else:
+        finger = np.empty(0, dtype=np.float32)
+    if finger.size >= 2:
+        grip2 = finger[:2]
+    elif finger.size == 1:
+        grip2 = np.array([finger[0], -finger[0]], dtype=np.float32)
+    else:
+        grip_val = state_raw.get("gripper")
+        gv = float(grip_val) if grip_val is not None else 0.0
+        grip2 = np.array([gv, -gv], dtype=np.float32)
+
+    return np.array(
+        [pos[0], pos[1], pos[2], axis_angle[0], axis_angle[1], axis_angle[2], grip2[0], grip2[1]],
+        dtype=np.float32,
+    )
+
+
+@register_payload_builder("gr00tn1d7")
+class GrootN1d7PayloadBuilder(PayloadBuilder):
+    """GR00T-N1.7 client-side payload assembly."""
+
+    # Capability declarations (YAML-overridable via type annotations).
+    #
+    # Supported ``state_encoding`` values:
+    #   ``libero_ee_axis_angle`` — LIBERO 8D raw state [pos(3), axis_angle(3), grip, grip]
+    #   ``simpler_widowx``       — SimplerEnv Bridge 8D raw state
+    #                              [pos(3), euler(3), pad=0, gripper_openness]
+    #   ``""``                   — no state kwarg emitted
+    state_encoding: str = "libero_ee_axis_angle"
+    action_encoding: str = "axis_angle"  # x,y,z + axis-angle(3) + gripper
+    action_dim: int = 7
+    # libero_sim's action ModalityConfig uses delta_indices=range(16); the model's
+    # own action_horizon (40) is the DiT sequence length, not the decoded length.
+    # simpler_env_widowx uses delta_indices=range(8) — override in YAML.
+    action_horizon: int = 16
+
+    def _encode_state(self, canonical: Dict[str, Any]) -> Optional[np.ndarray]:
+        """Encode ``canonical.state_raw`` per ``self.state_encoding``."""
+        if not self.state_encoding:
+            return None
+        state_raw = canonical.get("state_raw") or {}
+        if self.state_encoding == "libero_ee_axis_angle":
+            return _encode_libero_ee_axis_angle(state_raw)
+        if self.state_encoding == "simpler_widowx":
+            # ``simpler_env_widowx`` and N1.6's ``oxe_widowx`` declare the same 8D
+            # layout and the official WidowXBridgeEnv wrapper is byte-identical
+            # between the two releases (``[x,y,z] + mat2euler(quat2mat(q) @
+            # default_rot.T) + pad=0 + eef_pos[7]``), so reuse the N1.6 encoder
+            # rather than forking it -- see DRAWER_调查报告 §7.2 for the gripper trap
+            # that fork would re-introduce.
+            return _encode_simpler_widowx(state_raw)
+        raise ValueError(f"Unsupported Gr00tN1d7 state_encoding: {self.state_encoding!r}")
+
+    def build(self, canonical: Dict[str, Any], ctx: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the kwargs consumed by ``GrootN1d7Policy.predict_action``."""
+        state = self._encode_state(canonical)
+        if self.state_encoding and state is None:
+            raise ValueError(
+                "Gr00tN1d7 state_encoding="
+                f"{self.state_encoding!r} could not be built: canonical state_raw is "
+                "missing the fields it needs (LIBERO: eef_pos/eef_quat; SimplerEnv: "
+                "base_pose/tcp_pose or eef_pos). Sending a zero proprio would "
+                "silently degrade the policy, so this is a hard failure."
+            )
+        images = _pack_images(canonical["images"])
+        if self.state_encoding == "simpler_widowx":
+            # Official WidowXBridgeEnv._process_observation resizes the single
+            # exterior view to 256x256 (cv2, default INTER_LINEAR) before the
+            # model; the letterbox-pad + shortest-edge + 95%-center-crop stage
+            # runs inside predict_action, not here.
+            import cv2
+
+            images = [
+                cv2.resize(np.asarray(img), (256, 256)) if img is not None else img
+                for img in images
+            ]
+        return {
+            "images": images,
+            "instructions": [str(canonical["instruction"])],
+            "state": state,
+        }

--- a/loongforge/embodied/eval/payload_builders/registry.py
+++ b/loongforge/embodied/eval/payload_builders/registry.py
@@ -44,6 +44,7 @@ def _auto_import_payload_builder_modules() -> None:
         "loongforge.embodied.eval.payload_builders.pi05",
         "loongforge.embodied.eval.payload_builders.xvla",
         "loongforge.embodied.eval.payload_builders.groot_n1_6",
+        "loongforge.embodied.eval.payload_builders.groot_n1_7",
         "loongforge.embodied.eval.payload_builders.lingbot_va",
     ]
     for mod in _MODULES:

--- a/loongforge/embodied/model/groot_n1_7/modeling_groot_n1_7.py
+++ b/loongforge/embodied/model/groot_n1_7/modeling_groot_n1_7.py
@@ -14,9 +14,11 @@ import logging
 import os
 from pathlib import Path
 import random
-from typing import Dict, Tuple
+import re
+from typing import Any, Dict, Iterable, Optional, Tuple
 
 import numpy as np
+from PIL import Image
 import torch
 from safetensors.torch import load_file
 from torch import nn
@@ -24,6 +26,21 @@ import torch.nn.functional as F
 from torch.distributions import Beta
 from transformers.feature_extraction_utils import BatchFeature
 
+from loongforge.embodied.data.datasets.groot_n1_6.transforms.processor_groot_n1_6 import (
+    StateActionProcessor,
+)
+from loongforge.embodied.data.datasets.groot_n1_7.transforms.groot_collator import (
+    Gr00tN1d7DataCollator,
+)
+from loongforge.embodied.data.datasets.groot_n1_7.transforms.groot_transform import (
+    EMBODIMENT_STAT_CONFIGS,
+    EMBODIMENT_TAG_TO_PROJECTOR_INDEX,
+    MODALITY_CONFIGS,
+    convert_lerobot_stats_to_groot_n1d7_format,
+)
+from loongforge.embodied.data.datasets.groot_n1_7.transforms.image_augmentations import (
+    build_image_transformations_albumentations,
+)
 from loongforge.embodied.model.registry import register_model
 
 from .model_configuration_groot_n1_7 import GrootN1d7Config
@@ -32,6 +49,8 @@ from .modules.embodiment_mlp import CategorySpecificMLP, MultiEmbodimentActionEn
 from .modules.qwen3_backbone import Qwen3Backbone
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_PREDICT_ACTION_EMBODIMENT_TAG = "libero_sim"
 
 
 def _module_parameter_dtype(module: nn.Module) -> torch.dtype | None:
@@ -396,6 +415,28 @@ class GrootN1d7Policy(nn.Module):
                 "local_files_only": True,
             },
         )
+        self.collator: Gr00tN1d7DataCollator | None = None
+        self.embodiment_tag = _DEFAULT_PREDICT_ACTION_EMBODIMENT_TAG
+        self.modality_config = MODALITY_CONFIGS[self.embodiment_tag]
+        self.modality_meta = EMBODIMENT_STAT_CONFIGS[self.embodiment_tag]["modality_meta"]
+        self.state_keys = list(self.modality_config["state"].modality_keys)
+        self.action_keys = list(self.modality_config["action"].modality_keys)
+        self.embodiment_id = int(EMBODIMENT_TAG_TO_PROJECTOR_INDEX[self.embodiment_tag])
+        self.raw_state_dim = max(meta["end"] for meta in self.modality_meta["state"].values())
+        self.model_action_horizon = int(config.action_horizon)
+        self.action_horizon = len(self.modality_config["action"].delta_indices)
+        self.action_dim = int(
+            max(meta["end"] for meta in self.modality_meta["action"].values())
+        )
+        self._predict_action_initialized = False
+        self._predict_action_validation_zero_state = False
+        self._predict_action_use_bf16 = bool(config.use_bf16)
+        self._predict_action_statistics: Dict[str, Any] | None = None
+        self._predict_action_use_percentiles = False
+        self._predict_action_clip_outliers = True
+        self._predict_action_default_processor: StateActionProcessor | None = None
+        self._predict_action_processor_cache: dict[str, StateActionProcessor] = {}
+        self._predict_action_eval_image_transform = None
 
     def reset_data_iterator_rng(self, seed: int) -> None:
         """Align DataLoader worker base seeds with Isaac's finetune path."""
@@ -493,6 +534,573 @@ class GrootN1d7Policy(nn.Module):
             parameter.requires_grad and parameter.dtype != torch.float32
             for module in modules
             for parameter in module.parameters()
+        )
+
+    def configure_predict_action(
+        self,
+        *,
+        checkpoint_statistics: Dict[str, Any],
+        embodiment_tag: str = _DEFAULT_PREDICT_ACTION_EMBODIMENT_TAG,
+        use_bf16: bool | None = None,
+        validation_zero_state: bool = False,
+        processor_kwargs: Dict[str, Any] | None = None,
+    ) -> None:
+        """Configure eval-side resources used by ``predict_action``.
+
+        Args:
+            checkpoint_statistics: Per-embodiment or raw-LeRobot state/action stats.
+            embodiment_tag: Which embodiment's modality config / projector to activate.
+            use_bf16: Override the config's bf16 autocast setting.
+            validation_zero_state: Allow ``state=None`` to fall back to a zero
+                proprio. Only for interface validation / server warmup.
+            processor_kwargs: The checkpoint's ``processor_config.json``
+                ``processor_kwargs``. The image pipeline params are read from it
+                verbatim because the released values are not all derivable from
+                the model config: ``crop_fraction`` is 0.95, not the
+                ``image_crop_size / image_target_size`` ratio (0.898), and
+                ``letter_box_transform`` is False even though the training launch
+                config says otherwise. Falls back to the released GR00T-N1.7
+                values when omitted.
+        """
+        if embodiment_tag not in MODALITY_CONFIGS:
+            raise ValueError(f"Unsupported GR00T-N1.7 embodiment_tag={embodiment_tag!r}")
+        if embodiment_tag not in EMBODIMENT_TAG_TO_PROJECTOR_INDEX:
+            raise ValueError(f"No projector id registered for embodiment_tag={embodiment_tag!r}")
+
+        self.embodiment_tag = embodiment_tag
+        self.modality_config = MODALITY_CONFIGS[embodiment_tag]
+        self.modality_meta = EMBODIMENT_STAT_CONFIGS[embodiment_tag]["modality_meta"]
+        self.state_keys = list(self.modality_config["state"].modality_keys)
+        self.action_keys = list(self.modality_config["action"].modality_keys)
+        self.embodiment_id = int(EMBODIMENT_TAG_TO_PROJECTOR_INDEX[embodiment_tag])
+        self.raw_state_dim = max(meta["end"] for meta in self.modality_meta["state"].values())
+        self.action_horizon = len(self.modality_config["action"].delta_indices)
+        self.model_action_horizon = int(self.config.action_horizon)
+        self.action_dim = int(
+            max(meta["end"] for meta in self.modality_meta["action"].values())
+        )
+        self._predict_action_validation_zero_state = bool(validation_zero_state)
+        self._predict_action_use_bf16 = bool(self.config.use_bf16 if use_bf16 is None else use_bf16)
+        self._predict_action_statistics = self._coerce_statistics(checkpoint_statistics)
+        self._predict_action_processor_cache = {}
+        pk = processor_kwargs or {}
+        # State/action normalization mode comes from the checkpoint, not from the
+        # StateActionProcessor defaults: the released LIBERO checkpoints set
+        # use_percentiles=true (q01/q99), while the class defaults to min/max.
+        # Getting this wrong silently rescales both the proprio fed to
+        # state_encoder and the actions returned by unapply_action.
+        self._predict_action_use_percentiles = bool(pk.get("use_percentiles", False))
+        self._predict_action_clip_outliers = bool(pk.get("clip_outliers", True))
+        self._predict_action_default_processor = self._build_state_action_processor(
+            self._predict_action_statistics
+        )
+        self.collator = Gr00tN1d7DataCollator(
+            model_name=self.config.model_name,
+            model_type=self.config.backbone_model_type,
+            transformers_loading_kwargs={"trust_remote_code": True, "local_files_only": True},
+        )
+        # Official GrootN1d7FeatureTransform eval pipeline: letterbox ->
+        # SmallestMaxSize(shortest_image_edge) -> crop_fraction center crop ->
+        # SmallestMaxSize. predict_action() applies this before building
+        # vlm_content so callers only need to supply the env's native camera image.
+        image_target_size = list(pk.get("image_target_size") or [256, 256])
+        image_crop_size = list(pk.get("image_crop_size") or [230, 230])
+        crop_fraction = pk.get("crop_fraction", 0.95)
+        shortest_image_edge = pk.get("shortest_image_edge", 256)
+        _, self._predict_action_eval_image_transform = build_image_transformations_albumentations(
+            image_target_size,
+            image_crop_size,
+            int(pk.get("random_rotation_angle") or 0),
+            None,  # color_jitter_params: train-only augmentation
+            shortest_image_edge,
+            crop_fraction,
+            # Not read from processor_config.json: the checkpoint stores
+            # letter_box_transform=false, but official Gr00tN1d7Processor marks
+            # that field "stored but not actively used" and builds LetterBoxPad
+            # unconditionally. Padding is a no-op on already-square frames.
+            letter_box_transform=True,
+        )
+        logger.info(
+            "GR00T-N1.7 eval image pipeline: target=%s crop=%s crop_fraction=%s "
+            "shortest_edge=%s letterbox=True; state/action norm: percentiles=%s clip=%s",
+            image_target_size,
+            image_crop_size,
+            crop_fraction,
+            shortest_image_edge,
+            self._predict_action_use_percentiles,
+            self._predict_action_clip_outliers,
+        )
+        self._predict_action_initialized = True
+        self.eval()
+
+    @torch.no_grad()
+    def predict_action(
+        self,
+        images,
+        instructions,
+        state=None,
+        dataset_stats=None,
+    ) -> np.ndarray:
+        """Infer an action chunk for the shared eval ``predict_action`` interface."""
+        image_batch = self._normalize_image_batch(images, instructions)
+        image_batch = self._apply_eval_image_transform(image_batch)
+        batch_size = len(image_batch)
+        instruction_batch = self._normalize_instruction_batch(instructions, batch_size)
+        processor = self._get_predict_action_processor(dataset_stats)
+        raw_state_batch = self._coerce_state_batch(state, batch_size)
+        normalized_state_batch = self._normalize_state_batch(processor, raw_state_batch)
+
+        vlm_content = [
+            self._build_vlm_content(sample_images, instruction)
+            for sample_images, instruction in zip(image_batch, instruction_batch, strict=True)
+        ]
+        inputs = {
+            "vlm_content": vlm_content,
+            "state": torch.as_tensor(
+                normalized_state_batch,
+                dtype=torch.float32,
+                device=self.model.device,
+            ),
+            "embodiment_id": torch.full(
+                (batch_size,),
+                self.embodiment_id,
+                dtype=torch.long,
+                device=self.model.device,
+            ),
+        }
+
+        self.eval()
+        normalized_actions = self._sample_normalized_actions(inputs)
+        action_np = normalized_actions.float().cpu().numpy()
+        decoded = self._decode_action_batch(processor, action_np, raw_state_batch)
+        return decoded.astype(np.float32, copy=False)
+
+    def _sample_normalized_actions(self, inputs: dict[str, Any]) -> torch.Tensor:
+        self._ensure_predict_action_collator()
+        model = self.model
+        collated = self.collator([{"vlm_content": vlm} for vlm in inputs["vlm_content"]]).data["inputs"]
+        collated["state"] = inputs["state"]
+        collated["embodiment_id"] = inputs["embodiment_id"]
+        backbone_inputs, action_inputs = model.prepare_input(collated)
+        action_head = model.action_head
+
+        device = model.device
+        with torch.no_grad():
+            backbone_output = model.backbone(backbone_inputs)
+            # Qwen3Backbone.forward casts hidden_states to fp32 (training-side
+            # precision policy); the official server keeps bf16 for the whole
+            # model, so cast back here on the eval path. The action head is
+            # already bf16 (GROOT_ALLOW_TRAINABLE_PARAM_BF16=1 in the factory),
+            # so running without autocast keeps every intermediate bf16.
+            if self._predict_action_use_bf16 and device.type == "cuda":
+                backbone_output["backbone_features"] = backbone_output["backbone_features"].to(
+                    torch.bfloat16
+                )
+            backbone_output = action_head.process_backbone_output(backbone_output)
+            vl_embeds = backbone_output.backbone_features
+            batch_size = vl_embeds.shape[0]
+
+            embodiment_id = self._to_embodiment_tensor(
+                action_inputs.embodiment_id,
+                batch_size=batch_size,
+                device=vl_embeds.device,
+            )
+            state_tensor = action_inputs.state
+            if state_tensor.ndim == 2:
+                state_tensor = state_tensor.unsqueeze(1)
+            state_features = action_head.state_encoder(state_tensor, embodiment_id)
+
+            # Integrate the flow over the DiT's *trained* horizon
+            # (``config.action_horizon``, 40 for the released N1.7 checkpoints),
+            # not over the per-embodiment decoded horizon. The DiT attends over
+            # all action slots at once, so shortening the sequence changes every
+            # output; official slices the first ``len(delta_indices)`` steps only
+            # after sampling (processing_gr00t_n1d7.py:307/341). ``action_head``'s
+            # own value follows the YAML ``model.action_horizon`` and is the
+            # decoded length, which is why it must not be used here.
+            sample_horizon = int(getattr(self, "model_action_horizon", 0) or action_head.action_horizon)
+            actions = torch.randn(
+                size=(batch_size, sample_horizon, action_head.action_dim),
+                dtype=vl_embeds.dtype,
+                device=vl_embeds.device,
+            )
+            dt = 1.0 / float(action_head.num_inference_timesteps)
+
+            for step in range(action_head.num_inference_timesteps):
+                timestep = int(
+                    (step / float(action_head.num_inference_timesteps))
+                    * action_head.num_timestep_buckets
+                )
+                timesteps = torch.full(
+                    (batch_size,),
+                    timestep,
+                    dtype=torch.long,
+                    device=vl_embeds.device,
+                )
+                action_features = action_head.action_encoder(actions, timesteps, embodiment_id)
+                if action_head.config.add_pos_embed:
+                    pos_ids = torch.arange(
+                        action_features.shape[1],
+                        dtype=torch.long,
+                        device=vl_embeds.device,
+                    )
+                    action_features = action_features + action_head.position_embedding(pos_ids).unsqueeze(0)
+
+                state_action_embeds = torch.cat((state_features, action_features), dim=1)
+                if action_head.config.use_alternate_vl_dit:
+                    model_output, _ = action_head.model(
+                        hidden_states=state_action_embeds,
+                        encoder_hidden_states=vl_embeds,
+                        encoder_attention_mask=backbone_output.backbone_attention_mask,
+                        timestep=timesteps,
+                        return_all_hidden_states=True,
+                        image_mask=backbone_output.image_mask,
+                        backbone_attention_mask=backbone_output.backbone_attention_mask,
+                    )
+                else:
+                    model_output, _ = action_head.model(
+                        hidden_states=state_action_embeds,
+                        encoder_hidden_states=vl_embeds,
+                        encoder_attention_mask=backbone_output.backbone_attention_mask,
+                        timestep=timesteps,
+                        return_all_hidden_states=True,
+                    )
+
+                pred = action_head.action_decoder(model_output, embodiment_id)
+                pred_velocity = pred[:, -actions.shape[1] :]
+                actions = actions + dt * pred_velocity
+
+        # Keep only the per-embodiment decoded horizon (len(action delta_indices)).
+        decoded_horizon = int(getattr(self, "action_horizon", 0) or actions.shape[1])
+        return actions[:, :decoded_horizon]
+
+    def _normalize_state_batch(
+        self,
+        processor: StateActionProcessor,
+        raw_state_batch: np.ndarray,
+    ) -> np.ndarray:
+        state_dict = self._slice_state_batch(raw_state_batch)
+        normalized = processor.apply_state(state_dict, self.embodiment_tag)
+        packed = np.concatenate([np.asarray(normalized[key]) for key in self.state_keys], axis=-1)
+        # The action head's state_encoder is shared across embodiments and always
+        # consumes max_state_dim, so training's GrootN1d7FeatureTransform._pack_state
+        # zero-pads the per-embodiment state to that width. Mirror it here.
+        max_state_dim = int(self.config.max_state_dim)
+        if packed.shape[-1] < max_state_dim:
+            padding = np.zeros(
+                (*packed.shape[:-1], max_state_dim - packed.shape[-1]),
+                dtype=packed.dtype,
+            )
+            packed = np.concatenate([packed, padding], axis=-1)
+        elif packed.shape[-1] > max_state_dim:
+            packed = packed[..., :max_state_dim]
+        return packed
+
+
+    def _decode_action_batch(
+        self,
+        processor: StateActionProcessor,
+        action_batch: np.ndarray,
+        raw_state_batch: np.ndarray,
+    ) -> np.ndarray:
+        decoded_samples = []
+        for action_chunk, state_vec in zip(action_batch, raw_state_batch, strict=True):
+            action_dict = self._split_action_chunk(processor, action_chunk)
+            state_dict = self._slice_state_sample(state_vec)
+            decoded_dict = processor.unapply_action(
+                action_dict,
+                self.embodiment_tag,
+                state=state_dict,
+            )
+            decoded_samples.append(
+                np.concatenate([np.asarray(decoded_dict[key]) for key in self.action_keys], axis=-1)
+            )
+        return np.stack(decoded_samples, axis=0)
+
+    def _split_action_chunk(
+        self,
+        processor: StateActionProcessor,
+        action_chunk: np.ndarray,
+    ) -> dict[str, np.ndarray]:
+        out: dict[str, np.ndarray] = {}
+        start = 0
+        norm_params = processor.norm_params[self.embodiment_tag]["action"]
+        horizon = len(self.modality_config["action"].delta_indices)
+        for key in self.action_keys:
+            joint_dim = int(np.asarray(norm_params[key]["dim"]).item())
+            out[key] = action_chunk[:horizon, start : start + joint_dim]
+            start += joint_dim
+        return out
+
+    def _slice_state_batch(self, state_batch: np.ndarray) -> dict[str, np.ndarray]:
+        return {
+            key: state_batch[:, meta["start"] : meta["end"]]
+            for key, meta in self.modality_meta["state"].items()
+            if key in self.state_keys
+        }
+
+    def _slice_state_sample(self, state_vector: np.ndarray) -> dict[str, np.ndarray]:
+        return {
+            key: state_vector[meta["start"] : meta["end"]]
+            for key, meta in self.modality_meta["state"].items()
+            if key in self.state_keys
+        }
+
+    def _coerce_state_batch(self, state: Any, batch_size: int) -> np.ndarray:
+        if state is None:
+            if not self._predict_action_validation_zero_state:
+                raise ValueError(
+                    "GR00T-N1.7 predict_action requires a raw state matching the "
+                    "configured embodiment_tag. Use validation_zero_state=True "
+                    "only for local interface validation."
+                )
+            return np.zeros((batch_size, self.raw_state_dim), dtype=np.float32)
+
+        if isinstance(state, dict):
+            state_batch = self._flatten_state_dict(state)
+        else:
+            state_batch = _as_numpy(state)
+            if state_batch.ndim == 1:
+                state_batch = state_batch[None, :]
+            elif state_batch.ndim != 2:
+                raise ValueError(f"GR00T-N1.7 state must be [D] or [B, D], got {state_batch.shape}")
+
+        if state_batch.shape[0] == 1 and batch_size > 1:
+            state_batch = np.repeat(state_batch, batch_size, axis=0)
+        if state_batch.shape[0] != batch_size:
+            raise ValueError(
+                f"GR00T-N1.7 state batch size {state_batch.shape[0]} does not match images batch {batch_size}"
+            )
+
+        if state_batch.shape[-1] < self.raw_state_dim:
+            padding = np.zeros(
+                (state_batch.shape[0], self.raw_state_dim - state_batch.shape[-1]),
+                dtype=state_batch.dtype,
+            )
+            state_batch = np.concatenate([state_batch, padding], axis=-1)
+        elif state_batch.shape[-1] > self.raw_state_dim:
+            state_batch = state_batch[:, : self.raw_state_dim]
+        return np.asarray(state_batch, dtype=np.float32)
+
+    def _flatten_state_dict(self, state: dict[str, Any]) -> np.ndarray:
+        values = []
+        batch_size = None
+        for key in self.state_keys:
+            if key not in state:
+                raise KeyError(f"Missing GR00T-N1.7 state group {key!r}")
+            arr = _as_numpy(state[key])
+            if arr.ndim == 1:
+                arr = arr[None, :]
+            elif arr.ndim != 2:
+                raise ValueError(f"State group {key!r} must be [D] or [B, D], got {arr.shape}")
+            batch_size = arr.shape[0] if batch_size is None else batch_size
+            if arr.shape[0] != batch_size:
+                raise ValueError("All GR00T-N1.7 state groups must share the same batch size")
+            values.append(arr)
+        return np.concatenate(values, axis=-1)
+
+    def _normalize_image_batch(self, images: Any, instructions: Any) -> list[list[Image.Image]]:
+        instruction_count = None if isinstance(instructions, str) else _safe_len(instructions)
+
+        if _is_image_like(images):
+            samples = [[images]]
+        elif isinstance(images, dict):
+            samples = [[images[key] for key in sorted(images)]]
+        elif isinstance(images, (list, tuple)):
+            if not images:
+                raise ValueError("GR00T-N1.7 predict_action requires at least one image")
+            if all(_is_image_like(item) for item in images):
+                if instruction_count is not None and instruction_count == len(images) and len(images) > 1:
+                    samples = [[item] for item in images]
+                else:
+                    samples = [list(images)]
+            else:
+                samples = []
+                for sample in images:
+                    if _is_image_like(sample):
+                        samples.append([sample])
+                    elif isinstance(sample, dict):
+                        samples.append([sample[key] for key in sorted(sample)])
+                    elif isinstance(sample, (list, tuple)):
+                        if not sample:
+                            raise ValueError("GR00T-N1.7 image samples must not be empty")
+                        samples.append(list(sample))
+                    else:
+                        raise TypeError(
+                            f"Unsupported GR00T-N1.7 image sample type: {type(sample).__name__}"
+                        )
+        else:
+            raise TypeError(f"Unsupported GR00T-N1.7 images type: {type(images).__name__}")
+
+        return [[_to_pil_image(image) for image in sample] for sample in samples]
+
+    def _apply_eval_image_transform(
+        self, image_batch: list[list[Image.Image]]
+    ) -> list[list[Image.Image]]:
+        """Apply the official crop/resize pipeline so callers only need to
+        supply the env's native camera image (matching training-time
+        ``GrootN1d7FeatureTransform._build_vlm_content``, which applies the
+        same albumentations pipeline before assembling ``vlm_content``)."""
+        transform = getattr(self, "_predict_action_eval_image_transform", None)
+        if transform is None:
+            return image_batch
+        transformed = [
+            [
+                Image.fromarray(transform(image=np.asarray(image.convert("RGB")))["image"])
+                for image in sample
+            ]
+            for sample in image_batch
+        ]
+        self._log_eval_image_transform_once(image_batch, transformed)
+        return transformed
+
+    def _log_eval_image_transform_once(
+        self,
+        before: list[list[Image.Image]],
+        after: list[list[Image.Image]],
+    ) -> None:
+        """Log per-view pixel stats for the first transformed batch.
+
+        The training path builds its images through ``apply_with_replay`` and a
+        CHW tensor stack while eval feeds HWC arrays straight into the same
+        albumentations pipeline. Those two routes should agree, but a silent
+        divergence here is invisible to static review (the transform exists and
+        is called on both sides), so dump the actual values once per process for
+        value-by-value comparison against a training batch.
+        """
+        if getattr(self, "_predict_action_image_debug_logged", False):
+            return
+        # The server warmup feeds an all-zero dummy image; logging that would burn
+        # the one-shot on a frame that proves nothing. Wait for a real observation.
+        if all(
+            not np.asarray(raw.convert("RGB")).any()
+            for sample in before
+            for raw in sample
+        ):
+            return
+        self._predict_action_image_debug_logged = True
+        for sample_idx, (raw_sample, out_sample) in enumerate(zip(before, after, strict=True)):
+            for view_idx, (raw, out) in enumerate(zip(raw_sample, out_sample, strict=True)):
+                raw_arr = np.asarray(raw.convert("RGB"))
+                out_arr = np.asarray(out)
+                logger.info(
+                    "GR00T-N1.7 eval image transform sample=%d view=%d: "
+                    "in shape=%s dtype=%s mean=%.2f std=%.2f min=%d max=%d -> "
+                    "out shape=%s dtype=%s mean=%.2f std=%.2f min=%d max=%d",
+                    sample_idx,
+                    view_idx,
+                    raw_arr.shape,
+                    raw_arr.dtype,
+                    float(raw_arr.mean()),
+                    float(raw_arr.std()),
+                    int(raw_arr.min()),
+                    int(raw_arr.max()),
+                    out_arr.shape,
+                    out_arr.dtype,
+                    float(out_arr.mean()),
+                    float(out_arr.std()),
+                    int(out_arr.min()),
+                    int(out_arr.max()),
+                )
+
+    @staticmethod
+    def _normalize_instruction_batch(instructions: Any, batch_size: int) -> list[str]:
+        if isinstance(instructions, str):
+            return [instructions] * batch_size
+        instruction_list = [str(item) for item in list(instructions)]
+        if len(instruction_list) == 1 and batch_size > 1:
+            instruction_list = instruction_list * batch_size
+        if len(instruction_list) != batch_size:
+            raise ValueError(
+                f"GR00T-N1.7 instruction batch size {len(instruction_list)} does not match images batch {batch_size}"
+            )
+        return instruction_list
+
+    @staticmethod
+    def _build_vlm_content(images: Iterable[Image.Image], instruction: str) -> dict[str, Any]:
+        pil_images = [image.convert("RGB") for image in images]
+        conversation = [
+            {
+                "role": "user",
+                "content": [
+                    *[{"type": "image", "image": image} for image in pil_images],
+                    {"type": "text", "text": _formalize_language(instruction)},
+                ],
+            }
+        ]
+        return {"text": None, "images": pil_images, "conversation": conversation}
+
+    def _get_predict_action_processor(self, dataset_stats: Dict[str, Any] | None) -> StateActionProcessor:
+        if dataset_stats is None:
+            if self._predict_action_default_processor is None:
+                raise RuntimeError(
+                    "GR00T-N1.7 predict_action has not been configured with checkpoint statistics. "
+                    "Call configure_predict_action(...) before predict_action(..., dataset_stats=None)."
+                )
+            return self._predict_action_default_processor
+        statistics = self._coerce_statistics(dataset_stats)
+        cache_key = json.dumps(statistics, sort_keys=True)
+        if cache_key not in self._predict_action_processor_cache:
+            self._predict_action_processor_cache[cache_key] = self._build_state_action_processor(statistics)
+        return self._predict_action_processor_cache[cache_key]
+
+    def _coerce_statistics(self, statistics: Dict[str, Any]) -> Dict[str, Any]:
+        if self.embodiment_tag in statistics:
+            embodiment_stats = statistics[self.embodiment_tag]
+            if not {"state", "action"}.issubset(embodiment_stats):
+                raise ValueError(
+                    f"Statistics for {self.embodiment_tag!r} must include 'state' and 'action'."
+                )
+            return {self.embodiment_tag: embodiment_stats}
+
+        if "observation.state" in statistics and "action" in statistics:
+            return convert_lerobot_stats_to_groot_n1d7_format(
+                statistics,
+                self.embodiment_tag,
+                modality_meta=self.modality_meta,
+                modality_config=self.modality_config,
+            )
+
+        raise ValueError(
+            "GR00T-N1.7 statistics must be either checkpoint-style "
+            "{embodiment: {state, action, relative_action}} or raw LeRobot "
+            "{'observation.state', 'action', 'relative_action'} stats."
+        )
+
+    def _build_state_action_processor(self, statistics: Dict[str, Any]) -> StateActionProcessor:
+        processor = StateActionProcessor(
+            modality_configs={self.embodiment_tag: self.modality_config},
+            statistics=statistics,
+            use_percentiles=self._predict_action_use_percentiles,
+            clip_outliers=self._predict_action_clip_outliers,
+            apply_sincos_state_encoding=False,
+            use_relative_action=True,
+        )
+        processor.eval()
+        return processor
+
+    @staticmethod
+    def _to_embodiment_tensor(value: Any, *, batch_size: int, device: torch.device) -> torch.Tensor:
+        if not isinstance(value, torch.Tensor):
+            return torch.full((batch_size,), int(value), dtype=torch.long, device=device)
+        value = value.to(device=device, dtype=torch.long)
+        if value.ndim == 0:
+            return value.unsqueeze(0).expand(batch_size)
+        if value.ndim > 1:
+            value = value.flatten()
+        if value.shape[0] == 1 and batch_size > 1:
+            return value.expand(batch_size)
+        if value.shape[0] != batch_size:
+            raise ValueError(f"embodiment_id batch size {value.shape[0]} does not match {batch_size}")
+        return value
+
+    def _ensure_predict_action_collator(self) -> None:
+        if self.collator is not None:
+            return
+        self.collator = Gr00tN1d7DataCollator(
+            model_name=self.config.model_name,
+            model_type=self.config.backbone_model_type,
+            transformers_loading_kwargs={"trust_remote_code": True, "local_files_only": True},
         )
 
     def load_pretrained(
@@ -595,3 +1203,50 @@ def _restore_rotary_buffers_fp32(module: nn.Module) -> None:
         submodule.register_buffer("inv_freq", new_inv_freq, persistent=False)
         submodule.original_inv_freq = new_inv_freq
         submodule.attention_scaling = attention_scaling
+
+
+def _formalize_language(instruction: Any) -> str:
+    """Lowercase and strip punctuation, matching the training-time transform.
+
+    ``GrootN1d7FeatureTransform`` applies ``re.sub(r"[^\\w\\s]", "", text.lower())``
+    when ``formalize_language`` is set (true for every released GR00T-N1.7
+    checkpoint), so the eval path must normalize instructions identically or the
+    prompt tokens drift from what the checkpoint was trained on.
+    """
+    return re.sub(r"[^\w\s]", "", str(instruction).lower())
+
+
+def _is_image_like(value: Any) -> bool:
+    return isinstance(value, (Image.Image, np.ndarray, torch.Tensor))
+
+def _to_pil_image(image: Any) -> Image.Image:
+    if isinstance(image, Image.Image):
+        return image.convert("RGB")
+    arr = _as_numpy(image)
+    if arr.ndim != 3:
+        raise ValueError(f"GR00T-N1.7 images must be rank-3, got {arr.shape}")
+    if arr.shape[0] == 3 and arr.shape[-1] != 3:
+        arr = np.transpose(arr, (1, 2, 0))
+    if arr.shape[-1] != 3:
+        raise ValueError(f"GR00T-N1.7 images must have 3 channels, got {arr.shape}")
+    if arr.dtype != np.uint8:
+        finite = arr[np.isfinite(arr)]
+        if finite.size and finite.max() <= 1.0:
+            arr = arr * 255.0
+        arr = np.clip(arr, 0, 255).astype(np.uint8)
+    return Image.fromarray(np.ascontiguousarray(arr)).convert("RGB")
+
+
+def _as_numpy(value: Any) -> np.ndarray:
+    if isinstance(value, np.ndarray):
+        return value
+    if torch.is_tensor(value):
+        return value.detach().cpu().numpy()
+    return np.asarray(value)
+
+
+def _safe_len(value: Any) -> Optional[int]:
+    try:
+        return len(value)
+    except TypeError:
+        return None


### PR DESCRIPTION
## Change Summary

**What changed?**
Added inference and eval-framework integration for GRoot N1.7 (transform updates, model forward-pass extensions, new eval factory/payload builder), plus companion updates to GRoot N1.6 SimplerEnv eval configs.

**Which issue or requirement does this address?**
Brings GRoot N1.7 up to the same eval-ready state as other embodied models in this repo (LIBERO + SimplerEnv benchmarks).

**Which modules are affected?**
`vla` — `loongforge/embodied/model/groot_n1_7/`, `loongforge/embodied/data/datasets/groot_n1_7/`, `loongforge/embodied/eval/factories/`, `loongforge/embodied/eval/payload_builders/`, `loongforge/embodied/eval/orchestrator/runners/libero_runner.py`, `examples/embodied/groot_n1_7/eval/`, `examples/embodied/groot_n1_6/eval/configs/simplerenv/`.

## Validation

- [x] I ran the relevant local checks.
- [x] I added or updated tests where appropriate.
- [x] I checked compatibility with existing APIs and configurations.

## CI, GPU, and Image Impact

- [ ] This change affects dependencies, Dockerfiles, patches, or runtime environments.
- [x] GPU validation is required. Suggested suite: `embodied`.
- [ ] A local candidate image should be built during GPU validation.
- [ ] No GPU or image validation is required.

## Reviewer Notes

Verified via internal eval runs on LIBERO and SimplerEnv (WidowX) benchmarks for GRoot N1.7. GRoot N1.6 SimplerEnv configs were updated alongside for consistency; no behavioral change to GRoot N1.6 inference itself.