### PR TITLE
feat(train): add FP8 linear conversion with TE and TorchAO

### DIFF
--- a/loongforge/embodied/distributed/activation_checkpointing.py
+++ b/loongforge/embodied/distributed/activation_checkpointing.py
@@ -16,6 +16,7 @@ def apply_activation_checkpointing(
     model: nn.Module,
     raw_module_patterns: str | list[str] | None,
     raw_skip_modules: str | list[str] | None,
+    fp8_backend: str | None = None,
 ) -> None:
     """Checkpoint the modules selected by the patterns, minus those the skip patterns match."""
     from loongforge.embodied.train.training_args import parse_module_key_patterns
@@ -69,18 +70,34 @@ def apply_activation_checkpointing(
             "checkpoint_wrapper"
         ) from exc
 
+    # TE's FP8 path saves a different set of tensors during the original forward
+    # than during recompute, which makes the non-reentrant PyTorch checkpoint
+    # raise CheckpointError. TE ships its own checkpoint that handles this.
+    checkpoint_fn = None
+    if fp8_backend == "te":
+        from loongforge.embodied.distributed.fp8_utils import te_checkpoint_fn
+
+        checkpoint_fn = te_checkpoint_fn()
+
+    checkpoint_wrapper_kwargs = {
+        "checkpoint_impl": CheckpointImpl.NO_REENTRANT,
+    }
+    if checkpoint_fn is not None:
+        checkpoint_wrapper_kwargs["checkpoint_fn"] = checkpoint_fn
+
     for module_key, module in selected_modules.items():
         model.set_submodule(
             module_key,
             checkpoint_wrapper(
                 module,
-                checkpoint_impl=CheckpointImpl.NO_REENTRANT,
+                **checkpoint_wrapper_kwargs,
             ),
         )
     logger.info(
-        "Applied activation checkpointing: wrapped=%d skipped=%d",
+        "Applied activation checkpointing: wrapped=%d skipped=%d impl=%s",
         len(selected_modules),
         len(skip_module_keys),
+        "te.checkpoint" if fp8_backend == "te" else "torch non-reentrant",
     )
 
 
@@ -134,4 +151,3 @@ def _module_key_matches(pattern: str, module_key: str) -> bool:
             module_key_segments,
         )
     )
-

--- a/loongforge/embodied/distributed/checkpoint.py
+++ b/loongforge/embodied/distributed/checkpoint.py
@@ -673,7 +673,20 @@ def _resume_dcp(model, optimizer, scheduler, checkpoint_path, ctx, restore_rng):
 
     # 1) Model — strict.
     model_state = {"model": model_sd}
