### PR TITLE
[vla, ops] perf: optimize wall-oss-0.5 rmsnorm op and prefetch chain ordering

### DIFF
--- a/configs/models/embodied/wall_oss_0_5.yaml
+++ b/configs/models/embodied/wall_oss_0_5.yaml
@@ -25,6 +25,16 @@ model:
   action_horizon: 10
   action_horizon_flow: 10
   use_state_string_representation: false
+  # FSDP2 forward-prefetch depth for Wall-OSS norm leaves. Wall-OSS-specific:
+  # its norms are sharded separately from the decoder layers, so their
+  # AllGathers are not covered by the layer prefetch and need their own
+  # distance. The value is how many following norm leaves each norm unshards
+  # ahead of time.
+  #   0 = off; norms fall back to demand unshard and the AllGather sits on the
+  #       compute critical path
+  #   4 = current default, picked from a repeated sweep over
+  #       0/1/2/3/4/5/6/8/12/16/24 where 4 was the most stable
+  norm_forward_prefetch_distance: 4
 
 data:
   episodes: null

--- a/loongforge/embodied/model/wall_oss_0_5/core/attention/joint.py
+++ b/loongforge/embodied/model/wall_oss_0_5/core/attention/joint.py
@@ -133,7 +133,7 @@ class JointQwen2VLAttention(nn.Module):
 
         if self.config.mot_opt:
             bsz, q_len, _ = orig_shape
