### PR TITLE
[vla] fix: add import judgment for wall-oss-05-op

### DIFF
--- a/loongforge/embodied/model/wall_oss_0_5/core/action/moe.py
+++ b/loongforge/embodied/model/wall_oss_0_5/core/action/moe.py
@@ -9,7 +9,7 @@ import torch.nn as nn
 import torch.utils.checkpoint as cp
 from transformers.activations import ACT2FN
 
-from wall_oss_05_op import permute, swiglu, unpermute
+from loongforge.embodied.model.wall_oss_0_5.wall_oss_05_fused_ops import permute, swiglu, unpermute
 
 
 class TokenTypeRouter(nn.Module):

--- a/loongforge/embodied/model/wall_oss_0_5/core/attention/joint.py
+++ b/loongforge/embodied/model/wall_oss_0_5/core/attention/joint.py
@@ -20,7 +20,7 @@ from transformers.models.qwen2_5_vl.modeling_qwen2_5_vl import (
 )
 from transformers.utils import logging
 
-from wall_oss_05_op import m_rope, permute, unpermute
+from loongforge.embodied.model.wall_oss_0_5.wall_oss_05_fused_ops import m_rope, permute, unpermute
 
 
 logger = logging.get_logger(__name__)

--- a/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
+++ b/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
@@ -311,6 +311,6 @@ class WallOss05Model(nn.Module):
 
     def on_train_begin(self, *, ctx) -> None:
         """Emit operator backend inventory before measured iterations."""
-        from wall_oss_05_op import log_backend_inventory
+        from loongforge.embodied.model.wall_oss_0_5.wall_oss_05_fused_ops import log_backend_inventory
 
         log_backend_inventory(rank=ctx.rank, world_size=ctx.world_size)

--- a/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl.py
+++ b/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl.py
@@ -59,7 +59,13 @@ from transformers.utils import (
 
 from .configuration_qwen2_5_vl import Qwen25VLConfig, Qwen25VLVisionConfig
 from loongforge.embodied.model.wall_oss_0_5.core.attention.selector import AttentionsSelectorMixin
-from wall_oss_05_op import rot_pos_emb, get_window_index, m_rope, rmsnorm, swiglu
+from loongforge.embodied.model.wall_oss_0_5.wall_oss_05_fused_ops import (
+    rot_pos_emb,
+    get_window_index,
+    m_rope,
+    rmsnorm,
+    swiglu,
+)
 
 if is_flash_attn_2_available():
     from flash_attn import flash_attn_func

--- a/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl_act.py
+++ b/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl_act.py
@@ -53,7 +53,11 @@ from loongforge.embodied.model.wall_oss_0_5.core.action.normalizer import (
 from loongforge.embodied.model.wall_oss_0_5.core.action.moe import TokenTypeRouter, SparseMoeBlock
 from loongforge.embodied.model.wall_oss_0_5.core.attention.joint import JOINT_QWEN_ATTENTION_CLASSES
 from loongforge.embodied.model.wall_oss_0_5.core.moe_indices import build_moe_group_indices
-from wall_oss_05_op import unpermute, permute, get_rope_index
+from loongforge.embodied.model.wall_oss_0_5.wall_oss_05_fused_ops import (
+    unpermute,
+    permute,
+    get_rope_index,
+)
 from loongforge.embodied.model.wall_oss_0_5.core.vision_metadata import (
     compute_vision_grid_metadata,
 )

--- a/loongforge/embodied/model/wall_oss_0_5/wall_oss_05_fused_ops.py
+++ b/loongforge/embodied/model/wall_oss_0_5/wall_oss_05_fused_ops.py
@@ -1,0 +1,35 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""LoongForge compatibility exports for the installed Wall-OSS-0.5 ops."""
+
+try:
+    from wall_oss_05_op import (
+        get_rope_index,
+        get_window_index,
+        log_backend_inventory,
+        m_rope,
+        permute,
+        rmsnorm,
+        rot_pos_emb,
+        swiglu,
+        unpermute,
+    )
+except ImportError as exc:
+    raise ImportError(
+        "The Wall-OSS-0.5 CUDA operators are unavailable. Install "
+        "ops/cuda_source/wall_oss_05_op in the runtime Python environment."
+    ) from exc
+
+
+__all__ = [
+    "get_rope_index",
+    "get_window_index",
+    "log_backend_inventory",
+    "m_rope",
+    "permute",
+    "rmsnorm",
+    "rot_pos_emb",
+    "swiglu",
+    "unpermute",
+]


### PR DESCRIPTION
## Change Summary

Add a check for the import of wall-oss-05-op to prevent import failures when wall-oss-05-op is not installed, which could lead to other models failing to train properly