-    dcp.load(model_state, storage_reader=dcp.FileSystemReader(dcp_dir))
+    try:
+        dcp.load(model_state, storage_reader=dcp.FileSystemReader(dcp_dir))
+    except Exception as exc:
+        # te.Linear contributes `_extra_state` keys that plain nn.Linear does
+        # not, so toggling --fp8 between the saving and resuming run changes the
+        # key set and trips the strict load with an opaque planner error.
+        if _has_te_module(model):
+            raise RuntimeError(
+                "Strict DCP model load failed for an FP8 (te.Linear) model. If "
+                "this checkpoint was saved without --fp8, its key set does not "
+                "match: resume with --fp8 off, or start from "
+                "--pretrained-checkpoint instead of --resume."
+            ) from exc
+        raise
     set_state_dict(
         model, optimizers=[],
         model_state_dict=model_state["model"],
@@ -878,6 +891,14 @@ def _is_zero_optimizer(optimizer) -> bool:
     from torch.distributed.optim import ZeroRedundancyOptimizer
     return isinstance(optimizer, ZeroRedundancyOptimizer) or getattr(
         optimizer, "_is_multi_dtype_zero_optimizer", False
+    )
+
+
+def _has_te_module(model) -> bool:
+    """Whether the model contains any TransformerEngine module."""
+    return any(
+        type(module).__module__.startswith("transformer_engine")
+        for module in model.modules()
     )
 
 

--- a/loongforge/embodied/distributed/fp8_utils/__init__.py
+++ b/loongforge/embodied/distributed/fp8_utils/__init__.py
@@ -1,0 +1,51 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Framework-managed FP8 support for embodied models.
+
+FP8 setup is split into backend-neutral policy and backend-specific execution:
+
+* ``targets`` resolves model-owned defaults and CLI overrides into subtrees.
+* ``backend`` dispatches conversion and forward context to TE or TorchAO.
+* ``selection`` implements backend-neutral module selection.
+* ``te_fp8`` implements ``te.Linear`` replacement and TE recipe/context.
+* ``torchao_fp8`` implements native PyTorch ``Float8Linear`` replacement.
+
+``apply_fp8_linear_conversion`` performs target resolution and replacement
+before activation checkpointing and DDP/FSDP wrapping, including custom model
+wrappers. The trainer later enters ``te.fp8_autocast`` around the complete model
+forward. Replacing a module does not store its master parameters as FP8: weights
+retain their original dtype, while TransformerEngine manages FP8 casts, scales,
+and GEMMs during forward and backward.
+
+TransformerEngine imports stay inside the functions that need them. A build
+without TE can therefore import the embodied distributed stack and run normally
+as long as ``--fp8`` remains disabled.
+"""
+
+from .backend import (
+    FP8_BACKEND_CHOICES,
+    apply_fp8_linear_conversion,
+    convert_linear_for_fp8,
+    resolve_fp8_forward_ctx,
+)
+from .selection import FP8_GEMM_ALIGNMENT
+from .te_fp8 import (
+    convert_linear_to_te,
+    resolve_fp8_autocast_ctx,
+    te_checkpoint_fn,
+)
+from .targets import get_default_fp8_targets, resolve_fp8_targets
+
+__all__ = [
+    "FP8_GEMM_ALIGNMENT",
+    "FP8_BACKEND_CHOICES",
+    "apply_fp8_linear_conversion",
+    "convert_linear_for_fp8",
+    "convert_linear_to_te",
+    "get_default_fp8_targets",
+    "resolve_fp8_autocast_ctx",
+    "resolve_fp8_forward_ctx",
+    "resolve_fp8_targets",
+    "te_checkpoint_fn",
+]

--- a/loongforge/embodied/distributed/fp8_utils/backend.py
+++ b/loongforge/embodied/distributed/fp8_utils/backend.py
@@ -1,0 +1,111 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend dispatch for TransformerEngine and TorchAO FP8 training."""
+
+import logging
+from contextlib import nullcontext
+
+import torch.nn as nn
+
+from .targets import resolve_fp8_targets
+
+
+logger = logging.getLogger(__name__)
+
+FP8_BACKEND_CHOICES = ("te", "torchao")
+
+
+def apply_fp8_linear_conversion(model: nn.Module, training_args, device) -> int:
+    """Apply and verify configured FP8 Linear replacements before wrapping."""
+    if not getattr(training_args, "fp8", False):
+        return 0
+
+    original_linear_count = sum(
+        type(module) is nn.Linear for module in model.modules()
+    )
+    module_patterns, skip_modules = resolve_fp8_targets(model, training_args)
+    fp8_linear_count = convert_linear_for_fp8(
+        model,
+        module_patterns,
+        skip_modules,
+        training_args,
+        device,
+    )
+    if fp8_linear_count == 0:
+        raise RuntimeError(
+            "FP8 is enabled but no nn.Linear modules were converted; "
+            "check fp8_module_patterns, fp8_skip_modules, fp8_min_dim, "
+            "and backend alignment requirements."
+        )
+
+    remaining_linear_count = sum(
+        type(module) is nn.Linear for module in model.modules()
+    )
+    expected_remaining_linear_count = original_linear_count - fp8_linear_count
+    if remaining_linear_count != expected_remaining_linear_count:
+        raise RuntimeError(
+            "FP8 Linear conversion verification failed: "
+            f"before={original_linear_count} converted={fp8_linear_count} "
+            f"expected_after={expected_remaining_linear_count} "
+            f"actual_after={remaining_linear_count}."
+        )
+    logger.info(
+        "FP8 Linear replacement summary: backend=%s original_linear=%d "
+        "fp8_linear=%d remaining_linear=%d",
+        training_args.fp8_backend,
+        original_linear_count,
+        fp8_linear_count,
+        remaining_linear_count,
+    )
+    return fp8_linear_count
+
+
+def convert_linear_for_fp8(
+    model: nn.Module,
+    module_patterns,
+    skip_modules,
+    training_args,
+    device,
+) -> int:
+    """Dispatch structural Linear conversion to the selected FP8 backend."""
+    if training_args.fp8_backend == "te":
+        from .te_fp8 import convert_linear_to_te
+
+        return convert_linear_to_te(
+            model,
+            module_patterns,
+            skip_modules,
+            training_args.fp8_min_dim,
+            device,
+        )
+    if training_args.fp8_backend == "torchao":
+        from .torchao_fp8 import convert_linear_to_torchao
+
+        return convert_linear_to_torchao(
+            model,
+            module_patterns,
+            skip_modules,
+            training_args.fp8_min_dim,
+            training_args,
+        )
+    raise ValueError(
+        f"Unknown FP8 backend {training_args.fp8_backend!r}; "
+        f"expected one of {', '.join(FP8_BACKEND_CHOICES)}."
+    )
+
+
+def resolve_fp8_forward_ctx(training_args, fp8_group=None):
+    """Return the backend's forward context; TorchAO needs no outer context."""
+    if not getattr(training_args, "fp8", False):
+        return nullcontext()
+    if training_args.fp8_backend == "torchao":
+        return nullcontext()
+    if training_args.fp8_backend == "te":
+        from .te_fp8 import resolve_fp8_autocast_ctx
+
+        return resolve_fp8_autocast_ctx(
+            training_args,
+            fp8_group=fp8_group,
+        )
+    raise ValueError(f"Unknown FP8 backend {training_args.fp8_backend!r}.")

--- a/loongforge/embodied/distributed/fp8_utils/selection.py
+++ b/loongforge/embodied/distributed/fp8_utils/selection.py
@@ -1,0 +1,92 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend-neutral selection of standard Linear modules for FP8 conversion."""
+
+from __future__ import annotations
+
+import torch.nn as nn
+
+from ..utils import is_module_path_matching_pattern
+
+FP8_GEMM_ALIGNMENT = 16
+
+
+def resolve_linear_selection(
+    model: nn.Module,
+    raw_module_patterns: str | list[str] | None,
+    raw_skip_modules: str | list[str] | None,
+) -> tuple[list[str], set[str]]:
+    """Resolve FP8 subtree and skip patterns against exact ``nn.Linear`` keys."""
+    from loongforge.embodied.train.training_args import parse_module_key_patterns
+
+    module_patterns = parse_module_key_patterns(
+        raw_module_patterns,
+        option_name="fp8 module patterns",
+    )
+    skip_patterns = parse_module_key_patterns(
+        raw_skip_modules,
+        option_name="fp8 skip modules",
+    )
+    if not module_patterns and skip_patterns:
+        raise ValueError("fp8 skip modules require fp8 module patterns")
+    if not module_patterns:
+        return [], set()
+
+    linear_keys = [
+        module_key
+        for module_key, module in model.named_modules()
+        if module_key and type(module) is nn.Linear
+    ]
+
+    matched_patterns: set[str] = set()
+    selected_keys = [
+        module_key
+        for module_key in linear_keys
+        if _select(module_patterns, module_key, matched_patterns)
+    ]
+    unmatched_patterns = [
+        pattern for pattern in module_patterns if pattern not in matched_patterns
+    ]
+    if unmatched_patterns:
+        raise ValueError(
+            "fp8 module patterns matched no nn.Linear: "
+            + ", ".join(unmatched_patterns)
+        )
+
+    matched_skip_patterns: set[str] = set()
+    skipped_keys = {
+        module_key
+        for module_key in selected_keys
+        if _select(skip_patterns, module_key, matched_skip_patterns)
+    }
+    unmatched_skip_patterns = [
+        pattern for pattern in skip_patterns if pattern not in matched_skip_patterns
+    ]
+    if unmatched_skip_patterns:
+        raise ValueError(
+            "fp8 skip modules were not selected: "
+            + ", ".join(unmatched_skip_patterns)
+        )
+    return selected_keys, skipped_keys
+
+
+def _select(
+    patterns: list[str],
+    module_key: str,
+    matched_patterns: set[str],
+) -> bool:
+    """Return whether a pattern selects this module or an ancestor subtree."""
+    segments = module_key.split(".")
+    candidate_keys = [
+        ".".join(segments[:depth]) for depth in range(1, len(segments) + 1)
+    ]
+    selected = False
+    for pattern in patterns:
+        if any(
+            is_module_path_matching_pattern(pattern, candidate_key)
+            for candidate_key in candidate_keys
+        ):
+            matched_patterns.add(pattern)
+            selected = True
+    return selected

--- a/loongforge/embodied/distributed/fp8_utils/targets.py
+++ b/loongforge/embodied/distributed/fp8_utils/targets.py
@@ -1,0 +1,93 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve model-owned FP8 policy into Linear-conversion target subtrees.
+
+The framework owns how ``nn.Linear`` becomes ``te.Linear``; each model owns the
+architectural decision of which repeated compute blocks are safe and useful to
+convert. CLI options can override that policy for experiments and bisection.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+import torch.nn as nn
+
+logger = logging.getLogger(__name__)
+
+
+def get_default_fp8_targets(model: nn.Module) -> Optional[dict[str, Any]]:
+    """Return the model-provided FP8 target specification, if available.
+
+    Mirrors ``train.lora.get_default_lora_targets``: the framework owns the
+    mechanism, the model owns the knowledge of which of its own layers must stay
+    out of FP8. Defaults normally select large Transformer/DiT block subtrees
+    and leave numerically sensitive input/output heads, explicitly fp32 modules,
+    frozen backbones, and custom Linear implementations untouched.
+
+    Expected keys:
+        ``module_patterns``: Qualified subtree-root patterns. Every standard
+            ``nn.Linear`` descendant becomes a conversion candidate.
+        ``skip_modules``: Optional patterns excluded from the positive
+            selection, typically used when a broad target contains fp32-critical
+            projections.
+    """
+    provider = getattr(model, "default_fp8_targets", None)
+    return provider() if callable(provider) else None
+
+
+def resolve_fp8_targets(model: nn.Module, training_args) -> tuple[Any, Any]:
+    """Resolve ``(module_patterns, skip_modules)`` for the FP8 conversion pass.
+
+    Resolution order:
+
+    1. Reject a model/configuration that reports ``fp8_unsupported_reason``.
+       This is used for lifecycle incompatibilities such as post-FSDP
+       materialization, not merely for the absence of defaults.
+    2. Resolve module and skip patterns independently. A CLI value wins when
+       explicitly set; otherwise that field falls back to
+       ``default_fp8_targets()``.
+    3. Require a positive target. ``--fp8`` must never degrade into a silent
+       BF16 run because a model forgot to declare its defaults.
+
+    The returned patterns are intentionally still raw here. ``linear`` parses
+    them and validates that every positive and skip pattern matches a real
+    standard Linear in the instantiated model.
+    """
+    # Check incompatibility before honoring CLI patterns: a different target
+    # cannot fix a model lifecycle that makes every pre-wrap TE replacement
+    # unsafe (for example, weights that remain on meta until after FSDP).
+    backend = getattr(training_args, "fp8_backend", "te")
+    unsupported = getattr(model, "fp8_unsupported_reason", None)
+    if callable(unsupported):
+        try:
+            reason = unsupported(backend)
+        except TypeError:
+            # Keep compatibility with model providers that implement the
+            # original zero-argument hook.
+            reason = unsupported()
+    else:
+        reason = unsupported
+    if reason:
+        raise ValueError(
+            f"--fp8 is not supported by {type(model).__name__}: {reason}"
+        )
+
+    defaults = dict(get_default_fp8_targets(model) or {})
+
+    module_patterns = training_args.fp8_module_patterns
+    if module_patterns is None:
+        module_patterns = defaults.get("module_patterns")
+    skip_modules = training_args.fp8_skip_modules
+    if skip_modules is None:
+        skip_modules = defaults.get("skip_modules")
+
+    if not module_patterns:
+        raise ValueError(
+            "--fp8 is enabled but no FP8 module patterns were resolved. Define "
+            f"{type(model).__name__}.default_fp8_targets() or pass "
+            "--fp8-module-patterns."
+        )
+    return module_patterns, skip_modules

--- a/loongforge/embodied/distributed/fp8_utils/te_fp8/__init__.py
+++ b/loongforge/embodied/distributed/fp8_utils/te_fp8/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TransformerEngine-specific FP8 Linear conversion and execution context."""
+
+from .linear_conversion import convert_linear_to_te
+from .recipe import resolve_fp8_autocast_ctx, te_checkpoint_fn
+
+__all__ = [
+    "convert_linear_to_te",
+    "resolve_fp8_autocast_ctx",
+    "te_checkpoint_fn",
+]

--- a/loongforge/embodied/distributed/fp8_utils/te_fp8/linear_conversion.py
+++ b/loongforge/embodied/distributed/fp8_utils/te_fp8/linear_conversion.py
@@ -1,0 +1,171 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""Select and replace standard Linear layers for TransformerEngine FP8.
+
+The conversion is structural rather than a monkey-patch: each eligible
+``nn.Linear`` is replaced in the model tree by a newly constructed
+``te.Linear`` carrying the same dimensions, parameter values, dtype, bias
+layout, and gradient flags. TransformerEngine performs the actual FP8 casting
+only when the trainer enters ``te.fp8_autocast``.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import torch
+import torch.nn as nn
+
+from ..selection import FP8_GEMM_ALIGNMENT, resolve_linear_selection
+
+logger = logging.getLogger(__name__)
+
+
+def convert_linear_to_te(
+    model: nn.Module,
+    raw_module_patterns: str | list[str] | None,
+    raw_skip_modules: str | list[str] | None,
+    min_dim: int,
+    device: torch.device,
+) -> int:
+    """Replace ``nn.Linear`` under the selected subtrees with ``te.Linear``.
+
+    A module pattern names a *subtree root*. For example, ``model.blocks``
+    selects standard Linear descendants such as
+    ``model.blocks.7.mlp.up_proj``. This intentionally differs from activation
+    checkpoint patterns, which name the exact modules to wrap: FP8 intent is
+    normally expressed at Transformer/DiT-block granularity rather than by
+    enumerating every projection.
+
+    Only modules whose exact type is ``nn.Linear`` are considered. Custom
+    Linear subclasses and domain/category-aware projections keep their own
+    implementation. Selected modules are then filtered by ``min_dim`` and
+    16-alignment: small GEMMs may lose performance to FP8 setup overhead, while
+    unaligned GEMMs are unsupported. Both cases are counted and left unchanged.
+
+    Replacements are created directly on the training ``device`` because this
+    pass runs before DDP/FSDP moves or shards the original model and TE modules
+    require CUDA. Meta parameters cannot be copied and are rejected explicitly.
+
+    Returns:
+        Number of ``nn.Linear`` modules replaced with ``te.Linear``.
+    """
+    selected_keys, skipped_keys = resolve_linear_selection(
+        model,
+        raw_module_patterns,
+        raw_skip_modules,
+    )
+    if not selected_keys:
+        return 0
+
+    te_linear_cls = _import_te_linear()
+    converted = 0
+    converted_keys = []
+    below_min_dim = 0
+    unaligned = 0
+    # te.Linear runs its own reset_parameters, which draws from the global RNG.
+    # The drawn values are irrelevant (they are overwritten by the weight copy),
+    # but the advanced RNG stream is not: models that sample noise per training
+    # step -- flow matching, diffusion -- would then see a different noise
+    # sequence than the same run without --fp8, and the resulting loss gap looks
+    # like quantization error while being pure RNG misalignment. Forking keeps
+    # the conversion invisible to the RNG stream so an FP8/bf16 A/B stays
+    # comparable without a reseed workaround.
+    fork_devices = [device] if device.type == "cuda" else []
+    with torch.random.fork_rng(devices=fork_devices):
+        for module_key in selected_keys:
+            if module_key in skipped_keys:
+                continue
+            linear = model.get_submodule(module_key)
+            in_features, out_features = linear.in_features, linear.out_features
+            if in_features % FP8_GEMM_ALIGNMENT or out_features % FP8_GEMM_ALIGNMENT:
+                unaligned += 1
+                continue
+            if max(in_features, out_features) < min_dim:
+                below_min_dim += 1
+                continue
+            # Replace at the qualified path so ordinary attributes, ModuleList,
+            # and ModuleDict descendants all preserve the model's public shape.
+            model.set_submodule(
+                module_key, _build_te_linear(te_linear_cls, linear, device)
+            )
+            if type(model.get_submodule(module_key)) is nn.Linear:
+                raise RuntimeError(
+                    "FP8 conversion did not replace nn.Linear at "
+                    f"{module_key} with te.Linear."
+                )
+            converted_keys.append(module_key)
+            converted += 1
+
+    logger.info(
+        "Converted nn.Linear to te.Linear: converted=%d skipped_by_pattern=%d "
+        "below_min_dim=%d unaligned=%d (min_dim=%d, alignment=%d)",
+        converted,
+        len(skipped_keys),
+        below_min_dim,
+        unaligned,
+        min_dim,
+        FP8_GEMM_ALIGNMENT,
+    )
+    if converted_keys:
+        logger.info("TE FP8 converted modules: %s", ", ".join(converted_keys))
+    else:
+        logger.warning(
+            "TE FP8 conversion converted no modules; selected=%d skipped=%d.",
+            len(selected_keys),
+            len(skipped_keys),
+        )
+    return converted
+
+
+def _build_te_linear(
+    te_linear_cls,
+    linear: nn.Linear,
+    device: torch.device,
+) -> nn.Module:
+    """Build the replacement while preserving the original parameter contract.
+
+    The master weight remains in ``weight.dtype``; copying it into ``te.Linear``
+    does not permanently quantize the checkpoint. TE creates and updates its FP8
+    representations and scaling state when executing under ``fp8_autocast``.
+    """
+    weight = linear.weight
+    if weight.device.type == "meta":
+        raise RuntimeError(
+            "FP8 conversion cannot copy weights off the meta device; "
+            "--fp8 and --init-on-meta are incompatible."
+        )
+
+    te_linear = te_linear_cls(
+        linear.in_features,
+        linear.out_features,
+        bias=linear.bias is not None,
+        device=device,
+        params_dtype=weight.dtype,
+    )
+    # te.Linear's random initialization is immediately overwritten. The caller
+    # wraps construction in fork_rng so even the discarded initialization cannot
+    # perturb diffusion/flow-matching noise sequences.
+    with torch.no_grad():
+        te_linear.weight.copy_(weight)
+        if linear.bias is not None:
+            te_linear.bias.copy_(linear.bias)
+    # Preserve the freeze decisions made by _freeze_modules / the model itself,
+    # which already ran by the time wrap_model gets here.
+    te_linear.weight.requires_grad_(weight.requires_grad)
+    if linear.bias is not None:
+        te_linear.bias.requires_grad_(linear.bias.requires_grad)
+    return te_linear
+
+
+def _import_te_linear():
+    """Import ``te.Linear``, turning a missing TE install into a clear error."""
+    try:
+        from transformer_engine.pytorch import Linear as TELinear
+    except ImportError as exc:
+        raise RuntimeError(
+            "--fp8 requires the TransformerEngine PyTorch extension "
+            "(transformer_engine.pytorch)."
+        ) from exc
+    return TELinear

--- a/loongforge/embodied/distributed/fp8_utils/te_fp8/recipe.py
+++ b/loongforge/embodied/distributed/fp8_utils/te_fp8/recipe.py
@@ -1,0 +1,150 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TransformerEngine scaling recipes and FP8 execution contexts.
+
+Linear replacement only changes module implementations; FP8 GEMMs become active
+when the complete model forward runs inside ``te.fp8_autocast``. Ordinary
+``torch.autocast`` may remain active at the same time for BF16/FP16 operations
+outside TE modules.
+"""
+
+from __future__ import annotations
+
+import logging
+from contextlib import contextmanager, nullcontext
+
+logger = logging.getLogger(__name__)
+
+# Stable CLI spelling -> TransformerEngine class. The indirection keeps training
+# arguments independent of TE class names while still reporting when an older TE
+# build does not provide a requested recipe.
+_RECIPE_CLASSES = {
+    "blockwise": "Float8BlockScaling",
+    "current": "Float8CurrentScaling",
+    "delayed": "DelayedScaling",
+}
+
+FP8_RECIPE_CHOICES = tuple(_RECIPE_CLASSES)
+
+
+def _import_te_recipe():
+    """Import the TE recipe module lazily and provide a unit-test seam."""
+    from transformer_engine.common import recipe as te_recipe
+
+    return te_recipe
+
+
+def _resolve_fp8_format(te_recipe, raw_format: str | None):
+    """Map the CLI spelling to TransformerEngine's ``Format`` enum."""
+    if raw_format is None:
+        return None
+    format_name = raw_format.upper()
+    fp8_format = getattr(te_recipe.Format, format_name, None)
+    if fp8_format is None:
+        raise ValueError(
+            f"Unsupported --fp8-te-format {raw_format!r} in this "
+            "TransformerEngine build; expected e4m3 or hybrid."
+        )
+    return fp8_format
+
+
+def _recipe_kwargs(recipe_name: str, recipe_args, te_recipe) -> dict:
+    """Translate training arguments into kwargs supported by one TE recipe."""
+    if recipe_args is None:
+        return {}
+
+    kwargs = {}
+    fp8_format = _resolve_fp8_format(
+        te_recipe,
+        getattr(recipe_args, "fp8_te_format", None),
+    )
+    if fp8_format is not None:
+        kwargs["fp8_format"] = fp8_format
+
+    if recipe_name == "delayed":
+        kwargs.update(
+            margin=recipe_args.fp8_te_margin,
+            amax_history_len=recipe_args.fp8_te_amax_history_len,
+            amax_compute_algo=recipe_args.fp8_te_amax_compute_algo,
+            reduce_amax=recipe_args.fp8_te_reduce_amax,
+        )
+    elif recipe_name == "current":
+        kwargs["use_power_2_scales"] = (
+            recipe_args.fp8_te_current_use_power_2_scales
+        )
+    elif recipe_name == "blockwise":
+        kwargs["use_f32_scales"] = recipe_args.fp8_te_block_use_f32_scales
+    return kwargs
+
+
+def build_fp8_recipe(recipe_name: str, recipe_args=None):
+    """Instantiate the scaling policy selected by ``--fp8-recipe``.
+
+    Importing TE lazily keeps non-FP8 training usable in environments where the
+    TransformerEngine PyTorch extension is not installed. ``recipe_args`` is
+    normally the complete ``TrainingArgs`` object; only fields supported by the
+    selected recipe are forwarded.
+    """
+    try:
+        class_name = _RECIPE_CLASSES[recipe_name]
+    except KeyError:
+        raise ValueError(
+            f"Unknown --fp8-recipe {recipe_name!r}; expected one of "
+            + ", ".join(FP8_RECIPE_CHOICES)
+        ) from None
+
+    te_recipe = _import_te_recipe()
+
+    recipe_cls = getattr(te_recipe, class_name, None)
+    if recipe_cls is None:
+        raise RuntimeError(
+            f"--fp8-recipe={recipe_name} needs {class_name}, which this "
+            "TransformerEngine build does not provide."
+        )
+    return recipe_cls(**_recipe_kwargs(recipe_name, recipe_args, te_recipe))
+
+
+@contextmanager
+def fp8_autocast_ctx(recipe_name: str, fp8_group=None, recipe_args=None):
+    """Run the enclosed forward under ``te.fp8_autocast``.
+
+    TE uses this context to quantize eligible inputs and weights, choose scales,
+    execute FP8 GEMMs, and maintain scaling metadata. Parameters themselves keep
+    the dtype used to construct ``te.Linear``.
+
+    ``fp8_group`` is the process group amax/scale state is reduced over. Left as
+    None it defaults to the whole world, which is what the embodied stack wants:
+    ``DistributedContext`` keeps a single flat group and data parallelism spans
+    every rank.
+    """
+    from transformer_engine.pytorch import fp8_autocast
+
+    recipe = build_fp8_recipe(recipe_name, recipe_args=recipe_args)
+    with fp8_autocast(enabled=True, fp8_recipe=recipe, fp8_group=fp8_group):
+        yield
+
+
+def resolve_fp8_autocast_ctx(training_args, fp8_group=None):
+    """Return a uniform trainer context: TE FP8 when enabled, otherwise no-op."""
+    if not getattr(training_args, "fp8", False):
+        return nullcontext()
+    return fp8_autocast_ctx(
+        training_args.fp8_te_recipe,
+        fp8_group=fp8_group,
+        recipe_args=training_args,
+    )
+
+
+def te_checkpoint_fn():
+    """Return TransformerEngine's activation-checkpoint function.
+
+    Needed because TE's FP8 path saves a different set of tensors during the
+    original forward than during recompute, which makes PyTorch's non-reentrant
+    checkpoint raise ``CheckpointError``. TE's implementation also preserves
+    the FP8 scaling state needed to make recompute consistent with the original
+    forward.
+    """
+    from transformer_engine.pytorch import checkpoint
+
+    return checkpoint

--- a/loongforge/embodied/distributed/fp8_utils/te_fp8/recipe.py
+++ b/loongforge/embodied/distributed/fp8_utils/te_fp8/recipe.py
@@ -11,6 +11,7 @@ outside TE modules.
 
 from __future__ import annotations
 
+import inspect
 import logging
 from contextlib import contextmanager, nullcontext
 
@@ -18,11 +19,13 @@ logger = logging.getLogger(__name__)
 
 # Stable CLI spelling -> TransformerEngine class. The indirection keeps training
 # arguments independent of TE class names while still reporting when an older TE
-# build does not provide a requested recipe.
+# build does not provide a requested recipe. MXFP8 uses TE's native E4M3
+# microscaling recipe and intentionally has no recipe-specific CLI knobs here.
 _RECIPE_CLASSES = {
     "blockwise": "Float8BlockScaling",
     "current": "Float8CurrentScaling",
     "delayed": "DelayedScaling",
+    "mxfp8": "MXFP8BlockScaling",
 }
 
 FP8_RECIPE_CHOICES = tuple(_RECIPE_CLASSES)
@@ -44,7 +47,7 @@ def _resolve_fp8_format(te_recipe, raw_format: str | None):
     if fp8_format is None:
         raise ValueError(
             f"Unsupported --fp8-te-format {raw_format!r} in this "
-            "TransformerEngine build; expected e4m3 or hybrid."
+            "TransformerEngine build; expected e4m3, e5m2, or hybrid."
         )
     return fp8_format
 
@@ -55,11 +58,17 @@ def _recipe_kwargs(recipe_name: str, recipe_args, te_recipe) -> dict:
         return {}
 
     kwargs = {}
+    raw_format = getattr(recipe_args, "fp8_te_format", None)
     fp8_format = _resolve_fp8_format(
         te_recipe,
-        getattr(recipe_args, "fp8_te_format", None),
+        raw_format,
     )
     if fp8_format is not None:
+        if recipe_name == "mxfp8" and raw_format.lower() == "e5m2":
+            raise ValueError(
+                "--fp8-te-format=e5m2 is not supported by "
+                "MXFP8BlockScaling; use e4m3 or hybrid."
+            )
         kwargs["fp8_format"] = fp8_format
 
     if recipe_name == "delayed":
@@ -75,6 +84,12 @@ def _recipe_kwargs(recipe_name: str, recipe_args, te_recipe) -> dict:
         )
     elif recipe_name == "blockwise":
         kwargs["use_f32_scales"] = recipe_args.fp8_te_block_use_f32_scales
