### PR TITLE
[vla, train] feat: allow excluding frozen params from FSDP sharding

### DIFF
--- a/docs/source/embodied_tutorial/overview.md
+++ b/docs/source/embodied_tutorial/overview.md
@@ -397,6 +397,7 @@ The following arguments give fine-grained control over FSDP sharding, wrap polic
 | Root reshard policy | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, integer > 1 | Reshard policy for the root FSDP group |
 | Wrap classes | `--fsdp-wrap-modules` | `None` | Comma-separated module class names | Specify FSDP units |
 | Exclude wrap classes | `--fsdp-no-wrap-modules` | `None` | Comma-separated module class names | Exclude the given module classes |
+| Exclude params from sharding | `--fsdp-ignored-param-names` | `[]` | Space-separated name substrings | Frozen params matching any substring stay replicated on every rank |
 | Auto wrap threshold | `--fsdp-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping repeated layers |
 | Leftover wrap threshold | `--fsdp-leftover-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping leftover modules |
 | Original parameter dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Parameter dtype before FSDP sharding |

--- a/docs/source_zh/embodied_tutorial/overview.md
+++ b/docs/source_zh/embodied_tutorial/overview.md
@@ -396,6 +396,7 @@ bash examples/embodied/pi05/run_pi05_ddp_finetune.sh \
 | root reshard 策略 | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, 大于 1 的整数 | root FSDP group 的 reshard 策略 |
 | 指定 wrap 类 | `--fsdp-wrap-modules` | `None` | 逗号分隔模块类名 | 指定 FSDP unit |
 | 排除 wrap 类 | `--fsdp-no-wrap-modules` | `None` | 逗号分隔模块类名 | 排除指定模块类 |
+| 排除分片的参数 | `--fsdp-ignored-param-names` | `[]` | 空格分隔的参数名子串 | 命中任一子串的冻结参数在每张卡各留一份完整副本 |
 | 自动 wrap 阈值 | `--fsdp-min-num-params` | `1000000` | 非负整数 | 自动包装重复层的参数阈值 |
 | leftover wrap 阈值 | `--fsdp-leftover-min-num-params` | `1000000` | 非负整数 | 自动包装剩余模块的参数阈值 |
 | 原始参数 dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | FSDP 分片前参数 dtype |

--- a/examples/embodied/cosmos3/run_cosmos3_nano_droid_fsdp_finetune.sh
+++ b/examples/embodied/cosmos3/run_cosmos3_nano_droid_fsdp_finetune.sh
@@ -53,7 +53,7 @@ MODEL_CONFIG_ARGS=(
 )
 
 # ── Data params ───────────────────────────────────────────────