-            query_states, key_states, value_states = self._generate_qkv_mot_opt(
+            qkv_states = self._generate_qkv_mot_opt(
                 hidden_states,
                 token_types,
                 start_indices,
@@ -155,9 +155,33 @@ class JointQwen2VLAttention(nn.Module):
 
         # Because the input can be padded, the absolute sequence length depends on the max position id.
         cos, sin = position_embeddings
-        query_states, key_states = self._apply_rotary_pos_embed(
-            query_states, key_states, cos, sin, unsqueeze_dim=2
-        )
+        if self.config.mot_opt:
+            kv_dim = self.num_key_value_heads * self.head_dim
+            q_dim = self.num_heads * self.head_dim
+            qkv_states = m_rope.pack(
+                qkv_states,
+                self.num_heads,
+                self.num_key_value_heads,
+                cos,
+                sin,
+                self.rope_scaling["mrope_section"],
+            )
+            query_states, key_states, value_states = torch.split(
+                qkv_states, [q_dim, kv_dim, kv_dim], dim=-1
+            )
+            query_states = query_states.view(
+                bsz, q_len, self.num_heads, self.head_dim
+            )
+            key_states = key_states.view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+            value_states = value_states.view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+        else:
+            query_states, key_states = self._apply_rotary_pos_embed(
+                query_states, key_states, cos, sin, unsqueeze_dim=2
+            )
         query_states = query_states.transpose(1, 2)
         key_states = key_states.transpose(1, 2)
         value_states = value_states.transpose(1, 2)
@@ -361,7 +385,7 @@ class JointQwen2VLAttention(nn.Module):
         row_id_map: torch.Tensor,
         batch_size: int,
         seq_length: int,
-    ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    ) -> torch.Tensor:
         """
         Generate Q, K, V based on expert-sharded segments (start_indices / end_indices),
         then restore them to the original sequence order.
@@ -375,25 +399,26 @@ class JointQwen2VLAttention(nn.Module):
             batch_size, seq_length: original batch size and sequence length
 
         Returns:
-            query_states: [B, num_heads, S, head_dim]
-            key_states:   [B, num_key_value_heads, S, head_dim]
-            value_states: [B, num_key_value_heads, S, head_dim]
+            qkv_states: [B, S, q_dim + 2 * kv_dim]
         """
 
-        total_tokens, hidden_dim = hidden_states.shape
+        total_tokens, _ = hidden_states.shape
         device, dtype = hidden_states.device, hidden_states.dtype
 
-        # Initialize Q/K/V buffers in the permuted token space
-        q_buffer = torch.zeros(total_tokens, hidden_dim, device=device, dtype=dtype)
-        k_buffer = torch.zeros(
-            total_tokens,
-            self.num_key_value_heads * self.head_dim,
-            device=device,
-            dtype=dtype,
+        q_dim = self.num_heads * self.head_dim
+        kv_dim = self.num_key_value_heads * self.head_dim
+        # ``torch.empty`` leaves rows uninitialized, so it is only safe when the
+        # expert segments cover every row below. ``build_moe_group_indices``
+        # guarantees that, but the compatibility fallback that counts token types
+        # in ``range(num_experts)`` silently drops out-of-range types, which would
+        # otherwise feed uninitialized memory into m_rope/attention.
+        experts_cover_all_rows = (
+            len(end_indices) > 0 and int(end_indices[-1]) == total_tokens
         )
-        v_buffer = torch.zeros(
+        alloc = torch.empty if experts_cover_all_rows else torch.zeros
+        qkv_buffer = alloc(
             total_tokens,
-            self.num_key_value_heads * self.head_dim,
+            q_dim + 2 * kv_dim,
             device=device,
             dtype=dtype,
         )
@@ -409,35 +434,13 @@ class JointQwen2VLAttention(nn.Module):
             if expert_input.dtype != qkv_proj.weight.dtype:
                 expert_input = expert_input.to(qkv_proj.weight.dtype)
 
-            # Compute Q/K/V
-            qkv_out = qkv_proj(expert_input)
-            kv_dim = self.num_key_value_heads * self.head_dim
-            q_out, k_out, v_out = torch.split(
-                qkv_out, [self.num_heads * self.head_dim, kv_dim, kv_dim], dim=-1
-            )
-
-            q_buffer[start:end] = q_out
-            k_buffer[start:end] = k_out
-            v_buffer[start:end] = v_out
+            qkv_buffer[start:end] = qkv_proj(expert_input)
 
         # === Restore tokens to the original order ===
-        #  unpermute (using the same unpermute operation)
-        q_unpermuted = unpermute(q_buffer, row_id_map, probs)
-        k_unpermuted = unpermute(k_buffer, row_id_map, probs)
-        v_unpermuted = unpermute(v_buffer, row_id_map, probs)
-
-        # === Reshape to final form ===
-        query_states = q_unpermuted.view(
-            batch_size, seq_length, self.num_heads, self.head_dim
+        qkv_unpermuted = unpermute(qkv_buffer, row_id_map, probs)
+        return qkv_unpermuted.view(
+            batch_size, seq_length, q_dim + 2 * kv_dim
         )
-        key_states = k_unpermuted.view(
-            batch_size, seq_length, self.num_key_value_heads, self.head_dim
-        )
-        value_states = v_unpermuted.view(
-            batch_size, seq_length, self.num_key_value_heads, self.head_dim
-        )
-
-        return query_states, key_states, value_states
 
     def _apply_rotary_pos_embed(
         self, query_states, key_states, cos, sin, unsqueeze_dim=1
@@ -585,7 +588,7 @@ class JointQwen2VLFlashAttention(JointQwen2VLAttention):
 
         if self.config.mot_opt:
             bsz, q_len, _ = orig_shape
-            query_states, key_states, value_states = self._generate_qkv_mot_opt(
+            qkv_states = self._generate_qkv_mot_opt(
                 hidden_states,
                 token_types,
                 start_indices,
@@ -607,9 +610,33 @@ class JointQwen2VLFlashAttention(JointQwen2VLAttention):
 
         # Because the input can be padded, the absolute sequence length depends on the max position id.
         cos, sin = position_embeddings
-        query_states, key_states = self._apply_rotary_pos_embed(
-            query_states, key_states, cos, sin, unsqueeze_dim=2
-        )
+        if self.config.mot_opt:
+            kv_dim = self.num_key_value_heads * self.head_dim
+            q_dim = self.num_heads * self.head_dim
+            qkv_states = m_rope.pack(
+                qkv_states,
+                self.num_heads,
+                self.num_key_value_heads,
+                cos,
+                sin,
+                self.rope_scaling["mrope_section"],
+            )
+            query_states, key_states, value_states = torch.split(
+                qkv_states, [q_dim, kv_dim, kv_dim], dim=-1
+            )
+            query_states = query_states.view(
+                bsz, q_len, self.num_heads, self.head_dim
+            )
+            key_states = key_states.view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+            value_states = value_states.view(
+                bsz, q_len, self.num_key_value_heads, self.head_dim
+            )
+        else:
+            query_states, key_states = self._apply_rotary_pos_embed(
+                query_states, key_states, cos, sin, unsqueeze_dim=2
+            )
 
         if past_key_value is not None:
             cache_kwargs = {

--- a/loongforge/embodied/model/wall_oss_0_5/core/moe_indices.py
+++ b/loongforge/embodied/model/wall_oss_0_5/core/moe_indices.py
@@ -33,7 +33,7 @@ def build_moe_group_indices(
     if any(count < 0 for count in group_counts):
         raise ValueError(f"MoE group counts must be non-negative, got {group_counts}")
 
-    padded_counts = group_counts + (0,) * (num_experts - len(group_counts))
+    padded_counts = list(group_counts) + [0] * (num_experts - len(group_counts))
     start_indices = []
     end_indices = []
     running_total = 0

--- a/loongforge/embodied/model/wall_oss_0_5/core/vla_mixin.py
+++ b/loongforge/embodied/model/wall_oss_0_5/core/vla_mixin.py
@@ -81,7 +81,20 @@ class ActionModelMixMin:
             # Case 1A: mot_opt=True (segments assigned by start/end)
             # ---------------------------------------------------------
             if self.config.mot_opt:
-                new_hidden_states = torch.zeros_like(hidden_states)
+                # ``build_moe_group_indices`` hands out contiguous segments that
+                # start at 0, so when they reach the last row every row is owned
+                # by some expert and the scatter below overwrites it. Only the
+                # column tail an expert leaves untouched still needs zeroing,
+                # which is far less traffic than filling the whole tensor.
+                full_dim = hidden_states.shape[-1]
+                experts_cover_all_rows = (
+                    len(end_indices) > 0
+                    and int(end_indices[-1]) == hidden_states.shape[0]
+                )
+                if experts_cover_all_rows:
+                    new_hidden_states = torch.empty_like(hidden_states)
+                else:
+                    new_hidden_states = torch.zeros_like(hidden_states)
 
                 for expert_idx, expert_norm in enumerate(norms):
                     start = start_indices[expert_idx]
@@ -132,12 +145,23 @@ class ActionModelMixMin:
                         processed, gate = expert_norm(input_slice, cond)
 
                     # reshape back if needed
-                    if self.config.use_adarms and expert_idx == 1:
+                    if (
+                        processed is not None
+                        and self.config.use_adarms
+                        and expert_idx == 1
+                    ):
                         processed = processed.view(-1, dim_input)
 
-                    new_hidden_states[start:end, :dim_input] = processed.to(
-                        hidden_states.dtype
-                    )
+                    if processed is not None:
+                        new_hidden_states[start:end, :dim_input] = processed.to(
+                            hidden_states.dtype
+                        )
+                        if experts_cover_all_rows and dim_input < full_dim:
+                            new_hidden_states[start:end, dim_input:].zero_()
+                    elif experts_cover_all_rows:
+                        # Nothing was scattered for this expert, so its rows
+                        # still hold uninitialized memory.
+                        new_hidden_states[start:end].zero_()
 
                 hidden_states = new_hidden_states
 

--- a/loongforge/embodied/model/wall_oss_0_5/model_configuration_wall_oss_0_5.py
+++ b/loongforge/embodied/model/wall_oss_0_5/model_configuration_wall_oss_0_5.py
@@ -59,6 +59,7 @@ class WallOss05ModelConfig:
     action_horizon: int = 10
     action_horizon_flow: int = 10
     use_state_string_representation: bool = False
+    norm_forward_prefetch_distance: int = 0
 
     @property
     def action_dim(self) -> int:

--- a/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
+++ b/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
@@ -26,7 +26,8 @@ from loongforge.embodied.model.wall_oss_0_5.qwen2_5 import (
     Qwen25VLConfig,
     Qwen25VLMoEForAction,
 )
-from loongforge.embodied.train.global_vars import get_training_args
+
+from loongforge.embodied.train.global_vars import get_model_config, get_training_args
 
 logger = logging.getLogger(__name__)
 
@@ -261,6 +262,11 @@ class WallOss05Model(nn.Module):
             offload_policy=offload_policy,
             reshard_after_forward=reshard_after_forward,
             use_dmuon=use_dmuon,
+            norm_forward_prefetch_distance=getattr(
+                get_model_config(),
+                "norm_forward_prefetch_distance",
+                0,
+            ),
         )
         if use_dmuon and hasattr(wrapped, "_dedicated_comm_ctx"):
             self._dedicated_comm_ctx = wrapped._dedicated_comm_ctx

--- a/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl_act.py
+++ b/loongforge/embodied/model/wall_oss_0_5/qwen2_5/modeling_qwen2_5_vl_act.py
@@ -470,6 +470,13 @@ class Qwen25VLMoEModel(Qwen25VLPreTrainedModel, ActionModelMixMin):
 
         # create position embeddings to be shared across the decoder layers
         position_embeddings = self.rotary_emb(hidden_states, position_ids)
+        if self.config.mot_opt:
+            cos, sin = position_embeddings
+            mrope_half_dim = cos.size(-1) // 2
+            position_embeddings = (
+                cos[..., :mrope_half_dim].float().contiguous(),
+                sin[..., :mrope_half_dim].float().contiguous(),
+            )
 
         # When mot_opt is enabled, permute tokens from different experts first; shape becomes [Tokens, HiddenSize]
         orig_shape = hidden_states.shape
@@ -2027,6 +2034,99 @@ class Qwen25VLMoEForAction(
             if name in params_to_keep_float32:
                 param.data = param.data.to(torch.float32)
 
+    @staticmethod
+    def relink_dmuon_forward_prefetch(root, subtree_order) -> int:
+        """Rebuild DMuon's forward-prefetch chain in true execution order.
+
+        ``dmuon.api._link_forward_prefetch_states`` orders states by
+        ``model.modules()``, i.e. by the order submodules were *assigned* in
+        ``__init__``. Wall-OSS declares ``action_preprocessor`` after ``model``
+        but runs it before ``model.layers``, so every ``visual.*`` group prefetches
+        ``model.layers.0..N`` and ``action_preprocessor.*`` never gets prefetched at
+        all. Its demand unshard then queues behind the already-dispatched layer
+        broadcasts on the single ``broadcast_stream``, and the compute stream stalls
+        for the full head-of-line latency.
+
+        ``subtree_order`` lists the roots of each subtree in the order they actually
+        run; modules under an earlier subtree sort before modules under a later one,
+        and declaration order is preserved inside each subtree. ``root`` itself
+        always sorts first (it owns the embedding/head groups and is unsharded
+        before the first forward). Modules matching no entry keep their declaration
+        order and sort last.
+        """
+        states = []
+        for module in root.modules():
+            states.extend(getattr(module, "_dedicated_states", ()))
+        if not states:
+            return 0
+        comm_ctx = states[0].comm_ctx
+        # ``comm_ctx.all_states`` is the list DMuon itself iterates; reorder that
+        # exact list rather than a re-derived one.
+        states = list(comm_ctx.all_states)
+        if len(states) <= 1:
+            return 0
+
+        decl_index = {id(module): idx for idx, module in enumerate(root.modules())}
+        phase_of: dict[int, int] = {id(root): -1}
+        for phase, subtree_root in enumerate(subtree_order):
+            if subtree_root is None:
+                continue
+            for module in subtree_root.modules():
+                phase_of.setdefault(id(module), phase)
+        fallback_phase = len(subtree_order)
+
+        def sort_key(state):
+            module_id = id(state.module)
+            return (
+                phase_of.get(module_id, fallback_phase),
+                decl_index.get(module_id, len(decl_index)),
+            )
+
+        ordered = sorted(states, key=sort_key)
+        for state in ordered:
+            state._next_group = None
+            state._next_groups = []
+        for index in range(len(ordered) - 1):
+            ordered[index]._next_group = ordered[index + 1].group
+            ordered[index]._next_groups = [
+                later.group for later in ordered[index + 1 :]
+            ]
+        ordered[0].comm_ctx.all_states[:] = ordered
+
+        logger.info(
+            "[DMuon] forward prefetch relinked in execution order: states=%d head=%s",
+            len(ordered),
+            [type(state.module).__name__ for state in ordered[:4]],
+        )
+        return len(ordered)
+
+    @staticmethod
+    def configure_norm_forward_prefetch(ordered_norms, distance: int) -> int:
+        """Prefetch future norm leaves without changing their ownership."""
+        from torch.distributed.fsdp import FSDPModule
+
+        if distance <= 0:
+            return 0
+
+        modules = [module for module in ordered_norms if isinstance(module, FSDPModule)]
+        if len(modules) <= 1:
+            return 0
+
+        edge_count = 0
+        for index, module in enumerate(modules):
+            targets = modules[index + 1 : index + 1 + distance]
+            if targets:
+                module.set_modules_to_forward_prefetch(targets)
+                edge_count += len(targets)
+
+        logger.info(
+            "[FSDP2] norm forward prefetch: modules=%d distance=%d edges=%d",
+            len(modules),
+            distance,
+            edge_count,
+        )
+        return edge_count
+
     def convert_to_fsdp(
         self,
         *,
@@ -2035,6 +2135,7 @@ class Qwen25VLMoEForAction(
         offload_policy=None,
         reshard_after_forward: bool = True,
         use_dmuon: bool = False,
+        norm_forward_prefetch_distance: int = 0,
     ):
         """Wrap with FSDP2: per-decoder-layer + per-vision-block fully_shard
         with bf16 ``mp_policy``; layernorms and ``action_preprocessor`` leaves
@@ -2101,9 +2202,36 @@ class Qwen25VLMoEForAction(
                 len(assignment),
             )
 
+            # DMuon links its forward-prefetch chain by __init__ assignment
+            # order, in which ``action_preprocessor`` (declared after
+            # ``self.model``) lands behind every decoder layer even though it
+            # runs right after the vision encoder. Relink in execution order so
+            # its unshard is prefetched instead of queueing behind the
+            # already-dispatched layer broadcasts.
+            self.relink_dmuon_forward_prefetch(
+                self,
+                (self.visual, self.action_preprocessor),
+            )
+
+        ordered_norms = []
+        for layer in self.model.layers:
+            for norm_name in ("input_layernorms", "post_attention_layernorms"):
+                norm_container = getattr(layer, norm_name, None)
+                if norm_container is not None:
+                    ordered_norms.extend(list(norm_container))
+
         fp32_mp = MixedPrecisionPolicy(
             param_dtype=torch.float32,
             reduce_dtype=torch.float32,
+        )
+        # Same fp32 params and fp32 gradient reduction, but FSDP no longer
+        # materializes an fp32 copy of the activation. The RMSNorm kernel widens
+        # bf16 -> fp32 per element instead, which is lossless, so this removes a
+        # cast without touching how the norm parameters are sharded or reduced.
+        fp32_mp_nocast = MixedPrecisionPolicy(
+            param_dtype=torch.float32,
+            reduce_dtype=torch.float32,
+            cast_forward_inputs=False,
         )
         shard_kwargs = dict(
             mesh=mesh,
@@ -2113,6 +2241,21 @@ class Qwen25VLMoEForAction(
         if offload_policy is not None:
             shard_kwargs["offload_policy"] = offload_policy
         fp32_shard_kwargs = dict(shard_kwargs, mp_policy=fp32_mp)
+        fp32_nocast_shard_kwargs = dict(shard_kwargs, mp_policy=fp32_mp_nocast)
+        nocast_leaves = 0
+
+        def fp32_kwargs_for(leaf: nn.Module) -> dict:
+            """Skip the forward-input cast for plain (non-adaptive) RMSNorm leaves.
+
+            An AdaRMSNorm leaf keeps the cast: it returns a ``gate`` whose dtype
+            follows the input, and downstream ``_gated_residual`` consumes that
+            gate in fp32.
+            """
+            nonlocal nocast_leaves
+            if getattr(leaf, "dense", None) is not None:
+                return fp32_shard_kwargs
+            nocast_leaves += 1
+            return fp32_nocast_shard_kwargs
 
         def fully_shard_fp32_leaf_or_container(name: str, module: nn.Module) -> None:
             # FSDP2 cannot shard containers without forward(), e.g. ModuleList.
@@ -2137,11 +2280,11 @@ class Qwen25VLMoEForAction(
                         name,
                         leaf_name,
                     )
-                    fully_shard(leaf, **fp32_shard_kwargs)
+                    fully_shard(leaf, **fp32_kwargs_for(leaf))
                 return
 
             logger.info("[FSDP2] fully_shard fp32 layernorm: %s", name)
-            fully_shard(module, **fp32_shard_kwargs)
+            fully_shard(module, **fp32_kwargs_for(module))
 
         # Layernorm leaves inside decoder layers / vision blocks / model.norm
         # - wrap with fp32 mp_policy BEFORE wrapping their parents so the
@@ -2155,6 +2298,11 @@ class Qwen25VLMoEForAction(
                     fully_shard_fp32_leaf_or_container(
                         f"{module_name}.{child_name}", child
                     )
+
+        logger.info(
+            "[FSDP2] fp32 norm leaves without forward-input cast: %d",
+            nocast_leaves,
+        )
 
         # action_preprocessor leaves: same fp32 treatment as layernorms.
         for name, module in list(self.named_modules()):
@@ -2189,4 +2337,8 @@ class Qwen25VLMoEForAction(
         # nested fully_shard. Inner fp32 wraps maintain their own policy.
         logger.info("[FSDP2] fully_shard root (bf16)")
         fully_shard(self, **shard_kwargs)
+        self.configure_norm_forward_prefetch(
+            ordered_norms,
+            norm_forward_prefetch_distance,
+        )
         return self

--- a/ops/cuda_source/wall_oss_05_op/csrc/binding_exact.cu
+++ b/ops/cuda_source/wall_oss_05_op/csrc/binding_exact.cu
@@ -25,6 +25,8 @@ void SwigluExactBwd(const at::Tensor& grad_out, const at::Tensor& gate, const at
 
 namespace wallx_cuda_rmsnorm_exact {
 void RmsNormExactSquare(const at::Tensor& x, const at::Tensor& sq);
+void RmsNormExactInv(const at::Tensor& var, const at::Tensor& inv, double eps);
+void RmsNormExactGsq2(const at::Tensor& g_inv, const at::Tensor& inv, const at::Tensor& g_sq2, long cols);
 void RmsNormExactFwdOut(const at::Tensor& x, const at::Tensor& inv, const at::Tensor& weight, const at::Tensor& out);
 void RmsNormExactBwdProd(const at::Tensor& grad_out, const at::Tensor& x, const at::Tensor& inv, const at::Tensor& weight, const at::Tensor& p_dw, const at::Tensor& p_inv);
 void RmsNormExactBwdDx(const at::Tensor& grad_out, const at::Tensor& x, const at::Tensor& inv, const at::Tensor& g_sq2, const at::Tensor& weight, const at::Tensor& dx);
@@ -34,6 +36,8 @@ PYBIND11_MODULE(TORCH_EXTENSION_NAME, m) {
     m.def("swiglu_exact_fwd", &wallx_cuda_swiglu_exact::SwigluExactFwd);
     m.def("swiglu_exact_bwd", &wallx_cuda_swiglu_exact::SwigluExactBwd);
     m.def("rmsnorm_exact_square", &wallx_cuda_rmsnorm_exact::RmsNormExactSquare);
+    m.def("rmsnorm_exact_inv", &wallx_cuda_rmsnorm_exact::RmsNormExactInv);
+    m.def("rmsnorm_exact_gsq2", &wallx_cuda_rmsnorm_exact::RmsNormExactGsq2);
     m.def("rmsnorm_exact_fwd_out", &wallx_cuda_rmsnorm_exact::RmsNormExactFwdOut);
     m.def("rmsnorm_exact_bwd_prod", &wallx_cuda_rmsnorm_exact::RmsNormExactBwdProd);
     m.def("rmsnorm_exact_bwd_dx", &wallx_cuda_rmsnorm_exact::RmsNormExactBwdDx);

--- a/ops/cuda_source/wall_oss_05_op/csrc/rmsnorm_exact/rmsnorm_exact.cu
+++ b/ops/cuda_source/wall_oss_05_op/csrc/rmsnorm_exact/rmsnorm_exact.cu
@@ -79,6 +79,18 @@ void check_elem(const at::Tensor &t, at::ScalarType dtype, const char *name) {
     TORCH_CHECK(t.is_cuda(), "rmsnorm_exact: ", name, " must be a CUDA tensor");
 }
 
+// The weight may stay fp32 while the activations are bf16. That happens when the
+// norm leaf keeps fp32 parameters but FSDP no longer casts the forward inputs:
+// bf16 -> fp32 widening is lossless, so the kernel can do it per element instead
+// of materializing an fp32 copy of the activation.
+at::ScalarType weight_dtype(const at::Tensor &w, at::ScalarType elem) {
+    TORCH_CHECK(w.is_cuda(), "rmsnorm_exact: weight must be a CUDA tensor");
+    TORCH_CHECK(w.scalar_type() == elem || w.scalar_type() == at::kFloat,
+                "rmsnorm_exact: weight must match the activation dtype or be float32, got ",
+                w.scalar_type(), " for ", elem, " activations");
+    return w.scalar_type();
+}
+
 at::ScalarType elem_dtype(const at::Tensor &t) {
     TORCH_CHECK(t.scalar_type() == at::kBFloat16 || t.scalar_type() == at::kFloat,
                 "rmsnorm_exact: only bfloat16 and float32 are supported, got ", t.scalar_type());
@@ -110,6 +122,27 @@ long grid_for(long total) { return (total + kThreads - 1) / kThreads; }
         }                                                                    \
     } while (0)
 
+// Dispatch over the element type and, independently, the weight type. Only three
+// combinations exist: (bf16, bf16), (bf16, fp32) and (fp32, fp32) -- an fp32
+// activation never pairs with a bf16 weight.
+#define WALLX_RMSNORM_DISPATCH_W(DTYPE, WDTYPE, ...)                          \
+    do {                                                                      \
+        if ((DTYPE) == at::kBFloat16) {                                       \
+            using scalar_t = __nv_bfloat16;                                   \
+            if ((WDTYPE) == at::kBFloat16) {                                  \
+                using weight_t = __nv_bfloat16;                               \
+                __VA_ARGS__;                                                  \
+            } else {                                                          \
+                using weight_t = float;                                       \
+                __VA_ARGS__;                                                  \
+            }                                                                 \
+        } else {                                                              \
+            using scalar_t = float;                                           \
+            using weight_t = float;                                           \
+            __VA_ARGS__;                                                      \
+        }                                                                     \
+    } while (0)
+
 // sq = x32 * x32; consumed by at::mean afterwards. Matches eager's
 // `x.to(fp32).pow(2)` (ATen lowers pow(t, 2) to t*t).
 template <typename T>
@@ -123,18 +156,42 @@ __global__ void rmsnorm_exact_square_kernel(const T *__restrict__ x, long x_rs,
     sq[r * s_rs + c] = __fmul_rn(xf, xf);
 }
 
+// inv = rsqrt(var + eps), replacing the ATen `add` + `rsqrt` pair with one launch.
+// ``rsqrtf`` is the same device function ATen's rsqrt_kernel_cuda calls, and this
+// module is built without --use_fast_math, so the result is bit-identical.
+__global__ void rmsnorm_exact_inv_kernel(const float *__restrict__ var,
+                                         float *__restrict__ inv, float eps, long n) {
+    long idx = blockIdx.x * (long)blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    inv[idx] = rsqrtf(__fadd_rn(var[idx], eps));
+}
+
+// g_sq2 = ((-0.5 * g_inv) * inv^3 / N) * 2, collapsing five ATen pointwise launches.
+// Mirrors ATen op-for-op: pow(t, 3) lowers to t*t*t, and division by a CPU scalar
+// lowers to a multiply by the fp32 reciprocal, which is why recip_n is passed in.
+__global__ void rmsnorm_exact_gsq2_kernel(const float *__restrict__ g_inv,
+                                          const float *__restrict__ inv, float recip_n,
+                                          float *__restrict__ g_sq2, long n) {
+    long idx = blockIdx.x * (long)blockDim.x + threadIdx.x;
+    if (idx >= n) return;
+    float i = inv[idx];
+    float cube = __fmul_rn(__fmul_rn(i, i), i);
+    float g_var = __fmul_rn(__fmul_rn(-0.5f, g_inv[idx]), cube);
+    g_sq2[idx] = __fmul_rn(__fmul_rn(g_var, recip_n), 2.0f);
+}
+
 // out = (w * (x32 * inv)).to(input_dtype)
-template <typename T>
+template <typename T, typename W>
 __global__ void rmsnorm_exact_fwd_out_kernel(const T *__restrict__ x, long x_rs,
                                              const float *__restrict__ inv,
-                                             const T *__restrict__ w,
+                                             const W *__restrict__ w,
                                              T *__restrict__ out, long o_rs,
                                              long rows, long cols) {
     long idx = blockIdx.x * (long)blockDim.x + threadIdx.x;
     if (idx >= rows * cols) return;
     long r = idx / cols, c = idx - r * cols;
     float xf = Cvt<T>::load(x[r * x_rs + c]);
-    float wf = Cvt<T>::load(w[c]);
+    float wf = Cvt<W>::load(w[c]);
     float normed = __fmul_rn(xf, inv[r]);
     out[r * o_rs + c] = Cvt<T>::store(__fmul_rn(wf, normed));
 }
@@ -142,11 +199,11 @@ __global__ void rmsnorm_exact_fwd_out_kernel(const T *__restrict__ x, long x_rs,
 // The two fp32 products consumed by the ATen reductions:
 //   p_dw  = g32 * normed       -> sum over leading dims = dw
 //   p_inv = (g32 * w32) * x32  -> sum over last dim     = grad wrt inv
-template <typename T>
+template <typename T, typename W>
 __global__ void rmsnorm_exact_bwd_prod_kernel(const T *__restrict__ go, long g_rs,
                                               const T *__restrict__ x, long x_rs,
                                               const float *__restrict__ inv,
-                                              const T *__restrict__ w,
+                                              const W *__restrict__ w,
                                               float *__restrict__ p_dw, long pd_rs,
                                               float *__restrict__ p_inv, long pi_rs,
                                               long rows, long cols) {
@@ -155,19 +212,19 @@ __global__ void rmsnorm_exact_bwd_prod_kernel(const T *__restrict__ go, long g_r
     long r = idx / cols, c = idx - r * cols;
     float gf = Cvt<T>::load(go[r * g_rs + c]);
     float xf = Cvt<T>::load(x[r * x_rs + c]);
-    float wf = Cvt<T>::load(w[c]);
+    float wf = Cvt<W>::load(w[c]);
     float invf = inv[r];
     p_dw[r * pd_rs + c] = __fmul_rn(gf, __fmul_rn(xf, invf));
     p_inv[r * pi_rs + c] = __fmul_rn(__fmul_rn(gf, wf), xf);
 }
 
 // dx = ((g32*w32) * inv + g_sq2 * x32).to(input_dtype), g_sq2 = 2*g_var/N from ATen.
-template <typename T>
+template <typename T, typename W>
 __global__ void rmsnorm_exact_bwd_dx_kernel(const T *__restrict__ go, long g_rs,
                                             const T *__restrict__ x, long x_rs,
                                             const float *__restrict__ inv,
                                             const float *__restrict__ g_sq2,
-                                            const T *__restrict__ w,
+                                            const W *__restrict__ w,
                                             T *__restrict__ dx, long d_rs,
                                             long rows, long cols) {
     long idx = blockIdx.x * (long)blockDim.x + threadIdx.x;
@@ -175,7 +232,7 @@ __global__ void rmsnorm_exact_bwd_dx_kernel(const T *__restrict__ go, long g_rs,
     long r = idx / cols, c = idx - r * cols;
     float gf = Cvt<T>::load(go[r * g_rs + c]);
     float xf = Cvt<T>::load(x[r * x_rs + c]);
-    float wf = Cvt<T>::load(w[c]);
+    float wf = Cvt<W>::load(w[c]);
     float dx_a = __fmul_rn(__fmul_rn(gf, wf), inv[r]);
     float dx_b = __fmul_rn(g_sq2[r], xf);
     dx[r * d_rs + c] = Cvt<T>::store(__fadd_rn(dx_a, dx_b));
@@ -198,7 +255,7 @@ void RmsNormExactSquare(const at::Tensor &x, const at::Tensor &sq) {
 void RmsNormExactFwdOut(const at::Tensor &x, const at::Tensor &inv, const at::Tensor &weight,
                         const at::Tensor &out) {
     at::ScalarType dt = elem_dtype(x);
-    check_elem(weight, dt, "weight");
+    at::ScalarType wt = weight_dtype(weight, dt);
     check_elem(out, dt, "out");
     Shape2D sx = collapse(x), so = collapse(out);
     check_rowvec(inv, sx.rows, "inv");
@@ -206,12 +263,46 @@ void RmsNormExactFwdOut(const at::Tensor &x, const at::Tensor &inv, const at::Te
                 "rmsnorm_exact: weight must be contiguous with cols entries");
     long total = sx.rows * sx.cols;
     if (total == 0) return;
-    WALLX_RMSNORM_DISPATCH(dt,
-        rmsnorm_exact_fwd_out_kernel<scalar_t>
+    WALLX_RMSNORM_DISPATCH_W(dt, wt,
+        rmsnorm_exact_fwd_out_kernel<scalar_t, weight_t>
             <<<grid_for(total), kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 reinterpret_cast<const scalar_t *>(x.data_ptr()), sx.row_stride,
-                inv.data_ptr<float>(), reinterpret_cast<const scalar_t *>(weight.data_ptr()),
+                inv.data_ptr<float>(), reinterpret_cast<const weight_t *>(weight.data_ptr()),
                 reinterpret_cast<scalar_t *>(out.data_ptr()), so.row_stride, sx.rows, sx.cols));
+    sync_check_cuda_error();
+}
+
+void RmsNormExactInv(const at::Tensor &var, const at::Tensor &inv, double eps) {
+    TORCH_CHECK(var.scalar_type() == at::kFloat && inv.scalar_type() == at::kFloat,
+                "rmsnorm_exact: var/inv must be float32");
+    TORCH_CHECK(var.is_cuda() && inv.is_cuda(), "rmsnorm_exact: var/inv must be CUDA tensors");
+    TORCH_CHECK(var.is_contiguous() && inv.is_contiguous(),
+                "rmsnorm_exact: var/inv must be contiguous");
+    TORCH_CHECK(var.numel() == inv.numel(), "rmsnorm_exact: var/inv size mismatch");
+    long total = var.numel();
+    if (total == 0) return;
+    rmsnorm_exact_inv_kernel<<<grid_for(total), kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        var.data_ptr<float>(), inv.data_ptr<float>(), static_cast<float>(eps), total);
+    sync_check_cuda_error();
+}
+
+void RmsNormExactGsq2(const at::Tensor &g_inv, const at::Tensor &inv, const at::Tensor &g_sq2,
+                      long cols) {
+    TORCH_CHECK(g_inv.scalar_type() == at::kFloat && inv.scalar_type() == at::kFloat &&
+                    g_sq2.scalar_type() == at::kFloat,
+                "rmsnorm_exact: g_inv/inv/g_sq2 must be float32");
+    TORCH_CHECK(g_inv.is_cuda() && inv.is_cuda() && g_sq2.is_cuda(),
+                "rmsnorm_exact: g_inv/inv/g_sq2 must be CUDA tensors");
+    TORCH_CHECK(g_inv.is_contiguous() && inv.is_contiguous() && g_sq2.is_contiguous(),
+                "rmsnorm_exact: g_inv/inv/g_sq2 must be contiguous");
+    TORCH_CHECK(g_inv.numel() == inv.numel() && g_inv.numel() == g_sq2.numel(),
+                "rmsnorm_exact: g_inv/inv/g_sq2 size mismatch");
+    TORCH_CHECK(cols > 0, "rmsnorm_exact: cols must be positive");
+    long total = g_inv.numel();
+    if (total == 0) return;
+    float recip_n = 1.0f / static_cast<float>(cols);
+    rmsnorm_exact_gsq2_kernel<<<grid_for(total), kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
+        g_inv.data_ptr<float>(), inv.data_ptr<float>(), recip_n, g_sq2.data_ptr<float>(), total);
     sync_check_cuda_error();
 }
 
@@ -219,19 +310,19 @@ void RmsNormExactBwdProd(const at::Tensor &grad_out, const at::Tensor &x, const 
                          const at::Tensor &weight, const at::Tensor &p_dw,
                          const at::Tensor &p_inv) {
     at::ScalarType dt = elem_dtype(x);
+    at::ScalarType wt = weight_dtype(weight, dt);
     check_elem(grad_out, dt, "grad_out");
-    check_elem(weight, dt, "weight");
     Shape2D sgo = collapse(grad_out), sx = collapse(x);
     Shape2D spd = collapse(p_dw), spi = collapse(p_inv);
     check_rowvec(inv, sx.rows, "inv");
     long total = sx.rows * sx.cols;
     if (total == 0) return;
-    WALLX_RMSNORM_DISPATCH(dt,
-        rmsnorm_exact_bwd_prod_kernel<scalar_t>
+    WALLX_RMSNORM_DISPATCH_W(dt, wt,
+        rmsnorm_exact_bwd_prod_kernel<scalar_t, weight_t>
             <<<grid_for(total), kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 reinterpret_cast<const scalar_t *>(grad_out.data_ptr()), sgo.row_stride,
                 reinterpret_cast<const scalar_t *>(x.data_ptr()), sx.row_stride,
-                inv.data_ptr<float>(), reinterpret_cast<const scalar_t *>(weight.data_ptr()),
+                inv.data_ptr<float>(), reinterpret_cast<const weight_t *>(weight.data_ptr()),
                 p_dw.data_ptr<float>(), spd.row_stride, p_inv.data_ptr<float>(), spi.row_stride,
                 sx.rows, sx.cols));
     sync_check_cuda_error();
@@ -240,21 +331,21 @@ void RmsNormExactBwdProd(const at::Tensor &grad_out, const at::Tensor &x, const 
 void RmsNormExactBwdDx(const at::Tensor &grad_out, const at::Tensor &x, const at::Tensor &inv,
                        const at::Tensor &g_sq2, const at::Tensor &weight, const at::Tensor &dx) {
     at::ScalarType dt = elem_dtype(x);
+    at::ScalarType wt = weight_dtype(weight, dt);
     check_elem(grad_out, dt, "grad_out");
-    check_elem(weight, dt, "weight");
     check_elem(dx, dt, "dx");
     Shape2D sgo = collapse(grad_out), sx = collapse(x), sd = collapse(dx);
     check_rowvec(inv, sx.rows, "inv");
     check_rowvec(g_sq2, sx.rows, "g_sq2");
     long total = sx.rows * sx.cols;
     if (total == 0) return;
-    WALLX_RMSNORM_DISPATCH(dt,
-        rmsnorm_exact_bwd_dx_kernel<scalar_t>
+    WALLX_RMSNORM_DISPATCH_W(dt, wt,
+        rmsnorm_exact_bwd_dx_kernel<scalar_t, weight_t>
             <<<grid_for(total), kThreads, 0, at::cuda::getCurrentCUDAStream()>>>(
                 reinterpret_cast<const scalar_t *>(grad_out.data_ptr()), sgo.row_stride,
                 reinterpret_cast<const scalar_t *>(x.data_ptr()), sx.row_stride,
                 inv.data_ptr<float>(), g_sq2.data_ptr<float>(),
-                reinterpret_cast<const scalar_t *>(weight.data_ptr()),
+                reinterpret_cast<const weight_t *>(weight.data_ptr()),
                 reinterpret_cast<scalar_t *>(dx.data_ptr()), sd.row_stride, sx.rows, sx.cols));
     sync_check_cuda_error();
 }

--- a/ops/cuda_source/wall_oss_05_op/test/test_wall_oss_05_op.py
+++ b/ops/cuda_source/wall_oss_05_op/test/test_wall_oss_05_op.py
@@ -220,6 +220,125 @@ def test_rmsnorm_exact_matches_pytorch(ext_exact, dtype):
     torch.testing.assert_close(cuda_out, ref, rtol=1e-3, atol=1e-3)
 
 
+def test_rmsnorm_exact_inv_is_bitwise_identical_to_aten(ext_exact):
+    """The fused inv kernel must reproduce ``rsqrt(var + eps)`` bit for bit."""
+    torch.manual_seed(11)
+    eps = 1e-6
+    var = torch.rand(4096, 1, device="cuda", dtype=torch.float32).mul_(50.0)
+    inv = torch.empty_like(var)
+    ext_exact.rmsnorm_exact_inv(var, inv, eps)
+    assert torch.equal(inv, torch.rsqrt(var + eps))
+
+
+@pytest.mark.parametrize("cols", [256, 1024, 2048])
+def test_rmsnorm_exact_gsq2_is_bitwise_identical_to_aten(ext_exact, cols):
+    """The fused g_sq2 kernel must reproduce the ATen pointwise chain bit for bit."""
+    torch.manual_seed(13)
+    rows = 3072
+    g_inv = torch.randn(rows, 1, device="cuda", dtype=torch.float32)
+    inv = torch.rand(rows, 1, device="cuda", dtype=torch.float32).add_(0.1)
+    g_sq2 = torch.empty_like(g_inv)
+    ext_exact.rmsnorm_exact_gsq2(g_inv, inv, g_sq2, cols)
+
+    g_var = (-0.5 * g_inv) * inv.pow(3)
+    ref = ((g_var / cols) * 2.0).contiguous()
+    assert torch.equal(g_sq2, ref)
+
+
+@pytest.mark.parametrize("dtype", [torch.bfloat16, torch.float32])
+def test_rmsnorm_exact_backward_matches_unfused_chain(ext_exact, dtype):
+    """Forward and backward must stay bit-identical after the launch fusion."""
+    from wall_oss_05_op._cuda_wrappers import rmsnorm_exact_kernel
+
+    torch.manual_seed(23)
+    eps = 1e-6
+    x = torch.randn(129, 1024, device="cuda", dtype=dtype).requires_grad_()
+    w = torch.randn(1024, device="cuda", dtype=dtype).requires_grad_()
+    out = rmsnorm_exact_kernel(x, w, eps)
+    grad = torch.randn_like(out)
+    dx, dw = torch.autograd.grad((out * grad).sum(), (x, w))
+
+    # Unfused reference: same kernels, ATen pointwise glue (pre-fusion ordering).
+    module = ext_exact
+    xd = x.detach()
+    sq = torch.empty(xd.shape, dtype=torch.float32, device=xd.device)
+    module.rmsnorm_exact_square(xd, sq)
+    inv = torch.rsqrt(sq.mean(-1, keepdim=True) + eps)
+    ref_out = torch.empty(xd.shape, dtype=dtype, device=xd.device)
+    module.rmsnorm_exact_fwd_out(xd, inv.reshape(-1), w.detach(), ref_out)
+    assert torch.equal(out, ref_out)
+
+    opts = dict(dtype=torch.float32, device=xd.device)
+    p_dw = torch.empty(xd.shape, **opts)
+    p_inv = torch.empty(xd.shape, **opts)
+    module.rmsnorm_exact_bwd_prod(grad, xd, inv.reshape(-1), w.detach(), p_dw, p_inv)
+    ref_dw = p_dw.sum(dim=tuple(range(xd.dim() - 1))).to(dtype)
+    g_inv = p_inv.sum(-1, keepdim=True)
+    n = xd.shape[-1]
+    g_sq2 = (((-0.5 * g_inv) * inv.pow(3) / n) * 2.0).reshape(-1).contiguous()
+    ref_dx = torch.empty(xd.shape, dtype=dtype, device=xd.device)
+    module.rmsnorm_exact_bwd_dx(grad, xd, inv.reshape(-1), g_sq2, w.detach(), ref_dx)
+
+    assert torch.equal(dx, ref_dx)
+    assert torch.equal(dw, ref_dw)
+
+
+def _upcast_reference(x_bf16, w_fp32, eps=1e-6):
+    """Model today's path: FSDP casts the input to fp32, the scatter casts back."""
+    from wall_oss_05_op._cuda_wrappers import rmsnorm_exact_kernel
+
+    x32 = x_bf16.to(torch.float32)
+    out32 = rmsnorm_exact_kernel(x32, w_fp32, eps)
+    return out32.to(torch.bfloat16)
+
+
+@pytest.mark.parametrize("padding", [0, 1024])
+def test_rmsnorm_exact_fp32_weight_matches_upcast_path(ext_exact, padding):
+    """bf16 activations with an fp32 weight must equal the fp32-upcast path.
+
+    ``padding`` > 0 exercises a strided activation view, which is what the norm
+    receives once FSDP stops materializing a contiguous fp32 copy.
+    """
+    from wall_oss_05_op._cuda_wrappers import rmsnorm_exact_kernel
+
+    torch.manual_seed(31)
+    rows, cols = 137, 1024
+    storage = torch.randn(rows, cols + padding, device="cuda", dtype=torch.bfloat16)
+    weight = torch.randn(cols, device="cuda", dtype=torch.float32)
+    grad = torch.randn(rows, cols, device="cuda", dtype=torch.bfloat16)
+
+    x_ref = storage.clone().requires_grad_()
+    w_ref = weight.clone().requires_grad_()
+    ref = _upcast_reference(x_ref[:, :cols], w_ref)
+    ref_dx, ref_dw = torch.autograd.grad((ref * grad).sum(), (x_ref, w_ref))
+
+    x_cand = storage.clone().requires_grad_()
+    w_cand = weight.clone().requires_grad_()
+    cand = rmsnorm_exact_kernel(x_cand[:, :cols], w_cand)
+    cand_dx, cand_dw = torch.autograd.grad((cand * grad).sum(), (x_cand, w_cand))
+
+    assert cand.dtype is torch.bfloat16
+    assert cand_dw.dtype is torch.float32
+    assert torch.equal(cand, ref)
+    assert torch.equal(cand_dx, ref_dx)
+    assert torch.equal(cand_dw, ref_dw)
+
+
+def test_rmsnorm_dispatcher_uses_cuda_for_fp32_weight_with_bf16_activation(ext_exact):
+    """The dispatcher must not silently fall back for the mixed dtype pair."""
+    from wall_oss_05_op.norm import rmsnorm as rmsnorm_op
+
+    torch.manual_seed(37)
+    x = torch.randn(64, 256, device="cuda", dtype=torch.bfloat16)
+    w = torch.randn(256, device="cuda", dtype=torch.float32)
+    assert rmsnorm_op._cuda_supported(x, w)
+
+    out = rmsnorm_op(x, w, 1e-6)
+    assert out.dtype is torch.bfloat16
+    assert torch.equal(out, _upcast_reference(x, w))
+    assert not rmsnorm_op._input_fallback_logged
+
+
 @pytest.mark.parametrize("dtype", [torch.bfloat16])
 def test_swiglu_exact_matches_pytorch(ext_exact, dtype):
     """Exact SwiGLU CUDA must match eager PyTorch forward."""
@@ -400,6 +519,50 @@ def test_public_api_m_rope():
     assert k_out.shape == k.shape
 
 
+def test_public_api_m_rope_pack_matches_split_path():
+    """Packed M-RoPE preserves split-path outputs and gradients."""
+    from wall_oss_05_op import m_rope
+
+    torch.manual_seed(3)
+    b, s, hq, hkv, d = 2, 5, 8, 2, 32
+    q_dim = hq * d
+    kv_dim = hkv * d
+    first, second = 8, 8
+    qkv_data = torch.randn(
+        (b, s, q_dim + 2 * kv_dim), device="cuda", dtype=torch.bfloat16
+    )
+    cos = torch.randn(
+        (3, b, s, d // 2), device="cuda", dtype=torch.float32
+    )
+    sin = torch.randn_like(cos)
+
+    qkv_ref = qkv_data.detach().clone().requires_grad_()
+    q_ref = qkv_ref[..., :q_dim].view(b, s, hq, d)
+    k_ref = qkv_ref[..., q_dim : q_dim + kv_dim].view(b, s, hkv, d)
+    q_out, k_out = m_rope(q_ref, k_ref, cos, sin, (first, second))
+    reference = torch.cat(
+        (
+            q_out.reshape(b, s, q_dim),
+            k_out.reshape(b, s, kv_dim),
+            qkv_ref[..., q_dim + kv_dim :],
+        ),
+        dim=-1,
+    )
+
+    qkv_candidate = qkv_data.detach().clone().requires_grad_()
+    candidate = m_rope.pack(
+        qkv_candidate, hq, hkv, cos, sin, (first, second)
+    )
+    torch.testing.assert_close(candidate, reference, rtol=0, atol=0)
+
+    upstream = torch.randn_like(reference)
+    (reference * upstream).sum().backward()
+    (candidate * upstream).sum().backward()
+    torch.testing.assert_close(
+        qkv_candidate.grad, qkv_ref.grad, rtol=0, atol=0
+    )
+
+
 def test_public_api_rmsnorm():
     """rmsnorm() via top-level import with matching float32 weight."""
     from wall_oss_05_op import rmsnorm
@@ -431,6 +594,47 @@ def test_public_api_permute_unpermute():
     assert restored.shape == tokens.shape
     # Single topk: restored should equal original
     torch.testing.assert_close(restored, tokens)
+
+
+def test_single_qkv_unpermute_matches_three_separate_unpermutes():
+    """One packed QKV unpermute preserves three-path outputs and gradients."""
+    from wall_oss_05_op import permute, unpermute
+
+    torch.manual_seed(4)
+    n, q_dim, kv_dim = 37, 64, 16
+    qkv_dim = q_dim + 2 * kv_dim
+    qkv_data = torch.randn(
+        (n, qkv_dim), device="cuda", dtype=torch.bfloat16
+    )
+    expert_indices = torch.randint(
+        0, 2, (n,), device="cuda", dtype=torch.int32
+    )
+    permuted, row_map = permute(qkv_data, expert_indices)
+    probs = torch.rand((n, 1), device="cuda", dtype=torch.float32)
+
+    packed_ref = permuted.detach().clone().requires_grad_()
+    q_ref, k_ref, v_ref = torch.split(
+        packed_ref, (q_dim, kv_dim, kv_dim), dim=-1
+    )
+    reference = torch.cat(
+        (
+            unpermute(q_ref, row_map, probs),
+            unpermute(k_ref, row_map, probs),
+            unpermute(v_ref, row_map, probs),
+        ),
+        dim=-1,
+    )
+
+    packed_candidate = permuted.detach().clone().requires_grad_()
+    candidate = unpermute(packed_candidate, row_map, probs)
+    torch.testing.assert_close(candidate, reference, rtol=0, atol=0)
+
+    upstream = torch.randn_like(reference)
+    (reference * upstream).sum().backward()
+    (candidate * upstream).sum().backward()
+    torch.testing.assert_close(
+        packed_candidate.grad, packed_ref.grad, rtol=0, atol=0
+    )
 
 
 def test_public_api_get_rope_index(ext):

--- a/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/_cuda_wrappers.py
+++ b/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/_cuda_wrappers.py
@@ -789,6 +789,8 @@ def unpermute_kernel(input_act, row_id_map, probs=None):
 SWIGLU_EXACT_SYMBOLS = ("swiglu_exact_fwd", "swiglu_exact_bwd")
 RMSNORM_EXACT_SYMBOLS = (
     "rmsnorm_exact_square",
+    "rmsnorm_exact_inv",
+    "rmsnorm_exact_gsq2",
     "rmsnorm_exact_fwd_out",
     "rmsnorm_exact_bwd_prod",
     "rmsnorm_exact_bwd_dx",
@@ -856,8 +858,10 @@ class _RmsNormExactFunction(Function):
         sq = torch.empty(hidden_states.shape, dtype=torch.float32, device=hidden_states.device)
         module = _m_exact()
         module.rmsnorm_exact_square(hidden_states, sq)
-        inv = torch.rsqrt(sq.mean(-1, keepdim=True) + eps)
+        var = sq.mean(-1, keepdim=True)
         del sq
+        inv = torch.empty_like(var)
+        module.rmsnorm_exact_inv(var, inv, eps)
         out = torch.empty(
             hidden_states.shape, dtype=hidden_states.dtype, device=hidden_states.device
         )
@@ -883,8 +887,9 @@ class _RmsNormExactFunction(Function):
         del p_dw, p_inv
 
         n = hidden_states.shape[-1]
-        g_var = (-0.5 * g_inv) * inv.pow(3)
-        g_sq2 = ((g_var / n) * 2.0).reshape(-1).contiguous()
+        g_sq2 = torch.empty_like(g_inv)
+        module.rmsnorm_exact_gsq2(g_inv, inv, g_sq2, n)
+        g_sq2 = g_sq2.reshape(-1)
         dx = torch.empty(
             hidden_states.shape, dtype=hidden_states.dtype, device=hidden_states.device
         )

--- a/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/norm.py
+++ b/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/norm.py
@@ -35,6 +35,20 @@ class RMSNormOp(OpsProxy):
         super().__init__(name)
         self._input_fallback_logged = False
 
+    @staticmethod
+    def _weight_dtype_supported(hidden_states, weight):
+        """Return whether this activation/weight dtype pair has a kernel.
+
+        An fp32 weight with bf16 activations is allowed: the kernel widens the
+        activation per element, which is lossless, so an fp32 norm leaf does not
+        need FSDP to materialize an fp32 copy of its input.
+        """
+        if weight.dtype is hidden_states.dtype:
+            return True
+        return (
+            hidden_states.dtype is torch.bfloat16 and weight.dtype is torch.float32
+        )
+
     def _cuda_supported(self, hidden_states, weight):
         """Return whether the inputs satisfy the RMSNorm CUDA constraints."""
         return (
@@ -42,7 +56,7 @@ class RMSNormOp(OpsProxy):
             and type(weight) in (torch.Tensor, torch.nn.Parameter)
             and hidden_states.is_cuda
             and hidden_states.dtype in (torch.bfloat16, torch.float32)
-            and weight.dtype is hidden_states.dtype
+            and self._weight_dtype_supported(hidden_states, weight)
             and hidden_states.stride(-1) == 1
             and weight.is_contiguous()
         )

--- a/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/rope.py
+++ b/ops/cuda_source/wall_oss_05_op/wall_oss_05_op/rope.py
@@ -1,8 +1,7 @@
 # Copyright 2026 The LoongForge Authors.
 # SPDX-License-Identifier: Apache-2.0
 #
-# Modified from Wall-X (https://github.com/X-Square-Robot/wall-x)
-# under the Apache-2.0 License.
+# Modified from Wall-X under the Apache-2.0 License.
 
 """Rotary position embedding operators."""
 
@@ -156,13 +155,56 @@ class MRoPEOp(OpsProxy):
         )
         return q_embed.to(query_states.dtype), k_embed.to(key_states.dtype)
 
+    def _pytorch_fallback_pack(
+        self,
+        qkv,
+        q_num_heads,
+        kv_num_heads,
+        cos,
+        sin,
+        mrope_section: List[int],
+        inference=False,
+    ):
+        """Packed-QKV M-RoPE with PyTorch, mirroring ``MRope.pack``.
+
+        ``qkv`` is [bz, seq_len, q_dim + 2 * kv_dim] with Q, K and V concatenated
+        on the last dim; only Q and K are rotated and V passes through. Unlike the
+        CUDA kernel, which rotates in place, this returns a new tensor — every
+        caller consumes the return value, so the packed layout is preserved and
+        ``torch.split`` downstream keeps working.
+        """
+        del inference
+        head_dim = qkv.shape[-1] // (q_num_heads + 2 * kv_num_heads)
+        q_dim = q_num_heads * head_dim
+        kv_dim = kv_num_heads * head_dim
+        bz, seq_len = qkv.shape[0], qkv.shape[1]
+
+        query_states, key_states, value_states = qkv.split(
+            [q_dim, kv_dim, kv_dim], dim=-1
+        )
+        q_embed, k_embed = self._pytorch_fallback(
+            query_states.reshape(bz, seq_len, q_num_heads, head_dim),
+            key_states.reshape(bz, seq_len, kv_num_heads, head_dim),
+            cos,
+            sin,
+            mrope_section,
+        )
+        return torch.cat(
+            [
+                q_embed.reshape(bz, seq_len, q_dim),
+                k_embed.reshape(bz, seq_len, kv_dim),
+                value_states,
+            ],
+            dim=-1,
+        )
+
     def pack(self, *args, **kwargs):
-        """Delegate to resolved backend's pack method if available."""
+        """Delegate to resolved backend's pack, else use the PyTorch packed fallback."""
         if self._resolved_fn is None:
             self._resolve()
         if hasattr(self._resolved_fn, "pack"):
             return self._resolved_fn.pack(*args, **kwargs)
-        return args
+        return self._pytorch_fallback_pack(*args, **kwargs)
 
 
 class RotPosEmbOp(OpsProxy):


### PR DESCRIPTION
## Change Summary

Three independent optimizations to the Wall-OSS-0.5 training path: (1) a fused packed-QKV M-RoPE that replaces three separate Q/K/V buffers with one, (2) fp32-weight support in the RMSNorm CUDA kernel so FSDP no longer materializes an fp32 copy of every norm activation, and (3) two FSDP2 forward-prefetch fixes — relinking DMuon's prefetch chain into true execution order, and prefetching norm leaves ahead of use.