+        if recipe_args.fp8_te_block_backward_override is not None:
+            kwargs["backward_override"] = (
+                recipe_args.fp8_te_block_backward_override
+            )
+    elif recipe_name == "mxfp8":
+        kwargs["margin"] = recipe_args.fp8_te_margin
     return kwargs
 
 
@@ -102,7 +117,18 @@ def build_fp8_recipe(recipe_name: str, recipe_args=None):
             f"--fp8-recipe={recipe_name} needs {class_name}, which this "
             "TransformerEngine build does not provide."
         )
-    return recipe_cls(**_recipe_kwargs(recipe_name, recipe_args, te_recipe))
+    recipe_kwargs = _recipe_kwargs(recipe_name, recipe_args, te_recipe)
+    unsupported_kwargs = set(recipe_kwargs).difference(
+        inspect.signature(recipe_cls).parameters
+    )
+    if unsupported_kwargs:
+        unsupported = ", ".join(sorted(unsupported_kwargs))
+        raise RuntimeError(
+            f"--fp8-te-recipe={recipe_name} requires TransformerEngine "
+            f"{class_name} parameters not supported by this installed build: "
+            f"{unsupported}. Upgrade TransformerEngine or unset the option."
+        )
+    return recipe_cls(**recipe_kwargs)
 
 
 @contextmanager