-NUM_WORKERS=${NUM_WORKERS:-4}
+NUM_WORKERS=${NUM_WORKERS:-8}
 DATA_ARGS=(
     --dataset-format lerobot_datasets
     --dataset-strategy cosmos3_droid
@@ -64,8 +64,8 @@ DATA_ARGS=(
 )
 
 # ── Training params ───────────────────────────────────────────
-TRAIN_ITERS=${TRAIN_ITERS:-20}
-PER_DEVICE_BATCH_SIZE=${PER_DEVICE_BATCH_SIZE:-2}
+TRAIN_ITERS=${TRAIN_ITERS:-50}
+PER_DEVICE_BATCH_SIZE=${PER_DEVICE_BATCH_SIZE:-4}
 GRADIENT_ACCUMULATION_STEPS=${GRADIENT_ACCUMULATION_STEPS:-1}
 SAVE_INTERVAL=${SAVE_INTERVAL:-0}
 SEED=${SEED:-42}
@@ -104,6 +104,9 @@ DISTRIBUTED_TRAINING_ARGS=(
     --dtype bfloat16
     --fsdp-reduce-dtype bf16
     --fsdp-wrap-modules MoTDecoderLayer
+    --fsdp-ignored-param-names embed_tokens lm_head \
+            mlp.gate_proj mlp.up_proj mlp.down_proj \
+            q_proj.weight k_proj.weight v_proj.weight
 )
 
 # ── Logging params ────────────────────────────────────────────
@@ -129,8 +132,11 @@ PYTHONPATH=$LOONGFORGE_PATH:${PYTHONPATH:-} \
     "${MODEL_CONFIG_ARGS[@]}" \
     "${DATA_ARGS[@]}" \
     "${TRAINING_ARGS[@]}" \
-    "${DISTRIBUTED_TRAINING_ARGS[@]}" \
-    "${LOGGING_ARGS[@]}" \
     "model.qwen3_vl_path=$TOKENIZER_PATH" \
     "model.vae_path=$VAE_PATH" \
+    "model.compile_model=true" \
+    "data.use_image_augmentation=true" \
+    "data.colorjitter_on_gpu=true" \
+    "${DISTRIBUTED_TRAINING_ARGS[@]}" \
+    "${LOGGING_ARGS[@]}" \
     "$@"

--- a/loongforge/embodied/distributed/fsdp_utils/builders.py
+++ b/loongforge/embodied/distributed/fsdp_utils/builders.py
@@ -100,12 +100,20 @@ def build_mp_policy(training_args, model: nn.Module | None = None) -> MixedPreci
     return mp_policy
 
 
-def build_ignored_params(model: nn.Module, ctx: DistributedContext) -> set:
+def build_ignored_params(training_args, model: nn.Module, ctx: DistributedContext) -> set:
     """Collect parameters that FSDP must not manage.
 
     FSDP2 shards parameters on dim-0, so 0-dim (scalar) parameters have nothing
     to shard: ``fully_shard`` rejects them outright and they are handed over as
     ``ignored_params`` instead.
+
+    Frozen parameters named by ``--fsdp-ignored-param-names`` are added on top,
+    for a different reason: an ignored parameter is never all-gathered, so
+    keeping a large frozen tensor replicated trades 2 bytes/param of resident
+    memory for 4 bytes/param/step of all-gather traffic (once in forward, once
+    for the backward re-gather). Worth it for weights that dominate a group's
+    all-gather while contributing little compute -- e.g. the vocab tables, which
+    sit in the root unit and are gathered before the forward body runs.
 
     Being ignored means FSDP never touches them, gradients included: nothing
     reduces their gradients across ranks, so a *trainable* scalar parameter would
@@ -113,6 +121,10 @@ def build_ignored_params(model: nn.Module, ctx: DistributedContext) -> set:
     therefore rejected rather than quietly diverging.
 
     Args:
+        training_args: ``fsdp_ignored_param_names`` supplies the name substrings
+            to exclude. Matching is on substrings, not suffixes, so ``q_proj``
+            also selects ``q_proj_moe_gen``; qualify with ``.weight`` to separate
+            the two MoT pathways.
         model: Model to scan, before wrapping. Scanned with
             ``named_parameters()``, so tied parameters are collected once by
             identity.
@@ -139,28 +151,31 @@ def build_ignored_params(model: nn.Module, ctx: DistributedContext) -> set:
         identity filter throughout unit selection, so a rank that skipped it
         would size its units differently.
     """
-    scalar_params = [(n, p) for n, p in model.named_parameters() if p.ndim == 0]
-    trainable = [n for n, p in scalar_params if p.requires_grad]
+    ignored_params = [(n, p)
+                for n, p in model.named_parameters()
+                    if p.ndim == 0
+                        or any(k in n for k in training_args.fsdp_ignored_param_names)]
+    trainable = [n for n, p in ignored_params if p.requires_grad]
     if trainable:
         raise ValueError(
-            f"FSDP cannot train 0-dim (scalar) parameters: "
-            f"{', '.join(trainable[:8])}. They cannot be sharded on dim-0, so "
-            f"FSDP ignores them and their gradients are never reduced across "
-            f"ranks. Give them shape (1,) so FSDP can manage them, or freeze "
-            f"them with requires_grad=False."
+            "FSDP2 cannot ignore trainable parameters: nothing reduces their "
+            "gradients, so every rank would take a different optimizer step. "
+            f"Offenders ({len(trainable)}): {', '.join(trainable[:8])}. Freeze "
+            "them, give 0-dim parameters shape (1,) so FSDP can shard them, or "
+            "narrow --fsdp-ignored-param-names"
         )
-    ignored = {p for _, p in scalar_params}
+    ignored = {p for _, p in ignored_params}
 
     # fully_shard does not move ignored params to the device, so do it here.
     with torch.no_grad():
         for p in ignored:
-            if p.device != ctx.device:
+            if p.device != ctx.device and not p.is_meta:
                 p.data = p.to(device=ctx.device)
 
-    if scalar_params:
+    if ignored_params:
         logger.info(
             "FSDP2 ignores %d frozen scalar params: %s",
-            len(scalar_params), ", ".join(n for n, _ in scalar_params[:8]),
+            len(ignored_params), ", ".join(n for n, _ in ignored_params[:8]),
         )
     return ignored
 

--- a/loongforge/embodied/distributed/fsdp_utils/context.py
+++ b/loongforge/embodied/distributed/fsdp_utils/context.py
@@ -55,7 +55,7 @@ class FSDPWrapContext:
         fsdp_kwargs = {
             "mesh": build_fsdp_device_mesh(training_args, ctx),
             "mp_policy": build_mp_policy(training_args, model),
-            "ignored_params": build_ignored_params(model, ctx),
+            "ignored_params": build_ignored_params(training_args, model, ctx),
         }
 
         return cls(

--- a/loongforge/embodied/model/cosmos3/attention.py
+++ b/loongforge/embodied/model/cosmos3/attention.py
@@ -484,6 +484,7 @@ def build_packed_sequence(
 
 
 
+@torch.compiler.disable
 def flash2_attention(
     query: Tensor,
     key: Tensor,

--- a/loongforge/embodied/model/cosmos3/attention.py
+++ b/loongforge/embodied/model/cosmos3/attention.py
@@ -13,6 +13,21 @@ from torch.nn.attention.flex_attention import BlockMask, create_block_mask, flex
 from flash_attn.flash_attn_interface import flash_attn_func, flash_attn_varlen_func
 from enum import Enum
 
+from .sequence_packing import (
+    FactoredSequencePack,
+    JointSequencePack,
+    create_sparse_mask,
+    factored_from_joint_sequence,
+    from_joint,
+    from_mode_splits,
+    generate_natten_metadata,
+    generate_temporal_causal_natten_metadata,
+    get_all_seq,
+    get_causal_seq,
+    get_full_only_seq,
+    joint_from_joint_sequence,
+)
+
 flex_attention = torch.compile(_flex_attention)
 
 
@@ -109,21 +124,6 @@ AttentionMaskType = BlockMask | SplitInfo
 _dotproduct_attention_cache = {}
 
 
-from .sequence_packing import (
-    FactoredSequencePack,
-    JointSequencePack,
-    create_sparse_mask,
-    factored_from_joint_sequence,
-    from_joint,
-    from_mode_splits,
-    generate_natten_metadata,
-    generate_temporal_causal_natten_metadata,
-    get_all_seq,
-    get_causal_seq,
-    get_full_only_seq,
-    joint_from_joint_sequence,
-)
-
 
 def two_way_attention(
     packed_query_states: FactoredSequencePack | JointSequencePack,
@@ -205,8 +205,6 @@ def three_way_attention(
     full_q, full_q_offsets = get_full_only_seq(packed_query_states)
     full_k, full_k_offsets = get_full_only_seq(packed_key_states)
     full_v, _ = get_full_only_seq(packed_value_states)
-
-    sample_offsets = packed_query_states["sample_offsets"]
 
     if attention_meta is not None and attention_meta.null_action_supertokens:
         # Zero V for the first num_action_tokens_per_supertoken tokens of each
@@ -642,7 +640,7 @@ def is_torch_compiling() -> bool:
     """is_torch_compiling."""
     try:
         return torch.compiler.is_compiling()
-    except Exception as e:
+    except Exception:
         return False
 
 

--- a/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
+++ b/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
@@ -153,7 +153,7 @@ class Cosmos3(nn.Module):
         self.train_modules = config.train_modules
         if torch.are_deterministic_algorithms_enabled():
             self.keys_to_skip_loading = []
-            logger.info(f"clean config `keys_to_skip_loading` on deterministic mode")
+            logger.info("clean config `keys_to_skip_loading` on deterministic mode")
         else:
             self.keys_to_skip_loading = config.keys_to_skip_loading
 
@@ -295,7 +295,6 @@ class Cosmos3(nn.Module):
         device = next(self.net.parameters()).device
         dtype = next(self.net.parameters()).dtype
         special_tokens = self._get_special_tokens()
-        cpu_kwargs = {"device": "cpu", "dtype": torch.float32}
 
         B = len(batch.videos)
         action_loss_weight = float(self.action_loss_weight)

--- a/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
+++ b/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
@@ -121,7 +121,7 @@ class Cosmos3(nn.Module):
         if config.compile_model:
             _layers = self.net.language_model.model.layers
             for _layer in _layers:
-                _layer.compile(fullgraph=True, dynamic=config.compile_dynamic)
+                _layer.compile(fullgraph=False, dynamic=config.compile_dynamic)
             logger.info("[compile] in-place torch.compile on %d MoTDecoderLayer blocks (fullgraph=True, dynamic=%s)",
                         len(_layers), config.compile_dynamic)
 

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -1077,6 +1077,14 @@ class _DistributedArgs:
                     "reshard_after_forward, e.g. GemmaMLP=false,Linear=true.",
         },
     )
+    fsdp_ignored_param_names: List[str] = field(
+        default_factory=list,
+        metadata={
+            "help": "Parameter-name substrings excluded from FSDP sharding; "
+                    "matched params stay replicated on every rank. Frozen params "
+                    "only. Example: q_proj lm_head",
+        },
+    )
     fsdp_wrap_modules: Optional[list[str]] = field(
         default=None,
         metadata={


### PR DESCRIPTION
Add --fsdp-ignored-param-names so selected frozen parameters stay replicated on every rank instead of being sharded by FSDP2.


## Change Summary

- What changed?
- Which issue or requirement does this address?
- Which modules are affected?

## Validation

- [ ] I ran the relevant local checks.
- [ ] I added or updated tests where appropriate.
- [ ] I checked compatibility with existing APIs and configurations.

## CI, GPU, and Image Impact

- [ ] This change affects dependencies, Dockerfiles, patches, or runtime environments.
- [ ] GPU validation is required. Suggested suite: `llm_vlm` / `embodied`.
- [ ] A local candidate image should be built during GPU validation.
- [ ] No GPU or image validation is required.

## Reviewer Notes

Describe any known risks, rollout considerations, or follow-up work.
