### PR TITLE
[vla] feat: add DreamZero inference API and eval integration

### DIFF
--- a/examples/embodied/dreamzero/eval/configs/libero/libero_spatial.yaml
+++ b/examples/embodied/dreamzero/eval/configs/libero/libero_spatial.yaml
@@ -1,0 +1,89 @@
+# DreamZero LIBERO task-success template (open-source).
+# Verified: RLinf-DreamZero-WAN2.2-5B-LIBERO-SFT-Step26000 (Wan2.2-TI2V-5B
+# backbone), libero_spatial 81/100 (10 tasks x 10 eps).
+#
+# Open weights:
+#   checkpoint:  https://huggingface.co/RLinf/RLinf-DreamZero-WAN2.2-5B-LIBERO-SFT-Step26000
+#   Wan2.2-5B:   https://huggingface.co/Wan-AI/Wan2.2-TI2V-5B  (T5/VAE .pth + google/umt5-xxl tokenizer)
+#   Wan2.1-14B:  https://huggingface.co/Wan-AI/Wan2.1-I2V-14B-480P  (CLIP .pth only)
+# Fill /path/to/... below. Do not commit machine-specific absolute paths.
+#
+# Protocol notes (do not change without re-validating):
+# - Replan every 16 env steps; the full 16-action chunk executes open-loop.
+# - Each replan sends ONLY the current frame (the model interface applies the
+#   official 95% center-crop eval transform internally and re-initializes its
+#   autoregressive session from that single frame — no cross-chunk KV reuse).
+# - 2-view grid: exterior left | wrist right, 256x256 per view; q99
+#   normalization from the checkpoint's experiment_cfg/metadata.json; the
+#   gripper command is binarized (>0 -> +1) inside the eval wrapper.
+# - bf16, 16 flow-matching steps, max_episode_steps 480.
+#
+# Optional overrides (edit this file or copy it):
+#   suite: libero_spatial | libero_object | libero_goal | libero_10
+#   max_tasks / episodes_per_task: raise for full-suite eval (official: 10x50)
+
+benchmark:
+  name: libero
+  suite: libero_spatial
+  max_tasks: 1          # official full-suite: 10
+  episodes_per_task: 1  # official full-suite: 50
+  max_steps: 480        # official max_episode_steps
+  num_steps_wait: 10
+  continuous_gripper: true
+
+model:
+  backend: loongforge
+  model_type: dreamzero
+  name: dreamzero-libero-spatial
+  backbone_variant: wan22_5b
+  model_dtype: bfloat16
+  # Official LIBERO geometry (RLinf eval yaml).
+  num_frames: 33
+  action_horizon: 16
+  n_action_steps: 16
+  num_frame_per_block: 2
+  num_action_per_block: 16
+  num_state_per_block: 1
+  max_chunk_size: 4
+  max_state_dim: 64
+  max_action_dim: 32
+  dit_action_state_hidden_size: 1024
+  action_loss_embodiment_ids: [21]
+  eval_num_inference_timesteps: 16
+  # Frozen Wan encoders (same paths as the training YAML).
+  text_encoder_pretrained_path: /path/to/Wan2.2-TI2V-5B/models_t5_umt5-xxl-enc-bf16.pth
+  image_encoder_pretrained_path: /path/to/Wan2.1-I2V-14B-480P/models_clip_open-clip-xlm-roberta-large-vit-huge-14.pth
+  vae_pretrained_path: /path/to/Wan2.2-TI2V-5B/Wan2.2_VAE.pth
+
+server:
+  host: 127.0.0.1
+  port: 12150
+  health_port: 12151
+  python: /path/to/loongforge/bin/python
+  log: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/dreamzero/libero/libero_spatial/policy_server.log
+  start_timeout_sec: 1800   # 5B DiT + UMT5 + VAE + CLIP load
+  ckpt_path: /path/to/RLinf-DreamZero-WAN2.2-5B-LIBERO-SFT-Step26000
+  # q99 statistics; ships with the checkpoint at experiment_cfg/metadata.json
+  # (regenerate with RLinf toolkits/lerobot/generate_dreamzero_metadata.py if absent).
+  dataset_statistics_path: /path/to/RLinf-DreamZero-WAN2.2-5B-LIBERO-SFT-Step26000/experiment_cfg/metadata.json
+  loongforge_root: /path/to/LoongForge-VLA
+  tokenizer_path: /path/to/Wan2.2-TI2V-5B/google/umt5-xxl
+  use_bf16: true
+
+env:
+  eval_root: /path/to/LoongForge-VLA/loongforge/embodied/eval
+  libero_config_path: /path/to/libero_config
+  mujoco_gl: osmesa
+  pyopengl_platform: osmesa
+  ld_library_path: /path/to/nvidia_lib
+
+run:
+  output_dir: /path/to/LoongForge-VLA/loongforge/embodied/eval/reports/dreamzero/libero/libero_spatial
+  seed: 7
+  save_trace: true
+  save_replay: true
+
+timeouts:
+  policy_call_ms: 600000   # 16 diffusion steps x 33-frame encode on first call
+  per_step_sec: 600
+  per_episode_sec: 1800