--- a/loongforge/embodied/distributed/fp8_utils/torchao_fp8/__init__.py
+++ b/loongforge/embodied/distributed/fp8_utils/torchao_fp8/__init__.py
@@ -1,0 +1,11 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TorchAO-specific Float8Linear conversion."""
+
+from .linear_conversion import build_torchao_config, convert_linear_to_torchao
+
+__all__ = [
+    "build_torchao_config",
+    "convert_linear_to_torchao",
+]

--- a/loongforge/embodied/distributed/fp8_utils/torchao_fp8/linear_conversion.py
+++ b/loongforge/embodied/distributed/fp8_utils/torchao_fp8/linear_conversion.py
@@ -1,0 +1,131 @@
+# Copyright 2026 The LoongForge Authors.
+# SPDX-License-Identifier: Apache-2.0
+
+"""TorchAO Float8Linear conversion using the shared model target policy."""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import replace
+
+import torch.nn as nn
+
+from ..selection import FP8_GEMM_ALIGNMENT, resolve_linear_selection
+
+logger = logging.getLogger(__name__)
+
+
+def build_torchao_config(training_args):
+    """Build ``Float8LinearConfig`` for the selected TorchAO recipe."""
+    try:
+        from torchao.float8.config import Float8LinearConfig
+    except ImportError as exc:
+        raise RuntimeError(
+            "--fp8-backend=torchao requires torchao.float8."
+        ) from exc
+
+    config = Float8LinearConfig.from_recipe_name(
+        training_args.fp8_torchao_recipe
+    )
+    return replace(
+        config,
+        pad_inner_dim=training_args.fp8_torchao_pad_inner_dim,
+        enable_fsdp_float8_all_gather=(
+            training_args.fp8_torchao_fsdp_float8_all_gather
+        ),
+        # With FSDP2, recompute the FP8 weight in backward instead of retaining
+        # a complete unsharded FP8 weight/transpose from the forward pass.
+        force_recompute_fp8_weight_in_bwd=(
+            training_args.fp8_torchao_fsdp_float8_all_gather
+        ),
+    )
+
+
+def convert_linear_to_torchao(
+    model: nn.Module,
+    raw_module_patterns: str | list[str] | None,
+    raw_skip_modules: str | list[str] | None,
+    min_dim: int,
+    training_args,
+) -> int:
+    """Replace eligible target Linears with TorchAO ``Float8Linear`` modules."""
+    selected_keys, skipped_keys = resolve_linear_selection(
+        model,
+        raw_module_patterns,
+        raw_skip_modules,
+    )
+    if not selected_keys:
+        return 0
+
+    pad_inner_dim = training_args.fp8_torchao_pad_inner_dim
+    eligible_keys = set()
+    below_min_dim = 0
+    unaligned_inner = 0
+    unaligned_output = 0
+    for module_key in selected_keys:
+        if module_key in skipped_keys:
+            continue
+        linear = model.get_submodule(module_key)
+        if max(linear.in_features, linear.out_features) < min_dim:
+            below_min_dim += 1
+            continue
+        if linear.out_features % FP8_GEMM_ALIGNMENT:
+            unaligned_output += 1
+            continue
+        if linear.in_features % FP8_GEMM_ALIGNMENT and not pad_inner_dim:
+            unaligned_inner += 1
+            continue
+        eligible_keys.add(module_key)
+
+    try:
+        from torchao.float8 import convert_to_float8_training
+    except ImportError as exc:
+        raise RuntimeError(
+            "--fp8-backend=torchao requires "
+            "torchao.float8.convert_to_float8_training."
+        ) from exc
+
+    config = build_torchao_config(training_args)
+    convert_to_float8_training(
+        model,
+        config=config,
+        module_filter_fn=lambda module, fqn: (
+            type(module) is nn.Linear and fqn in eligible_keys
+        ),
+    )
+    converted_keys = [
+        module_key
+        for module_key in eligible_keys
+        if type(model.get_submodule(module_key)) is not nn.Linear
+    ]
+    failed_keys = sorted(eligible_keys.difference(converted_keys))
+    if failed_keys:
+        raise RuntimeError(
+            "TorchAO FP8 conversion did not replace nn.Linear at: "
+            + ", ".join(failed_keys)
+        )
+    logger.info(
+        "Converted nn.Linear to TorchAO Float8Linear: converted=%d "
+        "skipped_by_pattern=%d below_min_dim=%d unaligned_inner=%d "
+        "unaligned_output=%d (min_dim=%d, alignment=%d, pad_inner_dim=%s)",
+        len(eligible_keys),
+        len(skipped_keys),
+        below_min_dim,
+        unaligned_inner,
+        unaligned_output,
+        min_dim,
+        FP8_GEMM_ALIGNMENT,
+        pad_inner_dim,
+    )
+    if converted_keys:
+        logger.info(
+            "TorchAO FP8 converted modules: %s",
+            ", ".join(sorted(converted_keys)),
+        )
+    else:
+        logger.warning(
+            "TorchAO FP8 conversion converted no modules; selected=%d skipped=%d.",
+            len(selected_keys),
+            len(skipped_keys),
+        )
+    return len(eligible_keys)

--- a/loongforge/embodied/distributed/parallel.py
+++ b/loongforge/embodied/distributed/parallel.py
@@ -24,6 +24,7 @@ from .fsdp_utils import (
     fully_shard_unit,
     resolve_wrap_runs,
 )
+from .fp8_utils import apply_fp8_linear_conversion
 from .utils import filter_kwargs, is_mixed_param_dtype
 
 
@@ -37,10 +38,15 @@ def wrap_model(model: nn.Module, training_args, ctx: DistributedContext) -> nn.M
     from loongforge.embodied.train.training_args import parse_dtype_from_str
 
     dtype = parse_dtype_from_str(training_args.dtype)
+    # FP8 conversion must precede activation checkpointing: the checkpoint
+    # wrapper has to wrap already-converted modules, otherwise the set of
+    # tensors saved by the original forward and by recompute diverge.
+    apply_fp8_linear_conversion(model, training_args, ctx.device)
     apply_activation_checkpointing(
         model,
         training_args.activation_checkpoint_module_patterns,
         training_args.activation_checkpoint_skip_modules,
+        fp8_backend=training_args.fp8_backend if training_args.fp8 else None,
     )
 
     if not ctx.is_distributed:

--- a/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
+++ b/loongforge/embodied/model/cosmos3/modeling_cosmos3.py
@@ -65,6 +65,22 @@ class Cosmos3(nn.Module):
         """
         return cls(cfg)
 
