### PR TITLE
[ci] fix: allowlist the LoongForge role email in the sensitive scan

### DIFF
--- a/ci/sensitive_rules.py
+++ b/ci/sensitive_rules.py
@@ -268,6 +268,12 @@ ALLOWLIST = [
         "reason": "Same public attribution, mirrored into the docs site.",
     },
     {
+        "rule": "corp-email",
+        "path": "*",
+        "match": r"(?i)\bloongforge@baidu\.com\b",
+        "reason": "Project role address published for external contact; names no individual.",
+    },
+    {
         "rule": "internal-codename",
         "path": "*",
         "match": r"(?i)Qianfan-VL",


### PR DESCRIPTION
## Summary

`sensitive / scan` currently fails on every PR, including ones that touch no documentation. The two blocking findings come from `master`, not from the PR under test.

## Cause

- `README.md:303` and `README_zh.md:303` publish `loongforge@baidu.com` as the external contact address (added by #184, merge commit `a142809`).
- The `corp-email` rule (`ci/sensitive_rules.py:93`) is `severity: error` and its pattern `[a-z0-9._%+-]+@(?:baidu|baidu-int|baidubce)\.com` cannot distinguish a project role box from an individual mailbox. Its own hint suggests "replace with a role address" — which is exactly what this address is.
- `.github/workflows/sensitive.yml` runs the scan over the whole tree (no `--paths`), so the finding is attributed to whichever PR happens to be running.
- `sensitive.yml` is `workflow_call`-only and is invoked from `ci-gate.yml`, which triggers on `pull_request` and `workflow_dispatch` only. Pushes to `master` never run the scan, so #184 merged with its own `sensitive / scan` red and nothing reported it afterwards.

## Changes

- `ci/sensitive_rules.py`: add an `ALLOWLIST` entry allowing `loongforge@baidu.com` for the `corp-email` rule, repo-wide, with a reason.

## Test Plan

- `python3 ci/sensitive_scan.py --ci-summary` — before: `2 error(s) ... FAIL`; after: `0 error(s), 1388 warning(s) ... PASS`.
- Scoping check: a scratch file containing both a personal `<login>@baidu.com` address and `loongforge@baidu.com` still reports the personal address as a blocking error and lets the role address through, so the allowlist does not widen into individual mailboxes.
- `ruff check ci/sensitive_rules.py` passes.

## Notes

- Deliberately narrow: only the exact role address is allowed, and only for `corp-email`.
- Worth a follow-up (not in this PR): `ci-gate.yml` does not run on pushes to `master`, so a check that is red at merge time leaves no trace afterwards. Adding `push: branches: [master]` would surface this class of debt immediately.
