### PR TITLE
fix(fastwam): cast RoPE tables to query dtype

### DIFF
--- a/loongforge/embodied/model/fastwam/wan/dit.py
+++ b/loongforge/embodied/model/fastwam/wan/dit.py
@@ -142,6 +142,9 @@ def rope_apply(x, freqs, num_heads):
     """
     cos, sin = freqs
     x = rearrange(x, "b s (n d) -> b s n d", n=num_heads)
+    # FlashAttention's Triton kernel requires tables matching the Q/K dtype.
+    cos = cos.to(dtype=x.dtype, device=x.device)
+    sin = sin.to(dtype=x.dtype, device=x.device)
     return _TritonRoPE.apply(x, cos, sin).flatten(2)
 
 


### PR DESCRIPTION
## Summary

- Cast RoPE cosine and sine tables to the query/key tensor dtype and device before invoking the FlashAttention Triton kernel.
- Improve compatibility across FlashAttention and Triton environments with different input dtype requirements.

## Motivation

`prepare_rope_freqs` produces FP32 RoPE tables, while query and key tensors may use BF16 during mixed-precision training. 

Some FlashAttention Triton RoPE implementations require these inputs to have matching dtypes and devices, which can otherwise cause an environment-dependent runtime failure. Aligning the tables at the call boundary makes the FastWAM RoPE path work consistently across supported environments.