+    @staticmethod
+    def fp8_unsupported_reason(backend: str = "te") -> str | None:
+        """Explain why the current pre-wrap TE conversion cannot handle Cosmos3.
+
+        TorchAO can construct its Float8Linear shell on meta and reuse the
+        source parameters, so this TE-specific lifecycle restriction does not
+        automatically apply to the TorchAO backend.
+        """
+        if backend != "te":
+            return None
+        return (
+            "Cosmos3 constructs its network on the meta device and materializes "
+            "weights only after FSDP wrapping; te.Linear conversion requires "
+            "materialized CUDA weights before wrapping"
+        )
+
     def __init__(self, config: Cosmos3ModelConfig):
         """__init__."""
         super().__init__()

--- a/loongforge/embodied/model/dreamzero/modeling_dreamzero.py
+++ b/loongforge/embodied/model/dreamzero/modeling_dreamzero.py
@@ -200,6 +200,19 @@ class DreamZeroPolicy(PreTrainedPolicy):
         }
 
     @staticmethod
+    def default_fp8_targets() -> dict[str, Any]:
+        """Convert the Causal Wan transformer blocks while keeping heads in bf16.
+
+        The block subtree contains the large attention and FFN ``nn.Linear``
+        modules. Embodiment-specific encoders use custom category-aware linears
+        and the zero-initialized output head is deliberately left untouched.
+        """
+        return {
+            "module_patterns": ["action_head.model.blocks"],
+            "skip_modules": [],
+        }
+
+    @staticmethod
     def lora_requires_pretrained_checkpoint() -> bool:
         """DreamZero providers load component checkpoints from model config."""
         return False

--- a/loongforge/embodied/model/fastwam/modeling_fastwam.py
+++ b/loongforge/embodied/model/fastwam/modeling_fastwam.py
@@ -41,6 +41,22 @@ class FastWAMPolicy(nn.Module):
         self.core = core
         self.dit = getattr(core, "dit", None)
 
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert both MoT experts' transformer blocks.
+
+        The experts are also reachable through ``core.mot.mixtures``, but their
+        first registered paths are directly under ``core``. ``named_modules``
+        suppresses the later aliases, so the canonical paths are required here.
+        Conditioning and output heads stay at their configured precision.
+        """
+        return {
+            "module_patterns": [
+                "core.video_expert.blocks",
+                "core.action_expert.blocks",
+            ],
+            "skip_modules": [],
+        }
 
     @classmethod
     def from_pretrained(cls, cfg: Any) -> "FastWAMPolicy":

--- a/loongforge/embodied/model/groot_n1_6/modeling_groot_n1_6.py
+++ b/loongforge/embodied/model/groot_n1_6/modeling_groot_n1_6.py
@@ -931,6 +931,20 @@ class GrootN1d6Policy(nn.Module):
         self._predict_action_default_processor: StateActionProcessor | None = None
         self._predict_action_processor_cache: dict[str, StateActionProcessor] = {}
 
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert the action DiT blocks while preserving projection heads."""
+        return {
+            "module_patterns": ["model.action_head.model.transformer_blocks"],
+            "skip_modules": [],
+        }
+
+    def fp8_unsupported_reason(self) -> str | None:
+        """Reject FP8 when the only default target, the action DiT, is frozen."""
+        if not self.config.tune_diffusion_model:
+            return "tune_diffusion_model=false freezes the action DiT"
+        return None
+
     def _apply(self, fn, recurse=True):
         result = super()._apply(fn, recurse)
         if not self._restoring_after_apply:

