### PR TITLE
[data] chore: bump nltk to 3.10.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,7 +52,7 @@ gpu = [
     # NLP / dataset utils
     "jsonlines==4.0.0",
     "ftfy==6.1.3",
-    "nltk==3.9.1",
+    "nltk==3.10.3",
     "py-cpuinfo==9.0.0",
     # Monitoring / logging
     "wandb==0.21.4",


### PR DESCRIPTION
Updates `nltk` from 3.9.1 to 3.10.3 in the runtime dependencies.

Evidence:
- `pyproject.toml` pinned `nltk==3.9.1`
- OSV reports 62 advisories for `nltk@3.9.1`, including GHSA-7p94-766c-hgjp (CRITICAL), GHSA-m4rf-3fr8-xwx3 (CRITICAL), GHSA-2ww3-fxvq-293j, GHSA-5gh2-94qg-qppq and the PYSEC-2026-37xx series
- updated version: `3.10.3` (latest release)

Validation:
- `pip-audit` for `nltk==3.10.3` reports only PYSEC-2026-3740, which has no fixed release yet and also affects 3.9.1
- change is a single-line pin update, no source or workflow files touched

Scope: `pyproject.toml` only, nltk pin only.
