### PR TITLE
[vla] perf: optimize Pi05 attention and activation checkpointing

### DIFF
--- a/examples/embodied/pi05/run_pi05_ddp_finetune.sh
+++ b/examples/embodied/pi05/run_pi05_ddp_finetune.sh
@@ -90,6 +90,7 @@ TRAINING_ARGS=(
     # Checkpoint
     --save-interval "$SAVE_INTERVAL"
     --pretrained-checkpoint "$CHECKPOINT_PATH"
+    --activation-checkpoint-module-patterns "model.paligemma_with_expert.paligemma.model.vision_tower.vision_model.encoder.layers.*"
 )
 
 DISTRIBUTED_TRAINING_ARGS=(

--- a/loongforge/embodied/distributed/activation_checkpointing.py
+++ b/loongforge/embodied/distributed/activation_checkpointing.py
@@ -17,20 +17,18 @@ def apply_activation_checkpointing(
     raw_module_patterns: str | None,
     raw_skip_modules: str | None,
 ) -> None:
-    """Checkpoint selected modules except explicitly skipped module keys."""
+    """Checkpoint the modules selected by the patterns, minus those the skip patterns match."""
     from loongforge.embodied.train.training_args import parse_module_key_patterns
 
     module_patterns = parse_module_key_patterns(
         raw_module_patterns,
         option_name="activation checkpoint module patterns",
     )
-    skip_module_keys = set(
-        parse_module_key_patterns(
-            raw_skip_modules,
-            option_name="activation checkpoint skip modules",
-        )
+    skip_patterns = parse_module_key_patterns(
+        raw_skip_modules,
+        option_name="activation checkpoint skip modules",
     )
-    if not module_patterns and skip_module_keys:
+    if not module_patterns and skip_patterns:
         raise ValueError(
             "activation checkpoint skip modules require checkpoint module patterns"
         )
@@ -38,11 +36,20 @@ def apply_activation_checkpointing(
         return
 
     selected_modules = _resolve_module_key_patterns(model, module_patterns)
-    unknown_skip_modules = skip_module_keys.difference(selected_modules)
-    if unknown_skip_modules:
+    # Same segment-wise glob as the patterns, so a literal key still means exactly itself.
+    matched_skip_patterns = set()
+    skip_module_keys = set()
+    for module_key in selected_modules:
+        for pattern in skip_patterns:
+            if _module_key_matches(pattern, module_key):
+                matched_skip_patterns.add(pattern)
+                skip_module_keys.add(module_key)
+                break
+    unmatched_skip_patterns = set(skip_patterns).difference(matched_skip_patterns)
+    if unmatched_skip_patterns:
         raise ValueError(
             "activation checkpoint skip modules were not selected: "
-            + ", ".join(sorted(unknown_skip_modules))
+            + ", ".join(sorted(unmatched_skip_patterns))
         )
     selected_modules = {
         module_key: module

--- a/loongforge/embodied/model/pi05/modeling_pi05.py
+++ b/loongforge/embodied/model/pi05/modeling_pi05.py
@@ -34,6 +34,7 @@ import numpy as np
 import torch
 import torch.nn.functional as F
 from torch import Tensor, nn
+from torch.nn.attention.flex_attention import create_block_mask, flex_attention
 from transformers import AutoTokenizer
 
 try:
@@ -283,6 +284,32 @@ def _get_gemma_config(variant: str) -> _GemmaConfig:
 # compute_layer_complete (gradient checkpointing helper)
 # ═══════════════════════════════════════════════════════════════
 
+def _joint_attention_flex(query_states, key_states, value_states, block_mask, scaling):
+    """FlexAttention joint attention.  enable_gqa broadcasts the single kv head to the
+    8 query heads inside the kernel, so repeat_kv never materializes."""
+    att_output = flex_attention(
+        query_states, key_states, value_states,
+        block_mask=block_mask, scale=scaling, enable_gqa=True,
+    )
+    return att_output.transpose(1, 2).contiguous()
+
+
+_FLEX_BLOCK_MASK_FN = None
+
+
+def _flex_block_mask(att_2d_masks):
+    """BlockMask built once per step, shared by all layers; saves the additive fp32 mask."""
+    global _FLEX_BLOCK_MASK_FN
+    if _FLEX_BLOCK_MASK_FN is None:
+        _FLEX_BLOCK_MASK_FN = torch.compile(create_block_mask, dynamic=False)
+
+    def mask_mod(b, h, q_idx, kv_idx):
+        return att_2d_masks[b, q_idx, kv_idx]
+
+    bsize, q_len, kv_len = att_2d_masks.shape
+    return _FLEX_BLOCK_MASK_FN(mask_mod, bsize, 1, q_len, kv_len, device=att_2d_masks.device)
+
+
 def _compute_layer_complete(
     layer_idx, inputs_embeds, attention_mask, position_ids,
     adarms_cond, paligemma, gemma_expert
@@ -308,8 +335,8 @@ def _compute_layer_complete(
     cos, sin = paligemma.model.language_model.rotary_emb(dummy_tensor, position_ids)
     query_states, key_states = modeling_gemma.apply_rotary_pos_emb(query_states, key_states, cos, sin, unsqueeze_dim=1)
     scaling = paligemma.model.language_model.layers[layer_idx].self_attn.scaling
-    att_output, _ = modeling_gemma.eager_attention_forward(
-        paligemma.model.language_model.layers[layer_idx].self_attn,
+    # attention_mask is a BlockMask here, not an additive tensor.
+    att_output = _joint_attention_flex(
         query_states, key_states, value_states, attention_mask, scaling,
     )
     head_dim = paligemma.model.language_model.layers[layer_idx].self_attn.head_dim
@@ -788,17 +815,19 @@ class PI05Pytorch(nn.Module):
         att_masks = torch.cat([prefix_att_masks, suffix_att_masks], dim=1)
         att_2d_masks = make_att_2d_masks(pad_masks, att_masks)
         position_ids = torch.cumsum(pad_masks, dim=1) - 1
-        att_2d_masks_4d = self._prepare_attention_masks_4d(att_2d_masks)
+        # Only the joint path takes a BlockMask.  sample_actions/_denoise_step go through
+        # HF and keep the additive tensor from _prepare_attention_masks_4d.
+        joint_mask = _flex_block_mask(att_2d_masks)
 
-        def _fwd(prefix_embs, suffix_embs, att_2d_masks_4d, position_ids, adarms_cond):
+        def _fwd(prefix_embs, suffix_embs, joint_mask, position_ids, adarms_cond):
             (_, suffix_out), _ = self.paligemma_with_expert.forward(
-                attention_mask=att_2d_masks_4d, position_ids=position_ids,
+                attention_mask=joint_mask, position_ids=position_ids,
                 inputs_embeds=[prefix_embs, suffix_embs], use_cache=False,
                 adarms_cond=[None, adarms_cond],
             )
             return suffix_out
 
-        suffix_out = self._apply_checkpoint(_fwd, prefix_embs, suffix_embs, att_2d_masks_4d, position_ids, adarms_cond)
+        suffix_out = self._apply_checkpoint(_fwd, prefix_embs, suffix_embs, joint_mask, position_ids, adarms_cond)
         suffix_out = suffix_out[:, -self.config.chunk_size:]
         if hasattr(self, "_action_out_bundle_fn"):
             v_t = self._action_out_bundle_fn(suffix_out)

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -967,8 +967,10 @@ class _ActivationCheckpointArgs:
     activation_checkpoint_skip_modules: Optional[str] = field(
         default=None,
         metadata={
-            "help": "Optional comma-separated qualified module keys to exclude "
-                    "from --activation-checkpoint-module-patterns."
+            "help": "Optional comma-separated qualified module-key patterns to "
+                    "exclude from --activation-checkpoint-module-patterns. Same "
+                    "syntax: '*' matches one module-key segment. Every pattern "
+                    "must match at least one selected module."
         },
     )
 


### PR DESCRIPTION
## Summary
- Use FlexAttention for Pi05 joint QKV attention to reduce the memory footprint of the joint attention path.
- The Pi05 ViT/vision encoder has relatively high memory usage but short compute time, so activation recomputation is enabled for this part.
- FlexAttention further reduces memory usage without materializing the additive attention mask and repeated KV heads.
- MLP computation is relatively expensive, so activation recomputation is intentionally not enabled for MLP layers to avoid the extra recompute cost.
- Support glob patterns when selecting activation-checkpoint skip modules.
- Enable the vision encoder checkpoint pattern in the Pi05 DDP finetune example.