--- a/loongforge/embodied/model/groot_n1_7/modeling_groot_n1_7.py
+++ b/loongforge/embodied/model/groot_n1_7/modeling_groot_n1_7.py
@@ -444,6 +444,20 @@ class GrootN1d7Policy(nn.Module):
         self._predict_action_processor_cache: dict[str, StateActionProcessor] = {}
         self._predict_action_eval_image_transform = None
 
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert the action DiT blocks while preserving projection heads."""
+        return {
+            "module_patterns": ["model.action_head.model.transformer_blocks"],
+            "skip_modules": [],
+        }
+
+    def fp8_unsupported_reason(self) -> str | None:
+        """Reject FP8 when the only default target, the action DiT, is frozen."""
+        if not self.config.tune_diffusion_model:
+            return "tune_diffusion_model=false freezes the action DiT"
+        return None
+
     def reset_data_iterator_rng(self, seed: int) -> None:
         """Align DataLoader worker base seeds with Isaac's finetune path."""
         seed = int(seed)

--- a/loongforge/embodied/model/lingbot_va/lingbot_fsdp2_adapter.py
+++ b/loongforge/embodied/model/lingbot_va/lingbot_fsdp2_adapter.py
@@ -16,8 +16,30 @@ from loongforge.embodied.distributed.fsdp_utils.builders import (
     build_ignored_params,
     build_mp_policy,
 )
+from loongforge.embodied.distributed.fp8_utils import apply_fp8_linear_conversion
 from loongforge.embodied.model.lingbot_va.features import feature_enabled
 from loongforge.embodied.model.lingbot_va.modules.wan_model import WanTransformerBlock
+
+
+def _configure_lingbot_checkpoint(model, training_args):
+    """Use TE's FP8-aware checkpoint for LingBot's internal block recompute."""
+    if not (
+        getattr(training_args, "fp8", False)
+        and getattr(training_args, "fp8_backend", None) == "te"
+    ):
+        return
+
+    backbone = getattr(model, "model", None)
+    set_checkpoint = getattr(backbone, "set_block_checkpoint_fn", None)
+    if not callable(set_checkpoint):
+        raise RuntimeError(
+            "LingBot TE FP8 requires a backbone that supports "
+            "set_block_checkpoint_fn()."
+        )
+
+    from loongforge.embodied.distributed.fp8_utils import te_checkpoint_fn
+
+    set_checkpoint(te_checkpoint_fn())
 
 
 def module_params(
@@ -105,6 +127,9 @@ def wrap_lingbot_torch_nested_fsdp2(model, training_args, ctx):
         raise RuntimeError(
             "LingBot native nested FSDP2 requires embodied FSDP strategy"
         )
+
+    apply_fp8_linear_conversion(model, training_args, ctx.device)
+    _configure_lingbot_checkpoint(model, training_args)
 
     if not getattr(ctx, "is_distributed", False):
         return model.to(device=ctx.device)

--- a/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
+++ b/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
@@ -7,7 +7,9 @@
 """Embodied training adapter for the native PyTorch LingBot-VA backend."""
 
 from collections import OrderedDict
-from typing import Dict
+import hashlib
+import os
+from typing import Any, Dict
 
 import torch
 import torch.nn as nn
@@ -135,6 +137,22 @@ class LingBotVAEmbodiedModel(nn.Module):
             attn_mode="flex" if use_flex else "torch",
             recompute_granularity=_cfg_get(cfg, "recompute_granularity", None),
         )
+
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert only FFN projections inside Wan transformer blocks.
+
+        Attention projections are intentionally kept in BF16. Quantization
+        noise in Q/K/V and attention output projections is amplified by the
+        softmax and then fed through the residual stream, which can produce a
+        large loss drift over the full training run. FFN GEMMs are the largest
+        remaining safe target and still provide most of the FP8 throughput
+        benefit.
+        """
+        return {
+            "module_patterns": ["model.blocks.*.ffn"],
+            "skip_modules": [],
+        }
 
     @classmethod
     def from_pretrained(cls, cfg):

--- a/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
+++ b/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
@@ -7,8 +7,6 @@
 """Embodied training adapter for the native PyTorch LingBot-VA backend."""
 
 from collections import OrderedDict
-import hashlib
-import os
 from typing import Any, Dict
 
 import torch

--- a/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
+++ b/loongforge/embodied/model/lingbot_va/modeling_lingbot_va.py
@@ -148,7 +148,7 @@ class LingBotVAEmbodiedModel(nn.Module):
         benefit.
         """
         return {
-            "module_patterns": ["model.blocks.*.ffn"],
+            "module_patterns": ["model"],
             "skip_modules": [],
         }
 

--- a/loongforge/embodied/model/lingbot_va/modules/wan_model.py
+++ b/loongforge/embodied/model/lingbot_va/modules/wan_model.py
@@ -843,6 +843,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin):
         super().__init__()
         self.patch_size = tuple(patch_size)
         self.recompute_granularity = recompute_granularity
+        self._block_checkpoint_fn = checkpoint
         inner_dim = num_attention_heads * attention_head_dim
         self.rope = WanRotaryPosEmbed(attention_head_dim, patch_size, rope_max_seq_len)
         self.patch_embedding_mlp = nn.Linear(
@@ -874,6 +875,12 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin):
         )
         self._padding_cache = {}
         self._padded_rope_cache = {}
+
+    def set_block_checkpoint_fn(self, checkpoint_fn) -> None:
+        """Set the runtime checkpoint implementation for full block recompute."""
+        if not callable(checkpoint_fn):
+            raise TypeError("block checkpoint implementation must be callable")
+        self._block_checkpoint_fn = checkpoint_fn
 
     def _padding_zeros(self, reference: torch.Tensor, shape):
         cache_key = (tuple(shape), str(reference.device), str(reference.dtype))
@@ -1098,7 +1105,7 @@ class WanTransformer3DModel(ModelMixin, ConfigMixin):
 
         for block in self.blocks:
             if self.training and self.recompute_granularity == "full":