--- a/examples/embodied/dreamzero/eval/run_libero_eval.sh
+++ b/examples/embodied/dreamzero/eval/run_libero_eval.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+#
+# Public open-source entry: fill /path/to/... in the YAML first.
+# Default (only shipped config): configs/libero/libero_spatial.yaml
+# Optional suite/episode knobs: see comments in that YAML.
+
+set -euo pipefail
+
+REPO_ROOT=${REPO_ROOT:-/path/to/LoongForge-VLA}
+EXAMPLE_EVAL_ROOT=${EXAMPLE_EVAL_ROOT:-${REPO_ROOT}/examples/embodied/dreamzero/eval}
+CONFIG=${CONFIG:-${EXAMPLE_EVAL_ROOT}/configs/libero/libero_spatial.yaml}
+if [[ "${CONFIG}" != /* ]]; then
+  CONFIG=${REPO_ROOT}/${CONFIG}
+fi
+
+export PYTHONPATH=${REPO_ROOT}:${PYTHONPATH:-}
+export CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES:-0}
+export MUJOCO_GL=${MUJOCO_GL:-osmesa}
+export PYOPENGL_PLATFORM=${PYOPENGL_PLATFORM:-osmesa}
+
+BENCHMARK_PYTHON=${BENCHMARK_PYTHON:-/path/to/libero/bin/python}
+"${BENCHMARK_PYTHON}" -m loongforge.embodied.eval.orchestrator.run --config "${CONFIG}"

--- a/loongforge/embodied/eval/factories/dreamzero_factory.py
+++ b/loongforge/embodied/eval/factories/dreamzero_factory.py
@@ -1,0 +1,375 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DreamZero evaluation factory (LIBERO).
+
+Server-side eval boundary for DreamZero on LIBERO:
+
+- Builds the DreamZero policy via ``build_model`` / ``dreamzero_model_provider``
+  (checkpoint loading happens inside the provider through
+  ``dit_init_checkpoint_path`` — the full DreamZero checkpoint layout with
+  ``action_head.model.*`` keys, e.g. RLinf-DreamZero-WAN2.2-5B-LIBERO-SFT).
+- Wraps it in ``DreamZeroInferenceModel`` (tokenizer + action-head batch) plus
+  an eval-side stateful adapter (``DreamZeroLiberoEvalModel``) that owns the
+  LIBERO protocol: 33-frame two-view history window, the official ``libero_sim``
+  prompt template, q99 state normalization and q99 action denormalization from
+  the checkpoint's ``metadata.json`` statistics.
+
+Official LIBERO eval parameters (RLinf ``libero_spatial_dreamzero_eval.yaml``
+and the DreamZero release): embodiment projector id 21, action_horizon 16
+executed fully open-loop per chunk, num_frames 33 (= 8*max_chunk_size + 1),
+target video 160x320 (per-view 256x256 resized model-side), exterior-left +
+wrist-right grid, max_episode_steps 480, bf16.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from collections import deque
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+import numpy as np
+
+from loongforge.embodied.eval.factories.registry import register_factory
+from loongforge.embodied.eval.servers.eval_server_config import EvalServerArgs
+from loongforge.embodied.eval.servers.loongforge_policy import PredictActionModelSpec
+from loongforge.embodied.model.dreamzero.model_configuration_dreamzero import DreamZeroConfig
+from loongforge.embodied.model.dreamzero.modeling_dreamzero_infer import DreamZeroInferenceModel
+from loongforge.embodied.model.registry import build_model
+
+logger = logging.getLogger(__name__)
+
+# Official DreamZero CFG negative prompt (dreamzero_collator.py text_negative).
+_DREAMZERO_NEGATIVE_PROMPT = (
+    "Vibrant colors, overexposed, static, blurry details, text, subtitles, style, artwork, "
+    "painting, image, still, grayscale, dull, worst quality, low quality, JPEG artifacts, "
+    "ugly, mutilated, extra fingers, bad hands, bad face, deformed, disfigured, mutated limbs, "
+    "fused fingers, stagnant image, cluttered background, three legs, many people in the "
+    "background, walking backwards."
+)
+
+# Official libero_sim prompt template (dreamzero_collator.py LIBERO_SIM branch).
+_LIBERO_PROMPT_TEMPLATE = (
+    "A multi-view video shows that a robot {instruction} "
+    "The video is split into two horizontal views: the left view shows the "
+    "exterior camera and the right view shows the wrist camera. The robot {instruction}"
+)
+
+# ``libero_sim`` -> WAN action-head projector id in the official multi-
+# embodiment mapping (datasets/dreamzero/dataset/modality_configs.py). The
+# released RLinf LIBERO-SFT checkpoints, however, train a SINGLE-category
+# projector (``state_encoder.layer1.W`` is ``(1, 64, 1024)``), so the runtime
+# ``embodiment_id`` tensor must be 0 — the model indexes W[cat_ids] directly.
+LIBERO_SIM_EMBODIMENT_ID = 21
+DREAMZERO_RUNTIME_EMBODIMENT_ID = 0
+
+
+@dataclass
+class DreamZeroEvalConfig(DreamZeroConfig):
+    """DreamZero model config extended with eval-only LIBERO semantics."""
+
+    # Eval-side scheduler length; consumed by build_action_head_config.
+    eval_num_inference_timesteps: int = 16
+    # LIBERO geometry (official libero_spatial_dreamzero_eval.yaml).
+    num_frames: int = 33
+    action_horizon: int = 16
+    n_action_steps: int = 16
+    num_frame_per_block: int = 2
+    num_action_per_block: int = 16
+    num_state_per_block: int = 1
+    max_chunk_size: int = 4
+    max_state_dim: int = 64
+    max_action_dim: int = 32
+    dit_action_state_hidden_size: int = 1024
+
+
+class _Q99Stats:
+    """q01/q99 statistics for one modality key, from DreamZero metadata.json."""
+
+    def __init__(self, q01: np.ndarray, q99: np.ndarray):
+        self.q01 = np.asarray(q01, dtype=np.float32).reshape(-1)
+        self.q99 = np.asarray(q99, dtype=np.float32).reshape(-1)
+
+    def normalize(self, x: np.ndarray) -> np.ndarray:
+        """x -> [-1, 1] via 2*(x-q01)/(q99-q01)-1 (StateActionTransform q99)."""
+        x = np.asarray(x, dtype=np.float32).reshape(-1)
+        if x.size != self.q01.size:
+            raise ValueError(
+                f"q99 normalize: input dim {x.size} != stats dim {self.q01.size}"
+            )
+        span = self.q99 - self.q01
+        out = np.zeros_like(x)
+        valid = span != 0
+        out[valid] = 2.0 * (x[valid] - self.q01[valid]) / span[valid] - 1.0
+        out[~valid] = x[~valid]
+        return out
+
+    def unnormalize(self, x: np.ndarray) -> np.ndarray:
+        """Inverse of :meth:`normalize`."""
+        x = np.asarray(x, dtype=np.float32)
+        span = (self.q99 - self.q01).reshape(1, -1)
+        base = self.q01.reshape(1, -1)
+        out = np.where(span != 0, (x + 1.0) / 2.0 * span + base, x)
+        return out.astype(np.float32)
+
+
+def _load_q99_stats(
+    metadata_path: str, embodiment_tag: str
+) -> Tuple[_Q99Stats, _Q99Stats]:
+    """Load state/action q99 statistics from a DreamZero ``metadata.json``.
+
+    Actual layout (RLinf ``generate_dreamzero_metadata.py`` / Step26000
+    ``experiment_cfg/metadata.json``):
+    ``{embodiment_tag: {"statistics": {"state": {"state": {"q01":..., "q99":...}},
+    "action": {"actions": {"q01":..., "q99":...}}}}}`` — modality-nested dicts,
+    not flat ``state.state`` keys.
+    """
+    with open(metadata_path, "r") as f:
+        metadata = json.load(f)
+    entry = metadata.get(embodiment_tag) if isinstance(metadata, dict) else None
+    if not isinstance(entry, dict):
+        raise ValueError(
+            f"metadata.json at {metadata_path} has no entry for embodiment {embodiment_tag!r}"
+        )
+    stats = entry.get("statistics") or {}
+    try:
+        state_stats = stats["state"]["state"]
+        action_stats = stats["action"]["actions"]
+    except (KeyError, TypeError) as exc:
+        raise ValueError(
+            f"metadata.json statistics missing {exc!r} (keys: {sorted(stats)})"
+        ) from exc
+    return _Q99Stats(state_stats["q01"], state_stats["q99"]), _Q99Stats(
+        action_stats["q01"], action_stats["q99"]
+    )
+
+
+class DreamZeroLiberoEvalModel:
+    """Stateful ``predict_action`` adapter over ``DreamZeroInferenceModel``.
+
+    Owns the LIBERO rollout protocol so the shared chunk-cached RPC policy can
+    stay model-agnostic:
+
+    - Called once per env step (``disable_action_cache`` in the PayloadBuilder).
+    - Applies the official libero_sim per-frame preprocessing (RLinf
+      ``libero_sim.py`` transform chain): 95% center crop then bilinear resize
+      back to 256x256, before the exterior|wrist horizontal grid concat.
+    - Appends the current two-view frame to a per-episode history deque and
+      left-pads the window by repeating the oldest frame at episode start.
+    - When its action queue is empty, builds the 33-frame grid
+      (exterior-left | wrist-right), the official prompt, the normalized state,
+      runs one ``predict`` call and queues the denormalized 16-step chunk.
+    - Returns exactly one action per call, shape ``(1, 7)``.
+    """
+
+    def __init__(
+        self,
+        infer_model: DreamZeroInferenceModel,
+        state_stats: _Q99Stats,
+        action_stats: _Q99Stats,
+        num_frames: int = 33,
+        action_horizon: int = 16,
+        action_dim: int = 7,
+        max_state_dim: int = 64,
+        binarize_gripper: bool = True,
+    ):
+        self._infer_model = infer_model
+        self._state_stats = state_stats
+        self._action_stats = action_stats
+        self._num_frames = int(num_frames)
+        self._action_horizon = int(action_horizon)
+        self._action_dim = int(action_dim)
+        self._max_state_dim = int(max_state_dim)
+        # Official LIBERO rollout binarizes the gripper command (>0 -> +1).
+        self._binarize_gripper = bool(binarize_gripper)
+        # episode_id -> (frame deque of (H, W, 3) grids, action queue [t, D]).
+        # Single-session state (see _episode); DreamZero's caches are global.
+        self._episode_id: Optional[str] = None
+        self._frames: deque = deque()
+        self._queue: deque()
+        self._first_call = True
+
+    def reset(self) -> None:
+        """Drop session state (frames, queue, model KV/language caches)."""
+        self._episode_id = None
+        self._frames = deque()
+        self._queue = deque()
+        self._first_call = True
+        self._infer_model.reset()
+
+    def _episode(self, episode_id: str) -> Tuple[deque, deque]:
+        """Return this episode's buffers, resetting the model session on change.
+
+        DreamZero's KV / language caches are global to the single model
+        instance (same as the verified DROID eval: episode keys are NOT
+        independent model sessions), so a new episode_id resets everything.
+        """
+        if episode_id != self._episode_id:
+            if self._episode_id is not None:
+                self._infer_model.reset()
+            self._episode_id = episode_id
+            self._frames = deque(maxlen=1024)
+            self._queue = deque()
+            self._first_call = True
+        return self._frames, self._queue
+
+    def _build_video(self, frames: deque) -> np.ndarray:
+        """Select the frame block for this inference call.
+
+        Official LIBERO rollout protocol (RLinf ``libero_sim.py``
+        ``eval_delta_indices=[0]`` + action-head session logic): EVERY replan
+        sends only the current frame — the action head detects a single-frame
+        input, resets its autoregressive session, and re-initializes the
+        33-frame trajectory from that frame. No cross-chunk KV reuse.
+        """
+        return np.stack([frames[-1]]).astype(np.uint8)
+
+    def predict_action(
+        self,
+        images: list,
+        instructions: list,
+        state: Optional[np.ndarray] = None,
+        dataset_stats: Optional[Dict[str, Any]] = None,
+        episode_id: str = "default",
+        episode_step: int = 0,
+        **kwargs: Any,
+    ) -> np.ndarray:
+        """One env step: observe, refill the chunk if needed, pop one action."""
+        if state is None:
+            raise ValueError("DreamZero LIBERO eval requires the 8D proprio state")
+        views = images[0] if images and isinstance(images[0], list) else images
+        if len(views) < 2:
+            raise ValueError("DreamZero LIBERO eval requires exterior + wrist views")
+        exterior, wrist = np.asarray(views[0]), np.asarray(views[1])
+        if exterior.shape != wrist.shape:
+            raise ValueError(
+                f"exterior/wrist shape mismatch: {exterior.shape} vs {wrist.shape}"
+            )
+        # Official grid: exterior left, wrist right (matches prompt text). The
+        # eval image transform (95% center crop) lives in the inference facade.
+        grid = np.concatenate([exterior, wrist], axis=1)
+        if grid.ndim != 3:
+            raise ValueError(f"expected HWC frame grid, got shape {grid.shape}")
+        frames, queue = self._episode(str(episode_id))
+        frames.append(grid)
+
+        if not queue:
+            # Match DreamTransform's whitespace cleaning before templating.
+            # (No lowercasing: the RLinf libero_sim template does not lowercase
+            # and LIBERO instructions are already lowercase.)
+            instruction = " ".join(str(instructions[0]).strip().split())
+            prompt = _LIBERO_PROMPT_TEMPLATE.format(instruction=instruction)
+            video = self._build_video(frames)
+            state_norm = self._state_stats.normalize(state)
+            state_norm = np.clip(state_norm, -1.0, 1.0)
+            # Training collator zero-pads proprio to ``max_state_dim``; the
+            # checkpoint's state projector expects the padded width.
+            if state_norm.size < self._max_state_dim:
+                pad = np.zeros(self._max_state_dim, dtype=np.float32)
+                pad[: state_norm.size] = state_norm
+                state_norm = pad
+            chunk = self._infer_model.predict(
+                video=video,
+                prompt=prompt,
+                negative_prompt=_DREAMZERO_NEGATIVE_PROMPT,
+                state=state_norm,
+            )
+            self._first_call = False
+            # (1, H, 32) normalized padded actions -> (H, 7) raw. The model
+            # denoises actions padded to ``max_action_dim`` (32); the first
+            # ``action_dim`` (7) columns carry the LIBERO action.
+            chunk = np.asarray(chunk, dtype=np.float32)
+            chunk = chunk.reshape(-1, chunk.shape[-1])
+            chunk = self._action_stats.unnormalize(chunk[:, : self._action_dim])
+            if self._binarize_gripper:
+                # Official dreamzero_policy.py: actions[..., -1] = >0 ? +1 : -1
+                # (LIBERO gripper: -1 open, +1 close).
+                chunk[:, -1] = np.where(chunk[:, -1] > 0, 1.0, -1.0)
+            for step in chunk[: self._action_horizon]:
+                queue.append(step)
+            if not queue:
+                raise RuntimeError("DreamZero predict returned an empty action chunk")
+        action = queue.popleft()
+        if action.shape[0] != self._action_dim:
+            raise ValueError(
+                f"DreamZero action dim {action.shape[0]} != expected {self._action_dim}"
+            )
+        return action[None, :]
+
+
+@register_factory("dreamzero")
+class DreamZeroModelFactory:
+    """Build a DreamZero model instance implementing the predict_action interface."""
+
+    model_config_cls = DreamZeroEvalConfig
+
+    @classmethod
+    def build(
+        cls,
+        model_cfg: DreamZeroEvalConfig,
+        server_args: EvalServerArgs,
+    ) -> PredictActionModelSpec:
+        """Create the DreamZero LIBERO eval model and its metadata."""
+        import torch
+
+        ckpt_path = str(Path(server_args.ckpt_path).expanduser()) if server_args.ckpt_path else ""
+        resolved_device = torch.device(
+            server_args.device
+            if torch.cuda.is_available() or not server_args.device.startswith("cuda")
+            else "cpu"
+        )
+
+        # The full DreamZero checkpoint (action_head.model.* keys) loads through
+        # the provider's dit_init path; encoder paths come from the model
+        # section (Wan release dirs), matching the training YAML convention.
+        if ckpt_path and not server_args.random_init:
+            model_cfg.dit_init_checkpoint_path = ckpt_path
+            model_cfg.action_state_init_checkpoint_path = ckpt_path
+
+        model = build_model(model_cfg)
+        model = model.to(resolved_device)
+        model.eval()
+        if server_args.use_bf16 and resolved_device.type == "cuda":
+            model = model.to(dtype=torch.bfloat16)
+
+        tokenizer_path = server_args.tokenizer_path or os.environ.get("TOKENIZER_PATH", "")
+        infer_model = DreamZeroInferenceModel(
+            model=model,
+            tokenizer_path=tokenizer_path,
+            text_len=model_cfg.text_len,
+            embodiment_id=DREAMZERO_RUNTIME_EMBODIMENT_ID,
+            device=resolved_device,
+        )
+
+        state_stats, action_stats = _load_q99_stats(
+            server_args.dataset_statistics_path, "libero_sim"
+        )
+        eval_model = DreamZeroLiberoEvalModel(
+            infer_model=infer_model,
+            state_stats=state_stats,
+            action_stats=action_stats,
+            num_frames=model_cfg.num_frames,
+            action_horizon=model_cfg.action_horizon,
+            action_dim=7,
+            max_state_dim=model_cfg.max_state_dim,
+            binarize_gripper=getattr(model_cfg, "binarize_gripper", True),
+        )
+
+        metadata: Dict[str, Any] = {
+            "framework": "loongforge",
+            "model_type": "dreamzero",
+            "ckpt_path": ckpt_path if not server_args.random_init else "random_init://dreamzero",
+            "random_init": bool(server_args.random_init),
+            "loongforge_root": server_args.loongforge_root,
+            "action_dim": 7,
+            "action_horizon": model_cfg.action_horizon,
+            "embodiment_tag": "libero_sim",
+            "embodiment_id": LIBERO_SIM_EMBODIMENT_ID,
+            "dataset_statistics_path": server_args.dataset_statistics_path,
+            "tokenizer_path": tokenizer_path,
+        }
+        return PredictActionModelSpec(model=eval_model, metadata=metadata)

--- a/loongforge/embodied/eval/factories/registry.py
+++ b/loongforge/embodied/eval/factories/registry.py
@@ -65,6 +65,7 @@ def _auto_import_factory_modules() -> None:
         "loongforge.embodied.eval.factories.groot_n1_6_factory",
         "loongforge.embodied.eval.factories.groot_n1_7_factory",
         "loongforge.embodied.eval.factories.lingbot_va_factory",
+        "loongforge.embodied.eval.factories.dreamzero_factory",
     ]
     for mod in _FACTORY_MODULES:
         try:

--- a/loongforge/embodied/eval/payload_builders/dreamzero.py
+++ b/loongforge/embodied/eval/payload_builders/dreamzero.py
@@ -1,0 +1,97 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""DreamZero PayloadBuilder.
+
+DreamZero consumes a per-step 2-view observation (exterior + wrist) plus an
+8D proprio state (eef_pos + eef_quat + gripper). Temporal history, the video
+grid, prompt formatting, normalization and action denormalization all live
+server-side (see ``factories/dreamzero_factory.py``); this builder only packs
+the canonical dict into the ``predict_action`` kwargs and declares that the
+model owns its action queue (``disable_action_cache``) so the server wrapper
+observes every env step and maintains the 33-frame history window.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+
+from loongforge.embodied.eval.payload_builders.base import PayloadBuilder
+from loongforge.embodied.eval.payload_builders.registry import register_payload_builder
+
+
+def _pack_dreamzero_images(images_by_cam: Dict[str, Optional[np.ndarray]]) -> List[np.ndarray]:
+    """Return the ``[exterior, wrist]`` view list DreamZero expects.
+
+    The LIBERO modality config concatenates the two views horizontally
+    (exterior left, wrist right) server-side; the order here must match that
+    layout and the training-time prompt text.
+    """
+    exterior = images_by_cam.get("primary")
+    if exterior is None:
+        exterior = images_by_cam.get("head")
+    if exterior is None:
+        raise ValueError("images_by_cam must contain 'primary' or 'head' (exterior view)")
+    wrist = images_by_cam.get("wrist")
+    if wrist is None:
+        wrist = images_by_cam.get("right")
+    if wrist is None:
+        raise ValueError("images_by_cam must contain 'wrist' for DreamZero LIBERO eval")
+    return [np.asarray(exterior), np.asarray(wrist)]
+
+
+def encode_libero_state(state_raw: Dict[str, Any]) -> np.ndarray:
+    """Canonical LIBERO proprio -> DreamZero 8D state (pos3 + quat4 + gripper1).
+
+    Matches the ``state.state`` layout of the ``libero_sim`` modality config
+    used at training time (8D state).
+    """
+    eef_pos = np.asarray(state_raw.get("eef_pos"), dtype=np.float32).reshape(-1)
+    eef_quat = np.asarray(state_raw.get("eef_quat"), dtype=np.float32).reshape(-1)
+    gripper = state_raw.get("gripper")
+    if eef_pos.size != 3 or eef_quat.size != 4 or gripper is None:
+        raise ValueError(
+            "DreamZero libero state requires eef_pos[3], eef_quat[4] and gripper; "
+            f"got sizes {eef_pos.size}/{eef_quat.size}/{gripper}"
+        )
+    return np.concatenate(
+        [eef_pos, eef_quat, np.asarray([gripper], dtype=np.float32)]
+    ).astype(np.float32)
+
+
+@register_payload_builder("dreamzero")
+class DreamZeroPayloadBuilder(PayloadBuilder):
+    """DreamZero client-side payload assembly."""
+
+    # Capability declarations (YAML-overridable via type annotations).
+    #
+    # Supported ``state_encoding`` values:
+    #   ``libero_ee`` — eef_pos + eef_quat + gripper -> 8D (LIBERO default)
+    state_encoding: str = "libero_ee"
+    # LIBERO canonical action (pos + axis_angle + gripper) matches the model's
+    # decoded 7D action; the composed decoder key is identity.
+    action_encoding: str = "axis_angle"
+    action_dim: int = 7
+    action_horizon: int = 16
+    # DreamZero is a closed-loop stateful policy: the server wrapper must be
+    # called every env step to grow the 33-frame history window and pops one
+    # action from its own queue per step.
+    disable_action_cache: bool = True
+
+    def _encode_state(self, canonical: Dict[str, Any]) -> Optional[np.ndarray]:
+        """Encode ``canonical.state_raw`` per ``self.state_encoding``."""
+        state_raw = canonical.get("state_raw") or {}
+        if self.state_encoding == "libero_ee":
+            return encode_libero_state(state_raw)
+        raise ValueError(f"Unsupported dreamzero state_encoding: {self.state_encoding!r}")
+
+    def build(self, canonical: Dict[str, Any], ctx: Dict[str, Any]) -> Dict[str, Any]:
+        """Return the kwargs consumed by the DreamZero eval wrapper."""
+        images = _pack_dreamzero_images(canonical["images"])
+        return {
+            "images": images,
+            "instructions": [str(canonical["instruction"])],
+            "state": self._encode_state(canonical),
+        }

--- a/loongforge/embodied/eval/payload_builders/registry.py
+++ b/loongforge/embodied/eval/payload_builders/registry.py
@@ -46,6 +46,7 @@ def _auto_import_payload_builder_modules() -> None:
         "loongforge.embodied.eval.payload_builders.groot_n1_6",
         "loongforge.embodied.eval.payload_builders.groot_n1_7",
         "loongforge.embodied.eval.payload_builders.lingbot_va",
+        "loongforge.embodied.eval.payload_builders.dreamzero",
     ]
     for mod in _MODULES:
         try:

--- a/loongforge/embodied/model/dreamzero/dreamzero_provider.py
+++ b/loongforge/embodied/model/dreamzero/dreamzero_provider.py
@@ -704,7 +704,17 @@ def _build_vae(model_config: DreamZeroConfig) -> torch.nn.Module:
     - ``wan22_5b``  → ``WanVideoVAE38`` (z_dim=48, dim=160).
     """
     preset = _BACKBONE_PRESETS[model_config.backbone_variant]
+    # Keep the component path contract consistent with T5/CLIP: callers may
+    # provide either the concrete VAE file or a Wan checkpoint directory.
+    # The directory form is what the official model layout and eval configs
+    # expose, while the VAE constructors/loaders require a file path.
     pretrained_path = model_config.vae_pretrained_path or ""
+    if pretrained_path:
+        pretrained_path = _resolve_weight_path(
+            pretrained_path,
+            preset["vae_filename"],
+            "vae_pretrained_path",
+        )
     skip_default_reset = _should_skip_default_reset(model_config, pretrained_path)
     with _skip_default_reset_parameters(skip_default_reset):
         if preset["vae_class"] == "WanVideoVAE38":

--- a/loongforge/embodied/model/dreamzero/model_configuration_dreamzero.py
+++ b/loongforge/embodied/model/dreamzero/model_configuration_dreamzero.py
@@ -38,6 +38,7 @@ _BACKBONE_PRESETS: dict[str, dict] = {
         "frame_seqlen": 880,
         "concat_first_frame_latent": True,
         "vae_class": "WanVideoVAE",
+        "vae_filename": "Wan2.1_VAE.pth",
         "vae_z_dim": 16,
         "vae_dim": 96,
         "target_video_height": None,  # Wan2.1 keeps native resolution
@@ -56,6 +57,7 @@ _BACKBONE_PRESETS: dict[str, dict] = {
         "frame_seqlen": 50,
         "concat_first_frame_latent": False,
         "vae_class": "WanVideoVAE38",
+        "vae_filename": "Wan2.2_VAE.pth",
         "vae_z_dim": 48,
         "vae_dim": 160,
         "target_video_height": 160,
@@ -111,6 +113,8 @@ class DreamZeroConfig(PreTrainedConfig):
     # ------------------------------------------------------------------
     # Flow-matching scheduler
     # ------------------------------------------------------------------
+    # Retain the historical training/configuration field. Eval-only scheduler
+    # steps live on DreamZeroEvalConfig and do not alter shared model defaults.
     num_inference_timesteps: int = 4  # not used during training
     # ``1`` selects the fallback all-True inference skip mask, so all diffusion
     # steps run the DiT.

--- a/loongforge/embodied/model/dreamzero/modeling_dreamzero.py
+++ b/loongforge/embodied/model/dreamzero/modeling_dreamzero.py
@@ -67,6 +67,9 @@ def build_action_head_config(model_config: DreamZeroConfig) -> WANPolicyHeadConf
         num_frames=model_config.num_frames,
         input_embedding_dim=model_config.input_embedding_dim,
         # Flow-matching noise
+        # The action-head default is 16. Eval configs may opt into an explicit
+        # scheduler length without changing the shared training config field.
+        num_inference_steps=getattr(model_config, "eval_num_inference_timesteps", 16),
         num_dit_steps=model_config.num_dit_steps,
         noise_beta_alpha=model_config.noise_beta_alpha,
         noise_beta_beta=model_config.noise_beta_beta,

--- a/loongforge/embodied/model/dreamzero/modeling_dreamzero_infer.py
+++ b/loongforge/embodied/model/dreamzero/modeling_dreamzero_infer.py
@@ -1,0 +1,162 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Inference-only facade for the shared DreamZero action head.
+
+The DROID camera, prompt, state, and action semantics stay in the evaluation
+factory. This module owns only the model-facing inference boundary so eval
+does not need to call the training model directly.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Mapping
+
+import numpy as np
+
+
+class DreamZeroInferenceModel:
+    """Run the shared DreamZero model through an inference-only interface."""
+
+    def __init__(
+        self,
+        model: Any,
+        tokenizer_path: str,
+        text_len: int,
+        embodiment_id: int,
+        device: Any,
+    ):
+        """Initialize the facade.
+
+        Args:
+            model: Constructed DreamZero model exposing ``predict_action_chunk``.
+            tokenizer_path: Local UMT5 tokenizer path.
+            text_len: Maximum token sequence length.
+            embodiment_id: DreamZero embodiment identifier.
+            device: Device receiving model inputs.
+        """
+        self._model = model
+        self._tokenizer_path = tokenizer_path
+        self._text_len = int(text_len)
+        self._embodiment_id = int(embodiment_id)
+        self._device = device
+        self._tokenizer = None
+
+    def _load_tokenizer(self):
+        """Load the local tokenizer once for the inference process."""
+        if self._tokenizer is None:
+            if not self._tokenizer_path:
+                raise ValueError(
+                    "DreamZero eval requires a tokenizer path for inference"
+                )
+            from transformers import AutoTokenizer
+
+            load_kwargs = (
+                {"local_files_only": True}
+                if Path(self._tokenizer_path).is_dir()
+                else {}
+            )
+            self._tokenizer = AutoTokenizer.from_pretrained(
+                self._tokenizer_path, **load_kwargs
+            )
+        return self._tokenizer
+
+    @staticmethod
+    def _eval_image_transform(video: np.ndarray) -> np.ndarray:
+        """Apply the official eval image transform to a video grid.
+
+        Mirrors RLinf ``libero_sim.py`` (VideoCrop(scale=0.95) → VideoResize,
+        linear) applied per view before the horizontal grid concat: a center
+        crop of the concatenated exterior|wrist grid removes the same 5%
+        border from each view, so cropping the grid is equivalent. Training
+        VideoColorJitter augmentation is intentionally omitted at eval.
+        Callers pass the env-native grid; this is the model's input
+        convention (same placement as GR00T-N1.6's
+        ``_predict_action_eval_image_transform``).
+        """
+        import torch
+        from torchvision.transforms.v2 import functional as tvf
+
+        t, h, w, c = video.shape
+        half = w // 2
+        out = np.empty_like(video)
+        for start in (0, half):  # crop each view independently (grid = ext|wrist)
+            view = torch.from_numpy(video[:, :, start:start + half]).permute(0, 3, 1, 2).float()
+            view = tvf.center_crop(view, [int(h * 0.95), int(half * 0.95)])
+            view = tvf.resize(
+                view,
+                [h, half],
+                interpolation=tvf.InterpolationMode.BILINEAR,
+                antialias=True,
+            )
+            out[:, :, start:start + half] = view.permute(0, 2, 3, 1).to(torch.uint8).numpy()
+        return out
+
+    def predict(
+        self,
+        video: np.ndarray,
+        prompt: str,
+        negative_prompt: str,
+        state: np.ndarray,
+    ) -> np.ndarray:
+        """Tokenize a prepared prompt and run the action head.
+
+        Args:
+            video: Model video grid in uint8 THWC format — env-native pixels;
+                the official eval image transform (95% center crop + resize)
+                is applied here as part of the model's input convention.
+            prompt: Positive prompt already formatted by the eval adapter.
+            negative_prompt: Model classifier-free negative prompt.
+            state: Prepared normalized state vector.
+
+        Returns:
+            Action predictions as a CPU NumPy array with batch dimension.
+        """
+        import torch
+
+        video = self._eval_image_transform(np.asarray(video))
+        tokenizer = self._load_tokenizer()
+        tokens = tokenizer(
+            [prompt], return_tensors="pt", padding="max_length", truncation=True,
+            max_length=self._text_len,
+        )
+        negative_tokens = tokenizer(
+            [negative_prompt], return_tensors="pt", padding="max_length",
+            truncation=True, max_length=self._text_len,
+        )
+        batch = {
+            "images": torch.from_numpy(video)[None].to(self._device),
+            "text": tokens.input_ids.to(self._device),
+            "text_attention_mask": tokens.attention_mask.to(self._device),
+            "text_negative": negative_tokens.input_ids.to(self._device),
+            "text_attention_mask_negative": negative_tokens.attention_mask.to(self._device),
+            "state": torch.from_numpy(state)[None, None].to(self._device),
+            "embodiment_id": torch.tensor(
+                [self._embodiment_id], dtype=torch.long, device=self._device
+            ),
+        }
+        return self.predict_action_chunk(batch)
+
+    def predict_action_chunk(self, batch: Mapping[str, Any]) -> np.ndarray:
+        """Run one action-head inference call and return a CPU float array.
+
+        Args:
+            batch: Model-ready DreamZero tensors.
+
+        Returns:
+            Action predictions as a NumPy array; batch dimension is preserved.
+        """
+        import torch
+
+        with torch.no_grad():
+            result = self._model.predict_action_chunk(batch)
+        if hasattr(result, "detach"):
+            return result.detach().float().cpu().numpy()
+        return np.asarray(result, dtype=np.float32)
+
+    def reset(self) -> None:
+        """Reset temporal state when the wrapped model exposes it."""
+        reset = getattr(self._model, "reset", None)
+        if callable(reset):
+            reset()

--- a/loongforge/embodied/model/dreamzero/modules/flow_unipc_multistep_scheduler.py
+++ b/loongforge/embodied/model/dreamzero/modules/flow_unipc_multistep_scheduler.py
@@ -25,7 +25,9 @@ Implementation notes:
 - The initial sigma buffer stays on CPU; ``set_timesteps(device=...)`` moves the
   active buffers to the run device. This keeps construction independent of a
   CUDA context.
-- ``multistep_uni_{p,c}_bh_update`` remain ``@torch.compile``-decorated.
+- The update kernels intentionally remain eager. The official DreamZero
+  sampler is eager, and compiling these small reductions changes bfloat16
+  rounding enough to make later denoising steps diverge.
 """
 
 import math
@@ -147,7 +149,7 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         self.sigma_min = self.sigmas[-1].item()
         self.sigma_max = self.sigmas[0].item()
 
-    # Modified from diffusers.schedulers.scheduling_flow_match_euler_discrete.FlowMatchEulerDiscreteScheduler.set_timesteps
+    # Modified from diffusers FlowMatchEulerDiscreteScheduler.set_timesteps
     def set_timesteps(
         self,
         num_inference_steps: int,
@@ -315,11 +317,6 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
 
             return epsilon
 
-    @torch.compile(
-        mode="reduce-overhead",
-        fullgraph=True,
-        dynamic=False,
-    )
     def multistep_uni_p_bh_update(
         self,
         model_output: torch.Tensor,
@@ -431,11 +428,6 @@ class FlowUniPCMultistepScheduler(SchedulerMixin, ConfigMixin):
         x_t = x_t.to(x.dtype)
         return x_t
 
-    @torch.compile(
-        mode="reduce-overhead",
-        fullgraph=True,
-        dynamic=False,
-    )
     def multistep_uni_c_bh_update(
         self,
         this_model_output: torch.Tensor,


### PR DESCRIPTION
## Change Summary

**What changed?**
Added inference and eval-framework integration for DreamZero: new `modeling_dreamzero_infer.py` (online inference module), a new eval factory and payload builder with registry entries, small updates to the DreamZero provider/config/modeling and the flow UniPC multistep scheduler, plus a LIBERO eval config and run script.

**Which issue or requirement does this address?**
Brings DreamZero to the same eval-ready state as other embodied models in this repo (LIBERO benchmark support).

**Which modules are affected?**
`vla` — `loongforge/embodied/model/dreamzero/`, `loongforge/embodied/eval/factories/`, `loongforge/embodied/eval/payload_builders/`, `examples/embodied/dreamzero/eval/`.

## Validation

- [x] I ran the relevant local checks.
- [ ] I added or updated tests where appropriate.
- [x] I checked compatibility with existing APIs and configurations.

## CI, GPU, and Image Impact

- [ ] This change affects dependencies, Dockerfiles, patches, or runtime environments.
- [x] GPU validation is required. Suggested suite: `embodied`.
- [ ] A local candidate image should be built during GPU validation.
- [ ] No GPU or image validation is required.

## Reviewer Notes

Verified via internal eval runs on the LIBERO benchmark (`libero_spatial`). Change is additive: existing DreamZero training paths are untouched except for a minor scheduler adjustment; no behavioral change expected for existing models.