### PR TITLE
[vla] fix: pi05 drop CUDA graphs from compile_mode for grad accumulation

### DIFF
--- a/configs/models/embodied/pi05.yaml
+++ b/configs/models/embodied/pi05.yaml
@@ -13,7 +13,7 @@ model:
   # Training
   gradient_checkpointing: false
   compile_model: true
-  compile_mode: max-autotune
+  compile_mode: max-autotune-no-cudagraphs
   # torch.compile granularity 
   # Ignored when compile_model=false.
   #   backbone     (default) single compile over PaliGemmaWithExpertModel.forward — legacy behavior.


### PR DESCRIPTION
PI05 training with gradient accumulation conflicts with CUDA Graphs in the current compile path. Use max-autotune-no-cudagraphs to avoid the conflict and prevent OOM