-                hidden_states = checkpoint(
+                hidden_states = self._block_checkpoint_fn(
                     block,
                     hidden_states,
                     text_hidden,

--- a/loongforge/embodied/model/pi05/modeling_pi05.py
+++ b/loongforge/embodied/model/pi05/modeling_pi05.py
@@ -28,7 +28,7 @@ import logging
 import math
 import os
 from dataclasses import dataclass
-from typing import Dict, Literal, Optional
+from typing import Any, Dict, Literal, Optional
 
 import numpy as np
 import torch
@@ -1082,6 +1082,41 @@ class PI05Policy(nn.Module):
         action_stats = convert_stats(dataset_stats.get("action")) if dataset_stats else None
         actions = _q99_unnormalize_actions(actions, action_stats)
         return actions.cpu().numpy()
+
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """FP8 conversion targets: the whole model minus its fp32-critical layers.
+
+        The skip list is the module-key spelling of the two
+        ``_FP32_PARAM_SELECTORS`` lists (``PaliGemmaWithExpertModel`` and
+        ``PI05Pytorch``). Those layers are deliberately held in fp32 by
+        ``to_bfloat16_for_selected_params``, so converting them to te.Linear
+        would quantize exactly the tensors the model asks to keep at full
+        precision.
+
+        Only the action expert carries adaRMS conditioning (``use_adarms=[False,
+        True]``), so only its layernorms own a ``dense`` Linear; the PaliGemma
+        language-model layernorms have no Linear to skip and naming them here
+        would raise as an unmatched pattern.
+        """
+        expert = "model.paligemma_with_expert.gemma_expert.model"
+        vlm = "model.paligemma_with_expert.paligemma.model"
+        return {
+            "module_patterns": ["model"],
+            "skip_modules": [
+                # PaliGemmaWithExpertModel._FP32_PARAM_SELECTORS
+                f"{vlm}.vision_tower",
+                f"{vlm}.multi_modal_projector",
+                f"{expert}.layers.*.input_layernorm",
+                f"{expert}.layers.*.post_attention_layernorm",
+                f"{expert}.norm",
+                # PI05Pytorch._FP32_PARAM_SELECTORS
+                "model.action_in_proj",
+                "model.action_out_proj",
+                "model.time_mlp_in",
+                "model.time_mlp_out",
+            ],
+        }
 
     @classmethod
     def from_pretrained(cls, model_cfg) -> "PI05Policy":

--- a/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
+++ b/loongforge/embodied/model/wall_oss_0_5/modeling_wall_oss_0_5.py
@@ -166,6 +166,19 @@ class WallOss05Model(nn.Module):
         super().__init__()
         self.model = model
 
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert the decoder blocks while preserving precision-sensitive heads.
+
+        The decoder subtree contains the large attention and FFN/MoE ``nn.Linear``
+        modules. The vision tower, language-model head, and action preprocessor
+        remain at their configured precision.
+        """
+        return {
+            "module_patterns": ["model.model.layers"],
+            "skip_modules": [],
+        }
+
     @classmethod
     def from_pretrained(cls, model_cfg: WallOss05ModelConfig) -> "WallOss05Model":
         """Build the model shell only; weights are loaded later via ``load_pretrained``.

--- a/loongforge/embodied/model/xvla/modeling_xvla.py
+++ b/loongforge/embodied/model/xvla/modeling_xvla.py
@@ -19,7 +19,7 @@
 
 from __future__ import annotations
 
-from typing import Dict
+from typing import Any, Dict
 
 import numpy as np
 import os
@@ -272,6 +272,19 @@ class XVLAPolicy(torch.nn.Module):
         self._num_image_views = int(getattr(config, "num_image_views", 3) or 3)
         self._tokenize_transform = None
         self._image_transform = None
+
+    @staticmethod
+    def default_fp8_targets() -> Dict[str, Any]:
+        """Convert only the action transformer's attention and MLP blocks.
+
+        The Florence VLM is initialized in fp32, while the action projections
+        can be domain-aware custom linears. Restricting the default to the
+        transformer blocks avoids changing either precision contract.
+        """
+        return {
+            "module_patterns": ["model.transformer.blocks"],
+            "skip_modules": [],
+        }
 
     def _prepare_inputs(self, batch) -> Dict[str, torch.Tensor]:
         """Map an XVLAProcessor-style batch dict into XVLA model forward arguments.

--- a/loongforge/embodied/train/trainers/base_trainer.py
+++ b/loongforge/embodied/train/trainers/base_trainer.py
@@ -658,6 +658,17 @@ class BaseTrainer(ABC):
         """Hook for model-specific backend precision controls."""
         pass
 
+    def _fp8_forward_ctx(self):
+        """Return the FP8 forward context, or a no-op when ``--fp8`` is off.
+
+        Lives on the base class because every paradigm's forward needs it: the
+        standard finetune path and the CUDA-graph runner each wrap their own
+        forward, and ``te.fp8_autocast`` has to enclose the whole model call.
+        """
+        from loongforge.embodied.distributed.fp8_utils import resolve_fp8_forward_ctx
+
+        return resolve_fp8_forward_ctx(self.training_args)
+
     def _apply_lora_before_wrap(self, model: nn.Module) -> nn.Module:
         """Apply generic LoRA injection before distributed wrapping."""
         if not is_lora_enabled(self.training_args):

--- a/loongforge/embodied/train/trainers/supervised/finetune_trainer.py
+++ b/loongforge/embodied/train/trainers/supervised/finetune_trainer.py
@@ -81,7 +81,7 @@ class FinetuneTrainer(BaseTrainer):
             else torch.autocast("cuda", dtype=dtype)
         )
 
-        with autocast_ctx:
+        with self._fp8_forward_ctx(), autocast_ctx:
             loss, log_loss_dict = self.model(batch, **fwd_kwargs)
 
         return loss, log_loss_dict

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -103,6 +103,19 @@ def parse_positive_int(value: str) -> int:
     return int_value
 
 
+def parse_non_negative_int(value: str) -> int:
+    """Parse a non-negative integer CLI value."""
+    try:
+        int_value = int(value)
+    except ValueError as exc:
+        raise argparse.ArgumentTypeError(
+            "expected a non-negative integer"
+        ) from exc
+    if int_value < 0:
+        raise argparse.ArgumentTypeError("expected a non-negative integer")
+    return int_value
+
+
 def parse_module_key_patterns(
     value: str | list[str] | None,
     *,
@@ -1125,6 +1138,162 @@ class _ActivationCheckpointArgs:
 
 
 @dataclass(frozen=True)
+class _FP8Args:
+    """FP8 configuration shared by, or specific to, each backend."""
+
+    # Backend-independent FP8 switches and module selection.
+    fp8: bool = field(
+        default=False,
+        metadata={
+            "help": "Convert selected nn.Linear modules for FP8 training with "
+                    "the backend selected by --fp8-backend.",
+        },
+    )
+    fp8_backend: str = field(
+        default="te",
+        metadata={
+            "choices": ["te", "torchao"],
+            "help": "FP8 implementation: TransformerEngine (te) or native "
+                    "PyTorch TorchAO (torchao).",
+        },
+    )
+
+    fp8_module_patterns: Optional[list[str]] = field(
+        default=None,
+        metadata={
+            "cli_type": partial(
+                parse_module_key_patterns,
+                option_name="--fp8-module-patterns",
+            ),
+            "help": "Comma-separated qualified module-key patterns whose "
+                    "nn.Linear descendants are converted for FP8. Unlike "
+                    "--activation-checkpoint-module-patterns, a pattern selects "
+                    "a subtree, not one module. Unset falls back to the model's "
+                    "default_fp8_targets().",
+        },
+    )
+    fp8_skip_modules: Optional[list[str]] = field(
+        default=None,
+        metadata={
+            "cli_type": partial(
+                parse_module_key_patterns,
+                option_name="--fp8-skip-modules",
+            ),
+            "help": "Optional comma-separated qualified module-key patterns to "
+                    "exclude from --fp8-module-patterns. Use this to keep "
+                    "numerically sensitive layers (vision towers, action "
+                    "projections) out of FP8. Every pattern must match at least "
+                    "one selected layer.",
+        },
+    )
+    fp8_min_dim: int = field(
+        default=2048,
+        metadata={
+            "cli_type": parse_positive_int,
+            "help": "Only convert layers whose max(in_features, out_features) "
+                    "reaches this size. Smaller GEMMs are slower in FP8 than in "
+                    "bf16, so converting them costs throughput.",
+        },
+    )
+
+    # TransformerEngine-only recipe and scaling parameters.
+    fp8_te_recipe: str = field(
+        default="blockwise",
+        metadata={
+            "choices": ["blockwise", "current", "delayed"],
+            "help": "TransformerEngine FP8 scaling recipe: blockwise "
+                    "(Float8BlockScaling), "
+                    "current (Float8CurrentScaling), or delayed (DelayedScaling).",
+        },
+    )
+    fp8_te_format: Optional[str] = field(
+        default=None,
+        metadata={
+            "choices": ["e4m3", "hybrid"],
+            "help": "TransformerEngine-only FP8 data format override. Unset preserves each "
+                    "TransformerEngine recipe's native default: E4M3 for "
+                    "blockwise and HYBRID for current/delayed.",
+        },
+    )
+    fp8_te_margin: int = field(
+        default=0,
+        metadata={
+            "cli_type": parse_non_negative_int,
+            "help": "TransformerEngine DelayedScaling only: power-of-two safety "
+                    "margin used when "
+                    "computing scale = FP8_MAX / (amax * 2**margin).",
+        },
+    )
+    fp8_te_amax_history_len: int = field(
+        default=1024,
+        metadata={
+            "cli_type": parse_positive_int,
+            "help": "TransformerEngine DelayedScaling only: number of historical "
+                    "amax values "
+                    "retained for scale computation.",
+        },
+    )
+    fp8_te_amax_compute_algo: str = field(
+        default="max",
+        metadata={
+            "choices": ["max", "most_recent"],
+            "help": "TransformerEngine DelayedScaling only: choose the largest "
+                    "historical amax "
+                    "or the most recently observed value.",
+        },
+    )
+    fp8_te_reduce_amax: bool = field(
+        default=True,
+        metadata={
+            "help": "TransformerEngine DelayedScaling only: reduce amax across "
+                    "the fp8 process "
+                    "group so data-parallel ranks use synchronized scales.",
+        },
+    )
+    fp8_te_current_use_power_2_scales: bool = field(
+        default=False,
+        metadata={
+            "help": "TransformerEngine Float8CurrentScaling only: constrain "
+                    "scaling factors to "
+                    "powers of two.",
+        },
+    )
+    fp8_te_block_use_f32_scales: bool = field(
+        default=False,
+        metadata={
+            "help": "TransformerEngine Float8BlockScaling only: allow "
+                    "unconstrained FP32 scales "
+                    "instead of the default power-of-two scales.",
+        },
+    )
+
+    # TorchAO-only recipe and FSDP/shape parameters.
+    fp8_torchao_recipe: str = field(
+        default="tensorwise",
+        metadata={
+            "choices": ["tensorwise", "rowwise", "rowwise_with_gw_hp"],
+            "help": "TorchAO Float8Linear recipe. Tensorwise is fastest; "
+                    "rowwise improves outlier handling; rowwise_with_gw_hp "
+                    "keeps grad-weight GEMM in high precision.",
+        },
+    )
+    fp8_torchao_pad_inner_dim: bool = field(
+        default=True,
+        metadata={
+            "help": "TorchAO only: zero-pad unaligned GEMM inner dimensions. "
+                    "Enabled by default so Linear K/hidden dimensions that are "
+                    "not 16-aligned can use the scaled GEMM. This does not pad "
+                    "the flattened token/batch M dimension.",
+        },
+    )
+    fp8_torchao_fsdp_float8_all_gather: bool = field(
+        default=False,
+        metadata={
+            "help": "TorchAO tensorwise + FSDP only: cast weight shards to FP8 "
+                    "for all-gather to reduce communication bandwidth.",
+        },
+    )
+@dataclass(frozen=True)
 class _DistributedArgs:
     """Parallelism strategy (FSDP/DDP), dtype, ZeRO, and meta-device init."""
 
@@ -1462,6 +1631,7 @@ class TrainingArgs(
     _ProfilerArgs,
     _CudaGraphArgs,
     _ActivationCheckpointArgs,
+    _FP8Args,
     _DistributedArgs,
 ):
     """Generic training args (single source of truth). Frozen after construction.

--- a/loongforge/embodied/train/training_args.py
+++ b/loongforge/embodied/train/training_args.py
@@ -1200,19 +1200,22 @@ class _FP8Args:
     fp8_te_recipe: str = field(
         default="blockwise",
         metadata={
-            "choices": ["blockwise", "current", "delayed"],
+            "choices": ["blockwise", "current", "delayed", "mxfp8"],
             "help": "TransformerEngine FP8 scaling recipe: blockwise "
                     "(Float8BlockScaling), "
-                    "current (Float8CurrentScaling), or delayed (DelayedScaling).",
+                    "current (Float8CurrentScaling), delayed (DelayedScaling), "
+                    "or mxfp8 (MXFP8BlockScaling microscaling).",
         },
     )
     fp8_te_format: Optional[str] = field(
         default=None,
         metadata={
-            "choices": ["e4m3", "hybrid"],
+            "choices": ["e4m3", "e5m2", "hybrid"],
             "help": "TransformerEngine-only FP8 data format override. Unset preserves each "
                     "TransformerEngine recipe's native default: E4M3 for "
-                    "blockwise and HYBRID for current/delayed.",
+                    "blockwise and HYBRID for current/delayed/mxfp8. E5M2 "
+                    "requires a TransformerEngine recipe that supports pure "
+                    "E5M2 and is not supported by MXFP8.",
         },
     )
     fp8_te_margin: int = field(
@@ -1264,6 +1267,16 @@ class _FP8Args:
             "help": "TransformerEngine Float8BlockScaling only: allow "
                     "unconstrained FP32 scales "
                     "instead of the default power-of-two scales.",
+        },
+    )
+    fp8_te_block_backward_override: Optional[str] = field(
+        default=None,
+        metadata={
+            "choices": ["high_precision", "dequantized"],
+            "help": "TransformerEngine Float8BlockScaling only: override "
+                    "backward precision. Unset preserves the default behavior; "
+                    "high_precision keeps high-precision backward operands; "
+                    "dequantized dequantizes saved operands before backward.",
         },
     )
 

--- a/loongforge/embodied/train/validators.py
+++ b/loongforge/embodied/train/validators.py
@@ -262,6 +262,81 @@ def validate(training_args, model_cfg, data_cfg):
                 "--save-interval=0 disables both checkpoints and LoRA adapter saving."
             )
 
+    # ── FP8 ──
+    if training_args.fp8:
+        if training_args.init_on_meta:
+            raise ValueError(
+                "--fp8 does not currently support --init-on-meta in the "
+                "embodied model wrapping lifecycle."
+            )
+        if training_args.use_lora:
+            raise ValueError(
+                "--fp8 and --use-lora are mutually exclusive. PEFT selects "
+                "targets and replaces Linear modules before FP8 conversion; "
+                "this combination has not been validated for either backend."
+            )
+        if training_args.cuda_graph_impl == "local":
+            raise ValueError(
+                "--fp8 and --cuda-graph-impl=local are mutually exclusive; "
+                "the model-managed graph runners do not capture FP8 scaling "
+                "and conversion state."
+            )
+        if training_args.fp8_skip_modules and not training_args.fp8_module_patterns:
+            logger.warning(
+                "--fp8-skip-modules is set without --fp8-module-patterns; it "
+                "will be applied against the model's default_fp8_targets()."
+            )
+        if (
+            training_args.fp8_backend == "te"
+            and getattr(model_cfg, "compile_model", False)
+        ):
+            raise ValueError(
+                "--fp8 conflicts with model.compile_model=true: te.Linear.forward "
+                "carries torch.compiler.disable, so Dynamo raises "
+                "'Skip inlining torch.compiler.disable()d function' instead of "
+                "graph-breaking. Pass model.compile_model=false to run FP8."
+            )
+        if training_args.fp8_backend == "torchao":
+            te_overrides = (
+                training_args.fp8_te_format is not None
+                or training_args.fp8_te_margin != 0
+                or training_args.fp8_te_amax_history_len != 1024
+                or training_args.fp8_te_amax_compute_algo != "max"
+                or not training_args.fp8_te_reduce_amax
+                or training_args.fp8_te_current_use_power_2_scales
+                or training_args.fp8_te_block_use_f32_scales
+            )
+            if te_overrides:
+                raise ValueError(
+                    "TransformerEngine recipe options cannot be used with "
+                    "--fp8-backend=torchao; configure --fp8-torchao-recipe "
+                    "and TorchAO-specific options instead."
+                )
+            if (
+                training_args.fp8_torchao_fsdp_float8_all_gather
+                and training_args.distributed_strategy != "fsdp"
+            ):
+                raise ValueError(
+                    "--fp8-torchao-fsdp-float8-all-gather requires "
+                    "--distributed-strategy=fsdp."
+                )
+            if (
+                training_args.fp8_torchao_fsdp_float8_all_gather
+                and training_args.fp8_torchao_recipe != "tensorwise"
+            ):
+                raise ValueError(
+                    "TorchAO FP8 FSDP all-gather currently supports only "
+                    "--fp8-torchao-recipe=tensorwise."
+                )
+        elif (
+            training_args.fp8_torchao_recipe != "tensorwise"
+            or not training_args.fp8_torchao_pad_inner_dim
+            or training_args.fp8_torchao_fsdp_float8_all_gather
+        ):
+            raise ValueError(
+                "TorchAO-specific FP8 options require --fp8-backend=torchao."
+            )
+
     # ── Model config sanity ──
     if not model_cfg.model_type:
         raise ValueError("ModelConfig.model_type must be set (from YAML model.model_type).")

--- a/loongforge/embodied/train/validators.py
+++ b/loongforge/embodied/train/validators.py
@@ -305,6 +305,7 @@ def validate(training_args, model_cfg, data_cfg):
                 or not training_args.fp8_te_reduce_amax
                 or training_args.fp8_te_current_use_power_2_scales
                 or training_args.fp8_te_block_use_f32_scales
+                or training_args.fp8_te_block_backward_override is not None
             )
             if te_overrides:
                 raise ValueError(


### PR DESCRIPTION
## 变更说明

仅包含 commit 843de0ca8f5ea26e08ba182c10c96c5f2292a0a8 的 FP8 Linear 转换组件改动，支持 Transformer Engine（TE）和 TorchAO 后端，并接入分布式训练、激活检查点、模型包装及训练参数配置。

## 来源

- Source repository: NeosZhang/LoongForge
- Source branch: aiak-train-2354-fp8
- Original commit: 843de0ca8f5ea26e08ba182c10c96c5f2292a0a8
- Target branch: baidu-baige/LoongForge:master