### PR TITLE
[docs] feat: document DreamZero FSDP and Delta-FP8 AllGather

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ Since optimal training strategies differ across model families and scales, Loong
 
 ## 🔥 Latest News
 
+- **[2026/09]** ⚡ Added an optimized **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)** with cache-aware data loading, compiled attention blocks, frozen-module handling, and Delta-FP8 AllGather, reaching **4.38× speedup** over the official implementation.
 - **[2026/08]** 🤖 Added VLA training support for **[Wall-OSS-0.5](./examples/embodied/wall_oss_0_5/)**, with custom fused operators for higher training throughput.
 - **[2026/08]** 📄 Released the **[TAOT paper](https://arxiv.org/abs/2608.03676)** — topology-aware dynamic expert replica placement that tackles expert-parallel (**EP**) load imbalance in **MoE** training, cutting overhead by up to **74%** over industry solutions, with **1.43× speedup** measured on a real training case. [[blog](https://baidu-baige.github.io/LoongForge/blog/2026-08-taot-topology-aware-expert-placement.html)]
 - **[2026/08]** ✨ Added training support for **GLM-5.2**, along with a **[GLM-5.2 + MoonViT](./configs/models/glm5.2_vit/)** custom-composition [example](./examples/glm5.2_vit/) for extending GLM with multimodal capabilities.
@@ -108,6 +109,7 @@ Since optimal training strategies differ across model families and scales, Loong
 **🤖 Embodied Models**
 
 * **🦾 VLA & WAM Training** — A dedicated **torch-native DDP/FSDP** subsystem for **VLA and world-action (WAM)** models (e.g. Pi0.5, GR00T N1.6, FastWAM), decoupled from the Megatron core, with flexible **DDP / ZeRO-1 / FSDP / HSDP** strategies. [[README](./loongforge/embodied)]
+* **⚡ Delta-FP8 FSDP Communication** — Optionally compresses BF16 FSDP2 AllGather deltas into blockwise FP8 on supported NVIDIA GPUs while keeping model computation in BF16. [[Usage](./docs/source/features/delta_fp8_allgather.md)]
 * **⚡ Per-Model Deep Optimization** — Training code deeply customized for each supported model across I/O, communication strategy, and kernel efficiency, delivering significant speedups over official baselines.
 * **🧪 Unified Evaluation** — Evaluate trained policies on **LIBERO / CALVIN / SimplerEnv / RoboTwin**, with coverage expanding continuously.
 

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Since optimal training strategies differ across model families and scales, Loong
 
 ## 🔥 Latest News
 
-- **[2026/09]** ⚡ Added an optimized **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)** with cache-aware data loading, compiled attention blocks, frozen-module handling, and Delta-FP8 AllGather, reaching **4.38× speedup** over the official implementation.
+- **[2026/09]** ⚡ Added an optimized **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)** with cache-aware data loading, compiled attention blocks, frozen-module handling, and Delta-FP8 AllGather.
 - **[2026/08]** 🤖 Added VLA training support for **[Wall-OSS-0.5](./examples/embodied/wall_oss_0_5/)**, with custom fused operators for higher training throughput.
 - **[2026/08]** 📄 Released the **[TAOT paper](https://arxiv.org/abs/2608.03676)** — topology-aware dynamic expert replica placement that tackles expert-parallel (**EP**) load imbalance in **MoE** training, cutting overhead by up to **74%** over industry solutions, with **1.43× speedup** measured on a real training case. [[blog](https://baidu-baige.github.io/LoongForge/blog/2026-08-taot-topology-aware-expert-placement.html)]
 - **[2026/08]** ✨ Added training support for **GLM-5.2**, along with a **[GLM-5.2 + MoonViT](./configs/models/glm5.2_vit/)** custom-composition [example](./examples/glm5.2_vit/) for extending GLM with multimodal capabilities.

--- a/README_zh.md
+++ b/README_zh.md
@@ -64,6 +64,7 @@
 
 ## 🔥 最新动态
 
+- **[2026/09]** ⚡ 新增优化后的 **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)**，集成 cache-aware 数据加载、attention block 编译、冻结模块处理与 Delta-FP8 AllGather，相较官方实现达到 **4.38× 加速**。
 - **[2026/08]** 🤖 新增 **[Wall-OSS-0.5](./examples/embodied/wall_oss_0_5/)** VLA 训练支持，并通过自定义融合算子提升训练吞吐。
 - **[2026/08]** 📄 发布 **[TAOT 论文](https://arxiv.org/abs/2608.03676)** —— 通过拓扑感知的动态专家副本放置，优化 **MoE** 训练中的专家并行（**EP**）负载不均衡，相较业界方案开销最大可降低 **74%**，案例实测 **1.43× 加速**。[[blog](https://baidu-baige.github.io/LoongForge/blog/2026-08-taot-topology-aware-expert-placement.html)]
 - **[2026/08]** ✨ 新增 **GLM-5.2** 训练支持，并提供 **[GLM-5.2 + MoonViT](./configs/models/glm5.2_vit/)** 自定义组合[示例](./examples/glm5.2_vit/)，可用于为 GLM 扩展多模态能力。
@@ -108,6 +109,7 @@
 **🤖 具身模型**
 
 * **🦾 VLA 与 WAM 训练** —— 面向 **VLA 与世界-动作模型（WAM）**（如 Pi0.5、GR00T N1.6、FastWAM）的独立 **torch 原生 DDP/FSDP** 子系统，与 Megatron 核心解耦，支持 **DDP / ZeRO-1 / FSDP / HSDP** 多种分布式策略。[[README](./loongforge/embodied)]
+* **⚡ Delta-FP8 FSDP 通信** —— 在支持的 NVIDIA GPU 上，可选将 BF16 FSDP2 AllGather 的参数差值按 block 压缩为 FP8，模型计算仍保持 BF16。[[使用方法](./docs/source_zh/features/delta_fp8_allgather.md)]
 * **⚡ 逐模型深度定制优化** —— 针对当前覆盖的每个模型深度优化训练代码，涵盖 I/O、通信策略、算子效率等维度，实现显著的训练加速。
 * **🧪 统一评测** —— 在 **LIBERO / CALVIN / SimplerEnv / RoboTwin** 上评测训练出的策略，覆盖度持续完善。
 

--- a/README_zh.md
+++ b/README_zh.md
@@ -64,7 +64,7 @@
 
 ## 🔥 最新动态
 
-- **[2026/09]** ⚡ 新增优化后的 **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)**，集成 cache-aware 数据加载、attention block 编译、冻结模块处理与 Delta-FP8 AllGather，相较官方实现达到 **4.38× 加速**。
+- **[2026/09]** ⚡ 新增优化后的 **[DreamZero Wan2.2-5B FSDP recipe](./examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh)**，集成 cache-aware 数据加载、attention block 编译、冻结模块处理与 Delta-FP8 AllGather。
 - **[2026/08]** 🤖 新增 **[Wall-OSS-0.5](./examples/embodied/wall_oss_0_5/)** VLA 训练支持，并通过自定义融合算子提升训练吞吐。
 - **[2026/08]** 📄 发布 **[TAOT 论文](https://arxiv.org/abs/2608.03676)** —— 通过拓扑感知的动态专家副本放置，优化 **MoE** 训练中的专家并行（**EP**）负载不均衡，相较业界方案开销最大可降低 **74%**，案例实测 **1.43× 加速**。[[blog](https://baidu-baige.github.io/LoongForge/blog/2026-08-taot-topology-aware-expert-placement.html)]
 - **[2026/08]** ✨ 新增 **GLM-5.2** 训练支持，并提供 **[GLM-5.2 + MoonViT](./configs/models/glm5.2_vit/)** 自定义组合[示例](./examples/glm5.2_vit/)，可用于为 GLM 扩展多模态能力。

--- a/docs/source/embodied_tutorial/overview.md
+++ b/docs/source/embodied_tutorial/overview.md
@@ -125,6 +125,7 @@ The arguments in this section control DataLoader worker parallelism, the multipr
 | Feature | Argument | Default | Values / Type | Description |
 | --- | --- | --- | --- | --- |
 | Worker count | `--num-workers` | `4` | Non-negative integer | DataLoader workers per rank |
+| Prefetch factor | `--dataloader-prefetch-factor` | `2` | Positive integer | Number of batches prefetched by each worker; only applies when `--num-workers` is greater than 0 |
 | Worker seed | `--dataloader-seed-workers` | `False` | Bool flag | Whether to seed workers from `--seed` |
 | Multiprocessing context | `--dataloader-multiprocessing-context` | `None` | `fork`, `spawn`, `forkserver` | DataLoader worker start method |
 | Distributed sampler mode | `--distributed-sampler-mode` | `cyclic` | `cyclic`, `block` | Index sharding scheme for the distributed sampler (extensible) |
@@ -384,26 +385,36 @@ bash examples/embodied/pi05/run_pi05_ddp_finetune.sh \
 
 #### 4.2.2 FSDP Common Arguments
 
-The following arguments give fine-grained control over FSDP sharding, wrap policy, and dtypes, and take effect only under `--distributed-strategy fsdp`:
+The following arguments give fine-grained control over FSDP sharding, wrap policy, dtypes, prefetching, and communication, and take effect only under `--distributed-strategy fsdp`:
 
-- **Sharding and reshard**: control whether to reshard immediately after forward, configurable separately for the root group
+- **Sharding and reshard**: control whether to reshard immediately after forward, with optional per-module-class overrides; the FSDP2 root group remains unsharded after forward
 - **Wrap policy**: manually specify or exclude FSDP unit classes, or auto-wrap by a parameter-count threshold
 - **dtype control**: pre-shard parameter dtype, post-all-gather dtype, and gradient reduce dtype can each be configured independently
+- **Execution and communication**: prefetch adjacent FSDP units and optionally compress BF16 AllGather traffic with Delta-FP8
 
 | Feature | Argument | Default | Values / Type | Description |
 | --- | --- | --- | --- | --- |
 | HSDP | `--hsdp-shard-size` | `None` | Positive integer | Enable the shard dimension of the 2D mesh |
 | Default reshard policy | `--fsdp-reshard-default` | `None` | `true`, `false`, `none`, integer > 1 | Controls parameter reshard after forward |
-| Root reshard policy | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, integer > 1 | Reshard policy for the root FSDP group |
+| Per-class reshard policy | `--fsdp-reshard-module-overrides` | `None` | Comma-separated `ClassName=value` pairs | Override `reshard_after_forward` for selected module classes |
 | Wrap classes | `--fsdp-wrap-modules` | `None` | Comma-separated module class names | Specify FSDP units |
 | Exclude wrap classes | `--fsdp-no-wrap-modules` | `None` | Comma-separated module class names | Exclude the given module classes |
 | Exclude params from sharding | `--fsdp-ignored-param-names` | `[]` | Space-separated name substrings | Frozen params matching any substring stay replicated on every rank |
-| Auto wrap threshold | `--fsdp-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping repeated layers |
-| Leftover wrap threshold | `--fsdp-leftover-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping leftover modules |
+| Replicate frozen module classes | `--fsdp-ignore-frozen-module-classes` | `None` | Comma-separated module class names | Leave fully frozen matched modules outside FSDP sharding to avoid unused AllGathers; increases replicated parameter memory |
+| Replicated frozen parameter dtype | `--fsdp-ignored-frozen-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Optional dtype for replicated frozen parameters; when set, it must match `--dtype` |
+| Auto wrap threshold | `--fsdp-min-param-num` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping repeated layers |
 | Original parameter dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Parameter dtype before FSDP sharding |
-| Unsharded parameter dtype | `--fsdp-unsharded-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Forward/backward dtype after all-gather |
+| Unsharded parameter dtype | `--fsdp-unshard-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Forward/backward dtype after AllGather |
 | Reduce dtype | `--fsdp-reduce-dtype` | `fp32` | `fp32`, `bf16`, `fp16` | Gradient reduce dtype |
+| Output dtype | `--fsdp-output-dtype` | `None` | `fp32`, `bf16`, `fp16` | Optional dtype for floating-point outputs of each FSDP unit |
 | Cast forward inputs | `--fsdp-cast-forward-inputs` | `True` | Bool flag | Whether to cast inputs to the parameter dtype |
+| Forward prefetch distance | `--fsdp-forward-prefetch-distance` | `0` | Non-negative integer | Number of subsequent configured FSDP units to prefetch during forward |
+| Backward prefetch distance | `--fsdp-backward-prefetch-distance` | `0` | Non-negative integer | Number of preceding configured FSDP units to prefetch during backward |
+| Delta-FP8 AllGather | `--fsdp-delta-fp8-allgather` | `False` | Bool flag | Compress BF16 FSDP2 AllGather deltas into blockwise FP8; see the [usage guide](../features/delta_fp8_allgather.md) |
+
+When replicating frozen module classes, every matched parameter must have `requires_grad=False`. This mode is incompatible with `--init-on-meta`; if `--fsdp-ignored-frozen-param-dtype` is specified, it must match the training compute dtype selected by `--dtype`.
+
+Delta-FP8 changes only FSDP parameter communication precision; model computation remains in the dtype selected by the FSDP mixed-precision policy. See [Delta-FP8 AllGather](../features/delta_fp8_allgather.md) for prerequisites, usage, parameter reference, and validation guidance.
 
 ### 4.3 Stability and Runtime Control
 

--- a/docs/source/embodied_tutorial/overview.md
+++ b/docs/source/embodied_tutorial/overview.md
@@ -125,7 +125,6 @@ The arguments in this section control DataLoader worker parallelism, the multipr
 | Feature | Argument | Default | Values / Type | Description |
 | --- | --- | --- | --- | --- |
 | Worker count | `--num-workers` | `4` | Non-negative integer | DataLoader workers per rank |
-| Prefetch factor | `--dataloader-prefetch-factor` | `2` | Positive integer | Number of batches prefetched by each worker; only applies when `--num-workers` is greater than 0 |
 | Worker seed | `--dataloader-seed-workers` | `False` | Bool flag | Whether to seed workers from `--seed` |
 | Multiprocessing context | `--dataloader-multiprocessing-context` | `None` | `fork`, `spawn`, `forkserver` | DataLoader worker start method |
 | Distributed sampler mode | `--distributed-sampler-mode` | `cyclic` | `cyclic`, `block` | Index sharding scheme for the distributed sampler (extensible) |
@@ -385,36 +384,34 @@ bash examples/embodied/pi05/run_pi05_ddp_finetune.sh \
 
 #### 4.2.2 FSDP Common Arguments
 
-The following arguments give fine-grained control over FSDP sharding, wrap policy, dtypes, prefetching, and communication, and take effect only under `--distributed-strategy fsdp`:
+The following arguments give fine-grained control over FSDP sharding, wrap policy, dtypes, and communication, and take effect only under `--distributed-strategy fsdp`:
 
-- **Sharding and reshard**: control whether to reshard immediately after forward, with optional per-module-class overrides; the FSDP2 root group remains unsharded after forward
+- **Sharding and reshard**: control whether to reshard immediately after forward, configurable separately for the root group
 - **Wrap policy**: manually specify or exclude FSDP unit classes, or auto-wrap by a parameter-count threshold
 - **dtype control**: pre-shard parameter dtype, post-all-gather dtype, and gradient reduce dtype can each be configured independently
-- **Execution and communication**: prefetch adjacent FSDP units and optionally compress BF16 AllGather traffic with Delta-FP8
+- **Communication**: optionally compress BF16 AllGather traffic with Delta-FP8
 
 | Feature | Argument | Default | Values / Type | Description |
 | --- | --- | --- | --- | --- |
 | HSDP | `--hsdp-shard-size` | `None` | Positive integer | Enable the shard dimension of the 2D mesh |
 | Default reshard policy | `--fsdp-reshard-default` | `None` | `true`, `false`, `none`, integer > 1 | Controls parameter reshard after forward |
-| Per-class reshard policy | `--fsdp-reshard-module-overrides` | `None` | Comma-separated `ClassName=value` pairs | Override `reshard_after_forward` for selected module classes |
+| Root reshard policy | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, integer > 1 | Reshard policy for the root FSDP group |
 | Wrap classes | `--fsdp-wrap-modules` | `None` | Comma-separated module class names | Specify FSDP units |
 | Exclude wrap classes | `--fsdp-no-wrap-modules` | `None` | Comma-separated module class names | Exclude the given module classes |
 | Exclude params from sharding | `--fsdp-ignored-param-names` | `[]` | Space-separated name substrings | Frozen params matching any substring stay replicated on every rank |
 | Replicate frozen module classes | `--fsdp-ignore-frozen-module-classes` | `None` | Comma-separated module class names | Leave fully frozen matched modules outside FSDP sharding to avoid unused AllGathers; increases replicated parameter memory |
 | Replicated frozen parameter dtype | `--fsdp-ignored-frozen-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Optional dtype for replicated frozen parameters; when set, it must match `--dtype` |
-| Auto wrap threshold | `--fsdp-min-param-num` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping repeated layers |
+| Auto wrap threshold | `--fsdp-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping repeated layers |
+| Leftover wrap threshold | `--fsdp-leftover-min-num-params` | `1000000` | Non-negative integer | Parameter threshold for auto-wrapping leftover modules |
 | Original parameter dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Parameter dtype before FSDP sharding |
-| Unsharded parameter dtype | `--fsdp-unshard-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Forward/backward dtype after AllGather |
+| Unsharded parameter dtype | `--fsdp-unsharded-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | Forward/backward dtype after all-gather |
 | Reduce dtype | `--fsdp-reduce-dtype` | `fp32` | `fp32`, `bf16`, `fp16` | Gradient reduce dtype |
-| Output dtype | `--fsdp-output-dtype` | `None` | `fp32`, `bf16`, `fp16` | Optional dtype for floating-point outputs of each FSDP unit |
 | Cast forward inputs | `--fsdp-cast-forward-inputs` | `True` | Bool flag | Whether to cast inputs to the parameter dtype |
-| Forward prefetch distance | `--fsdp-forward-prefetch-distance` | `0` | Non-negative integer | Number of subsequent configured FSDP units to prefetch during forward |
-| Backward prefetch distance | `--fsdp-backward-prefetch-distance` | `0` | Non-negative integer | Number of preceding configured FSDP units to prefetch during backward |
 | Delta-FP8 AllGather | `--fsdp-delta-fp8-allgather` | `False` | Bool flag | Compress BF16 FSDP2 AllGather deltas into blockwise FP8; see the [usage guide](../features/delta_fp8_allgather.md) |
 
 When replicating frozen module classes, every matched parameter must have `requires_grad=False`. This mode is incompatible with `--init-on-meta`; if `--fsdp-ignored-frozen-param-dtype` is specified, it must match the training compute dtype selected by `--dtype`.
 
-Delta-FP8 changes only FSDP parameter communication precision; model computation remains in the dtype selected by the FSDP mixed-precision policy. See [Delta-FP8 AllGather](../features/delta_fp8_allgather.md) for prerequisites, usage, parameter reference, and validation guidance.
+Delta-FP8 changes only FSDP parameter communication precision; model computation remains in the dtype selected by the FSDP mixed-precision policy. See [Delta-FP8 AllGather](../features/delta_fp8_allgather.md) for prerequisites, usage, parameter reference, and troubleshooting.
 
 ### 4.3 Stability and Runtime Control
 

--- a/docs/source/embodied_tutorial/quick_start_dreamzero.md
+++ b/docs/source/embodied_tutorial/quick_start_dreamzero.md
@@ -144,30 +144,30 @@ cd "$LOONGFORGE_PATH"
 export DATA_PATH=$DROID_DATA_ROOT
 export WANDB_MODE=disabled
 
-# 5B Full, default 200000 steps
-bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+# 5B Full with FSDP + Delta-FP8, default 200000 steps
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 
 # 5B LoRA
 TRAIN_ITERS=10000 SAVE_INTERVAL=1000 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_fsdp_finetune.sh
 
 # 14B Full
-bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_finetune.sh
+bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_fsdp_finetune.sh
 
 # 14B LoRA, DROID
 TRAIN_ITERS=10000 SAVE_INTERVAL=1000 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 
 # LIBERO 5B Full
 MODEL_NAME=dreamzero_libero_wan22_5b DATA_PATH="$LIBERO_DATA_ROOT" \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 
 # AgiBot / YAM 14B LoRA (initialized from DreamZero-AgiBot)
 MODEL_NAME=dreamzero_agibot_wan21_14b DATA_PATH=/path/to/agibot_lerobot \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 
 MODEL_NAME=dreamzero_yam_wan21_14b DATA_PATH=/path/to/yam_lerobot \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 ```
 
 For the DROID scenario, `MODEL_NAME` does not need to be set; the training script automatically picks the correct config. Only when switching to LIBERO, AgiBot, or YAM do you need to override it as shown.
@@ -176,7 +176,7 @@ Defaults:
 
 | Scenario | Distributed Strategy | Per-GPU batch | Default global batch | Default LR |
 | --- | --- | --- | --- | --- |
-| 5B Full | 8-GPU DDP + ZeRO-1 | 1 | 8 | `1e-5` |
+| 5B Full | 8-GPU FSDP + Delta-FP8 | 1 | 8 | `1e-5` |
 | 5B LoRA | 8-GPU FSDP | 1 | 8 | `1e-5` |
 | 14B Full | 8-GPU FSDP | 1 | 8 | `1e-5` |
 | 14B DROID LoRA | 8-GPU FSDP | 1 | 8 | `1e-4` |
@@ -188,7 +188,7 @@ Batch sizes can be adjusted via `PER_DEVICE_BATCH_SIZE` and `GLOBAL_BATCH_SIZE`,
 ```bash
 TRAIN_ITERS=20000 SAVE_INTERVAL=1000 \
 OUTPUT_DIR=/workspace/outputs/dreamzero/droid_wan22_5b_lora \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_finetune.sh \
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_fsdp_finetune.sh \
     --resume
 ```
 
@@ -204,24 +204,24 @@ GPUS_PER_NODE=8 SAMPLE_TRANSFORM_SEED=0 VALIDATION_REQUIRE_FULL_COVERAGE=1 \
 
 # Train with cache (must match SAMPLE_TRANSFORM_SEED, resolution, and language chunk config used at generation time)
 CACHE_DIR=$DREAMZERO_CACHE_ROOT/dreamzero_full_wan22_5b SAMPLE_TRANSFORM_SEED=0 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 ```
 
 The training script strictly validates the cache at startup. When manifest, `_SUCCESS`, or transform config mismatch, training aborts before the first step.
 
 ### 2.4 Performance Optimization Switches
-The DROID 5B / 14B configs enable validated default optimizations. LIBERO, AgiBot, and YAM use conservative defaults. After adjusting performance switches, we recommend running 3–10 steps first and checking loss, grad norm, and memory usage.
+The DROID 5B / 14B configs enable validated default optimizations. The 5B Full FSDP recipe also enables Delta-FP8 AllGather by default on supported CUDA/NCCL devices; pass `--no-fsdp-delta-fp8-allgather` for a native BF16 communication A/B comparison. LIBERO, AgiBot, and YAM use conservative defaults. After adjusting performance switches, we recommend running 3–10 steps first and checking loss, grad norm, and memory usage.
 
 Control group (disable all kernel optimizations, for isolating loss / performance issues):
 
 ```bash
 # Wan2.2 5B
-bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh \
-    model.flash_attention_dense=false model.avoid_rope_reconcat=false \
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    model.flash_attention_dense=false model.compile_causal_attention_block=false \
     model.batch_vae_encode=false 'model.prompt_emb_cache=""'
 
 # Wan2.1 14B
-bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_finetune.sh \
+bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_fsdp_finetune.sh \
     model.skip_single_state_attention=false model.compile_causal_cross_attention=false \
     model.compile_cross_attention_emulate_precision_casts=false model.compile_block_norm_modulate=false \
     model.qk_rmsnorm_impl=wan model.manual_self_attn_linear_backward=false model.fused_rope=false \
@@ -235,7 +235,7 @@ Main switches:
 | Switch | Default | Description |
 | --- | --- | --- |
 | `model.flash_attention_dense` | `true` | dense attention uses FlashAttention directly |
-| `model.avoid_rope_reconcat` | `true` | reuse segmented RoPE results, reduce temporary tensors |
+| `model.compile_causal_attention_block` | `true` | compile the causal attention block |
 | `model.batch_vae_encode` | `true` | batched VAE encoding; higher throughput but larger peak memory; disable when OOM |
 | `model.prompt_emb_cache` | `gpu` | cache frozen Text Encoder outputs; set to `cpu` or empty string to disable |
 | `model.compile_causal_cross_attention` (14B) | `true` | `torch.compile` compile causal cross-attention |

--- a/docs/source/embodied_tutorial/quick_start_dreamzero.md
+++ b/docs/source/embodied_tutorial/quick_start_dreamzero.md
@@ -210,13 +210,14 @@ CACHE_DIR=$DREAMZERO_CACHE_ROOT/dreamzero_full_wan22_5b SAMPLE_TRANSFORM_SEED=0 
 The training script strictly validates the cache at startup. When manifest, `_SUCCESS`, or transform config mismatch, training aborts before the first step.
 
 ### 2.4 Performance Optimization Switches
-The DROID 5B / 14B configs enable validated default optimizations. The 5B Full FSDP recipe also enables Delta-FP8 AllGather by default on supported CUDA/NCCL devices; pass `--no-fsdp-delta-fp8-allgather` for a native BF16 communication A/B comparison. LIBERO, AgiBot, and YAM use conservative defaults. After adjusting performance switches, we recommend running 3–10 steps first and checking loss, grad norm, and memory usage.
+The DROID 5B / 14B configs enable validated default optimizations. The 5B Full FSDP recipe also enables Delta-FP8 AllGather by default and requires a supported CUDA/NCCL environment; pass `--no-fsdp-delta-fp8-allgather` to use native BF16 AllGather on an unsupported environment or for an A/B comparison. LIBERO, AgiBot, and YAM use conservative defaults. After adjusting performance switches, we recommend running 3–10 steps first and checking loss, grad norm, and memory usage.
 
-Control group (disable all kernel optimizations, for isolating loss / performance issues):
+Control group (disable optional model-side optimizations and Delta-FP8 to isolate loss or performance issues):
 
 ```bash
 # Wan2.2 5B
 bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    --no-fsdp-delta-fp8-allgather \
     model.flash_attention_dense=false model.compile_causal_attention_block=false \
     model.batch_vae_encode=false 'model.prompt_emb_cache=""'
 
@@ -235,7 +236,7 @@ Main switches:
 | Switch | Default | Description |
 | --- | --- | --- |
 | `model.flash_attention_dense` | `true` | dense attention uses FlashAttention directly |
-| `model.compile_causal_attention_block` | `true` | compile the causal attention block |
+| `model.compile_causal_attention_block` (5B) | `true` | compile the full `CausalWanAttentionBlock` forward with `torch.compile` |
 | `model.batch_vae_encode` | `true` | batched VAE encoding; higher throughput but larger peak memory; disable when OOM |
 | `model.prompt_emb_cache` | `gpu` | cache frozen Text Encoder outputs; set to `cpu` or empty string to disable |
 | `model.compile_causal_cross_attention` (14B) | `true` | `torch.compile` compile causal cross-attention |

--- a/docs/source/features/delta_fp8_allgather.md
+++ b/docs/source/features/delta_fp8_allgather.md
@@ -1,0 +1,89 @@
+# Delta-FP8 AllGather
+
+Delta-FP8 AllGather is an opt-in FSDP2 communication optimization for the LoongForge embodied training stack. It reduces parameter AllGather traffic by communicating blockwise FP8 deltas instead of complete BF16 parameters. It changes communication precision only; forward and backward computation continue to use the dtype configured by the FSDP mixed-precision policy.
+
+Delta-FP8 AllGather is independent of LoongForge's end-to-end [FP8 training](fp8_training.md). Enabling this feature does not convert model weights, activations, or GEMMs to FP8.
+
+## 1. Requirements
+
+Delta-FP8 requires all of the following:
+
+- FSDP2 selected with `--distributed-strategy fsdp`
+- A CUDA device and the NCCL distributed backend
+- An NVIDIA GPU with compute capability 8.9 or later
+- PyTorch FP8 E4M3 support
+- A CUDA Triton backend exposing `tl.float8e4nv`
+- BF16 FSDP parameter communication using the default AllGather implementation
+
+The runtime capability check executes while FSDP groups are registered. Unsupported devices or backends fail at startup with an error containing the detected device and backend. Non-BF16 parameter groups and custom AllGather implementations retain native FSDP behavior.
+
+## 2. Usage
+
+### 2.1 DreamZero Wan2.2-5B
+
+The DreamZero Wan2.2-5B full FSDP recipe enables Delta-FP8 with its validated settings. No additional Delta-FP8 argument is required:
+
+```bash
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
+```
+
+To use native BF16 AllGather for an A/B comparison:
+
+```bash
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    --no-fsdp-delta-fp8-allgather
+```
+
+### 2.2 Other Embodied Models
+
+The framework-level default is disabled. Append the following flag to an FSDP launcher to enable Delta-FP8 for eligible parameter groups:
+
+```bash
+bash path/to/fsdp_launcher.sh \
+    --fsdp-delta-fp8-allgather
+```
+
+Support in the communication path does not by itself establish numerical or performance suitability for every model. Validate loss, step time, and peak memory against the same model's BF16 FSDP baseline before adopting it in another recipe.
+
+## 3. Configuration
+
+| Argument | Default | Description |
+| --- | --- | --- |
+| `--fsdp-delta-fp8-allgather` | `False` | Enable Delta-FP8 for the current model's eligible FSDP groups |
+| `--fsdp-delta-fp8-block` | `256` | Number of elements sharing one FP32 scale; must be a positive power of two no greater than 1,048,576 |
+| `--fsdp-delta-fp8-prime-steps` | `1` | Number of full BF16 AllGathers used to initialize each FSDP unit before delta communication |
+| `--fsdp-delta-fp8-reprime-interval` | `0` | Perform a full BF16 AllGather every N unshards; `0` disables periodic re-priming |
+
+Keep the default block size and priming settings unless a matched loss and performance validation supports changing them. A smaller block gives finer quantization scales but communicates more scale data. Periodic re-priming can re-anchor the reference after discontinuous parameter changes, but it also adds full BF16 collectives.
+
+## 4. How It Works
+
+For each eligible FSDP unit:
+
+1. Full BF16 AllGather initializes a persistent BF16 reference.
+2. The local parameter shard is compared with the corresponding reference shard.
+3. The delta is quantized per block into an FP8 E4M3 payload with an FP32 scale.
+4. FP8 payloads and scales are gathered across ranks while preserving the caller's asynchronous collective semantics.
+5. Gathered deltas are dequantized and accumulated into the BF16 reference used by FSDP.
+
+Accumulating reconstructed deltas into the reference feeds quantization residuals into later updates instead of repeatedly quantizing against a fixed initial value. The reference aliases FSDP's unsharded parameter storage, and quantization scratch buffers are shared across FSDP units to avoid persistent per-unit staging allocations.
+
+## 5. Validation
+
+Delta-FP8 uses lossy communication. For a new model, optimizer, block size, or re-priming policy, compare it with a canonical native BF16 FSDP run under the same weights, data order, batch configuration, precision, hardware, and measurement window. At minimum, check:
+
+- Step-by-step loss and gradient norm over a representative training window
+- Stable step time after excluding initialization and compilation warmup
+- Per-rank peak GPU memory
+- NaN, Inf, communication, and distributed runtime errors
+
+Do not infer support for a model solely from a successful short smoke test. Promote the setting into a default recipe only after its numerical and performance behavior has been validated for that workload.
+
+## 6. Troubleshooting
+
+| Symptom | Action |
+| --- | --- |
+| Startup reports an unsupported device, backend, or Triton FP8 type | Use native BF16 AllGather or run on a supported CUDA/NCCL environment |
+| Performance does not improve | Confirm that communication uses BF16 default FSDP AllGather and that AllGather is a material bottleneck |
+| Loss diverges from the BF16 reference | Restore the default block and priming settings; if the difference remains unacceptable, disable Delta-FP8 for that workload |
+| Behavior changes after a discontinuous parameter update | Validate a nonzero `--fsdp-delta-fp8-reprime-interval` or restart the run so references are initialized again |

--- a/docs/source/features/delta_fp8_allgather.md
+++ b/docs/source/features/delta_fp8_allgather.md
@@ -66,24 +66,13 @@ For each eligible FSDP unit:
 4. FP8 payloads and scales are gathered across ranks while preserving the caller's asynchronous collective semantics.
 5. Gathered deltas are dequantized and accumulated into the BF16 reference used by FSDP.
 
-Accumulating reconstructed deltas into the reference feeds quantization residuals into later updates instead of repeatedly quantizing against a fixed initial value. The reference aliases FSDP's unsharded parameter storage, and quantization scratch buffers are shared across FSDP units to avoid persistent per-unit staging allocations.
+Accumulating reconstructed deltas into the reference feeds quantization residuals into later updates instead of repeatedly quantizing against a fixed initial value. For the standard contiguous dim-0 FSDP layout, the reference aliases FSDP's unsharded parameter storage and FP8 payload/scale scratch buffers are shared across FSDP units. Unsupported layouts fall back to a separate reference, and non-contiguous inputs lazily allocate a per-unit BF16 copy buffer.
 
-## 5. Validation
-
-Delta-FP8 uses lossy communication. For a new model, optimizer, block size, or re-priming policy, compare it with a canonical native BF16 FSDP run under the same weights, data order, batch configuration, precision, hardware, and measurement window. At minimum, check:
-
-- Step-by-step loss and gradient norm over a representative training window
-- Stable step time after excluding initialization and compilation warmup
-- Per-rank peak GPU memory
-- NaN, Inf, communication, and distributed runtime errors
-
-Do not infer support for a model solely from a successful short smoke test. Promote the setting into a default recipe only after its numerical and performance behavior has been validated for that workload.
-
-## 6. Troubleshooting
+## 5. Troubleshooting
 
 | Symptom | Action |
 | --- | --- |
 | Startup reports an unsupported device, backend, or Triton FP8 type | Use native BF16 AllGather or run on a supported CUDA/NCCL environment |
-| Performance does not improve | Confirm that communication uses BF16 default FSDP AllGather and that AllGather is a material bottleneck |
+| Performance does not improve | Confirm that the startup log reports registered FSDP groups, those groups use BF16 and the default AllGather implementation, and AllGather is a material bottleneck |
 | Loss diverges from the BF16 reference | Restore the default block and priming settings; if the difference remains unacceptable, disable Delta-FP8 for that workload |
 | Behavior changes after a discontinuous parameter update | Validate a nonzero `--fsdp-delta-fp8-reprime-interval` or restart the run so references are initialized again |

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -44,6 +44,7 @@ A modular, scalable, and highly efficient training framework for language, multi
    :caption: Embodied Training
 
    embodied_tutorial/overview
+   features/delta_fp8_allgather
    embodied_tutorial/quick_start_pi05
    embodied_tutorial/quick_start_groot_n1_6
    embodied_tutorial/quick_start_groot_n1_7

--- a/docs/source_zh/embodied_tutorial/overview.md
+++ b/docs/source_zh/embodied_tutorial/overview.md
@@ -124,6 +124,7 @@ model.forward(batch)
 | 功能 | 配置项 | 默认值 | 取值 / 类型 | 说明 |
 | --- | --- | --- | --- | --- |
 | worker 数 | `--num-workers` | `4` | 非负整数 | 每个 rank 的 DataLoader worker 数 |
+| 预取倍数 | `--dataloader-prefetch-factor` | `2` | 正整数 | 每个 worker 预取的 batch 数；仅在 `--num-workers` 大于 0 时生效 |
 | worker seed | `--dataloader-seed-workers` | `False` | 布尔开关 | 是否基于 `--seed` 设置 worker seed |
 | 多进程上下文 | `--dataloader-multiprocessing-context` | `None` | `fork`, `spawn`, `forkserver` | DataLoader worker 启动方式 |
 | 分布式采样方式 | `--distributed-sampler-mode` | `cyclic` | `cyclic`, `block` | 分布式 sampler 的 index 切分方式（可扩展） |
@@ -383,26 +384,36 @@ bash examples/embodied/pi05/run_pi05_ddp_finetune.sh \
 
 #### 4.2.2 FSDP 通用参数
 
-以下参数提供对 FSDP 分片、wrap 策略和 dtype 的精细控制，仅在 `--distributed-strategy fsdp` 时生效：
+以下参数提供对 FSDP 分片、wrap 策略、dtype、预取和通信的精细控制，仅在 `--distributed-strategy fsdp` 时生效：
 
-- **分片与 reshard**：控制 forward 后是否立即 reshard，可针对 root group 单独配置
+- **分片与 reshard**：控制 forward 后是否立即 reshard，并可按模块类覆盖；FSDP2 root group 在 forward 后保持 unsharded
 - **wrap 策略**：可手动指定或排除 FSDP unit 类，也可按参数量阈值自动包装
 - **dtype 控制**：分片前参数 dtype、all-gather 后 dtype 与梯度 reduce dtype 均可独立配置
+- **执行与通信**：可预取相邻 FSDP unit，并可选用 Delta-FP8 压缩 BF16 AllGather 通信
 
 | 功能 | 配置项 | 默认值 | 取值 / 类型 | 说明 |
 | --- | --- | --- | --- | --- |
 | HSDP | `--hsdp-shard-size` | `None` | 正整数 | 启用二维 mesh 的 shard 维度 |
 | 默认 reshard 策略 | `--fsdp-reshard-default` | `None` | `true`, `false`, `none`, 大于 1 的整数 | 控制 forward 后参数 reshard |
-| root reshard 策略 | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, 大于 1 的整数 | root FSDP group 的 reshard 策略 |
+| 按类覆盖 reshard 策略 | `--fsdp-reshard-module-overrides` | `None` | 逗号分隔的 `ClassName=value` | 为指定模块类覆盖 `reshard_after_forward` |
 | 指定 wrap 类 | `--fsdp-wrap-modules` | `None` | 逗号分隔模块类名 | 指定 FSDP unit |
 | 排除 wrap 类 | `--fsdp-no-wrap-modules` | `None` | 逗号分隔模块类名 | 排除指定模块类 |
 | 排除分片的参数 | `--fsdp-ignored-param-names` | `[]` | 空格分隔的参数名子串 | 命中任一子串的冻结参数在每张卡各留一份完整副本 |
-| 自动 wrap 阈值 | `--fsdp-min-num-params` | `1000000` | 非负整数 | 自动包装重复层的参数阈值 |
-| leftover wrap 阈值 | `--fsdp-leftover-min-num-params` | `1000000` | 非负整数 | 自动包装剩余模块的参数阈值 |
+| 复制冻结模块类 | `--fsdp-ignore-frozen-module-classes` | `None` | 逗号分隔模块类名 | 将完全冻结的命中模块保留在 FSDP 分片外，避免无效 AllGather；会增加参数副本显存 |
+| 复制冻结参数 dtype | `--fsdp-ignored-frozen-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | 可选指定复制冻结参数的 dtype；设置时必须与 `--dtype` 一致 |
+| 自动 wrap 阈值 | `--fsdp-min-param-num` | `1000000` | 非负整数 | 自动包装重复层的参数阈值 |
 | 原始参数 dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | FSDP 分片前参数 dtype |
-| unsharded 参数 dtype | `--fsdp-unsharded-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | all-gather 后前向/反向 dtype |
+| unsharded 参数 dtype | `--fsdp-unshard-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | AllGather 后前向/反向 dtype |
 | reduce dtype | `--fsdp-reduce-dtype` | `fp32` | `fp32`, `bf16`, `fp16` | 梯度 reduce dtype |
+| 输出 dtype | `--fsdp-output-dtype` | `None` | `fp32`, `bf16`, `fp16` | 可选指定每个 FSDP unit 浮点输出的 dtype |
 | cast forward inputs | `--fsdp-cast-forward-inputs` | `True` | 布尔开关 | 是否将输入 cast 到参数 dtype |
+| forward 预取距离 | `--fsdp-forward-prefetch-distance` | `0` | 非负整数 | forward 时预取后续已配置 FSDP unit 的数量 |
+| backward 预取距离 | `--fsdp-backward-prefetch-distance` | `0` | 非负整数 | backward 时预取前序已配置 FSDP unit 的数量 |
+| Delta-FP8 AllGather | `--fsdp-delta-fp8-allgather` | `False` | 布尔开关 | 将 BF16 FSDP2 AllGather 的参数差值按 block 压缩为 FP8；详见[使用文档](../features/delta_fp8_allgather.md) |
+
+复制冻结模块类时，所有命中参数都必须满足 `requires_grad=False`。该模式与 `--init-on-meta` 不兼容；若设置 `--fsdp-ignored-frozen-param-dtype`，其值必须与 `--dtype` 选择的训练计算 dtype 一致。
+
+Delta-FP8 只改变 FSDP 参数通信精度，模型计算仍使用 FSDP 混合精度策略选择的 dtype。使用条件、启动方式、参数说明和验证建议详见 [Delta-FP8 AllGather](../features/delta_fp8_allgather.md)。
 
 ### 4.3 稳定性与运行时控制
 

--- a/docs/source_zh/embodied_tutorial/overview.md
+++ b/docs/source_zh/embodied_tutorial/overview.md
@@ -124,7 +124,6 @@ model.forward(batch)
 | 功能 | 配置项 | 默认值 | 取值 / 类型 | 说明 |
 | --- | --- | --- | --- | --- |
 | worker 数 | `--num-workers` | `4` | 非负整数 | 每个 rank 的 DataLoader worker 数 |
-| 预取倍数 | `--dataloader-prefetch-factor` | `2` | 正整数 | 每个 worker 预取的 batch 数；仅在 `--num-workers` 大于 0 时生效 |
 | worker seed | `--dataloader-seed-workers` | `False` | 布尔开关 | 是否基于 `--seed` 设置 worker seed |
 | 多进程上下文 | `--dataloader-multiprocessing-context` | `None` | `fork`, `spawn`, `forkserver` | DataLoader worker 启动方式 |
 | 分布式采样方式 | `--distributed-sampler-mode` | `cyclic` | `cyclic`, `block` | 分布式 sampler 的 index 切分方式（可扩展） |
@@ -384,36 +383,34 @@ bash examples/embodied/pi05/run_pi05_ddp_finetune.sh \
 
 #### 4.2.2 FSDP 通用参数
 
-以下参数提供对 FSDP 分片、wrap 策略、dtype、预取和通信的精细控制，仅在 `--distributed-strategy fsdp` 时生效：
+以下参数提供对 FSDP 分片、wrap 策略、dtype 和通信的精细控制，仅在 `--distributed-strategy fsdp` 时生效：
 
-- **分片与 reshard**：控制 forward 后是否立即 reshard，并可按模块类覆盖；FSDP2 root group 在 forward 后保持 unsharded
+- **分片与 reshard**：控制 forward 后是否立即 reshard，可针对 root group 单独配置
 - **wrap 策略**：可手动指定或排除 FSDP unit 类，也可按参数量阈值自动包装
 - **dtype 控制**：分片前参数 dtype、all-gather 后 dtype 与梯度 reduce dtype 均可独立配置
-- **执行与通信**：可预取相邻 FSDP unit，并可选用 Delta-FP8 压缩 BF16 AllGather 通信
+- **通信**：可选用 Delta-FP8 压缩 BF16 AllGather 通信
 
 | 功能 | 配置项 | 默认值 | 取值 / 类型 | 说明 |
 | --- | --- | --- | --- | --- |
 | HSDP | `--hsdp-shard-size` | `None` | 正整数 | 启用二维 mesh 的 shard 维度 |
 | 默认 reshard 策略 | `--fsdp-reshard-default` | `None` | `true`, `false`, `none`, 大于 1 的整数 | 控制 forward 后参数 reshard |
-| 按类覆盖 reshard 策略 | `--fsdp-reshard-module-overrides` | `None` | 逗号分隔的 `ClassName=value` | 为指定模块类覆盖 `reshard_after_forward` |
+| root reshard 策略 | `--fsdp-reshard-root` | `False` | `true`, `false`, `none`, 大于 1 的整数 | root FSDP group 的 reshard 策略 |
 | 指定 wrap 类 | `--fsdp-wrap-modules` | `None` | 逗号分隔模块类名 | 指定 FSDP unit |
 | 排除 wrap 类 | `--fsdp-no-wrap-modules` | `None` | 逗号分隔模块类名 | 排除指定模块类 |
 | 排除分片的参数 | `--fsdp-ignored-param-names` | `[]` | 空格分隔的参数名子串 | 命中任一子串的冻结参数在每张卡各留一份完整副本 |
 | 复制冻结模块类 | `--fsdp-ignore-frozen-module-classes` | `None` | 逗号分隔模块类名 | 将完全冻结的命中模块保留在 FSDP 分片外，避免无效 AllGather；会增加参数副本显存 |
 | 复制冻结参数 dtype | `--fsdp-ignored-frozen-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | 可选指定复制冻结参数的 dtype；设置时必须与 `--dtype` 一致 |
-| 自动 wrap 阈值 | `--fsdp-min-param-num` | `1000000` | 非负整数 | 自动包装重复层的参数阈值 |
+| 自动 wrap 阈值 | `--fsdp-min-num-params` | `1000000` | 非负整数 | 自动包装重复层的参数阈值 |
+| leftover wrap 阈值 | `--fsdp-leftover-min-num-params` | `1000000` | 非负整数 | 自动包装剩余模块的参数阈值 |
 | 原始参数 dtype | `--fsdp-original-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | FSDP 分片前参数 dtype |
-| unsharded 参数 dtype | `--fsdp-unshard-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | AllGather 后前向/反向 dtype |
+| unsharded 参数 dtype | `--fsdp-unsharded-param-dtype` | `None` | `fp32`, `bf16`, `fp16` | all-gather 后前向/反向 dtype |
 | reduce dtype | `--fsdp-reduce-dtype` | `fp32` | `fp32`, `bf16`, `fp16` | 梯度 reduce dtype |
-| 输出 dtype | `--fsdp-output-dtype` | `None` | `fp32`, `bf16`, `fp16` | 可选指定每个 FSDP unit 浮点输出的 dtype |
 | cast forward inputs | `--fsdp-cast-forward-inputs` | `True` | 布尔开关 | 是否将输入 cast 到参数 dtype |
-| forward 预取距离 | `--fsdp-forward-prefetch-distance` | `0` | 非负整数 | forward 时预取后续已配置 FSDP unit 的数量 |
-| backward 预取距离 | `--fsdp-backward-prefetch-distance` | `0` | 非负整数 | backward 时预取前序已配置 FSDP unit 的数量 |
 | Delta-FP8 AllGather | `--fsdp-delta-fp8-allgather` | `False` | 布尔开关 | 将 BF16 FSDP2 AllGather 的参数差值按 block 压缩为 FP8；详见[使用文档](../features/delta_fp8_allgather.md) |
 
 复制冻结模块类时，所有命中参数都必须满足 `requires_grad=False`。该模式与 `--init-on-meta` 不兼容；若设置 `--fsdp-ignored-frozen-param-dtype`，其值必须与 `--dtype` 选择的训练计算 dtype 一致。
 
-Delta-FP8 只改变 FSDP 参数通信精度，模型计算仍使用 FSDP 混合精度策略选择的 dtype。使用条件、启动方式、参数说明和验证建议详见 [Delta-FP8 AllGather](../features/delta_fp8_allgather.md)。
+Delta-FP8 只改变 FSDP 参数通信精度，模型计算仍使用 FSDP 混合精度策略选择的 dtype。使用条件、启动方式、参数说明和常见问题详见 [Delta-FP8 AllGather](../features/delta_fp8_allgather.md)。
 
 ### 4.3 稳定性与运行时控制
 

--- a/docs/source_zh/embodied_tutorial/quick_start_dreamzero.md
+++ b/docs/source_zh/embodied_tutorial/quick_start_dreamzero.md
@@ -210,13 +210,14 @@ CACHE_DIR=$DREAMZERO_CACHE_ROOT/dreamzero_full_wan22_5b SAMPLE_TRANSFORM_SEED=0 
 训练脚本会在启动阶段严格校验 cache。manifest、`_SUCCESS` 或 transform 配置不匹配时，训练会在执行首步前终止。
 
 ### 2.4 性能优化开关
-DROID 5B / 14B 配置已启用经过验证的默认性能优化。5B Full FSDP recipe 在支持的 CUDA/NCCL 设备上默认开启 Delta-FP8 AllGather；可传入 `--no-fsdp-delta-fp8-allgather` 与原生 BF16 通信做 A/B 对比。LIBERO、AgiBot 和 YAM 默认采用保守配置；调整性能开关后，建议先运行 3～10 步，检查 loss、grad norm 和显存占用。
+DROID 5B / 14B 配置已启用经过验证的默认性能优化。5B Full FSDP recipe 默认开启 Delta-FP8 AllGather，因此需要支持该功能的 CUDA/NCCL 环境；环境不支持或需要进行 A/B 对比时，可传入 `--no-fsdp-delta-fp8-allgather` 使用原生 BF16 AllGather。LIBERO、AgiBot 和 YAM 默认采用保守配置；调整性能开关后，建议先运行 3～10 步，检查 loss、grad norm 和显存占用。
 
-对照组（关闭全部内核优化，用于定位 loss / 性能问题）：
+对照组（关闭可选的模型侧优化和 Delta-FP8，用于定位 loss 或性能问题）：
 
 ```bash
 # Wan2.2 5B
 bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    --no-fsdp-delta-fp8-allgather \
     model.flash_attention_dense=false model.compile_causal_attention_block=false \
     model.batch_vae_encode=false 'model.prompt_emb_cache=""'
 
@@ -235,7 +236,7 @@ bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_fsdp_finetune.sh \
 | 开关 | 默认值 | 作用 |
 | --- | --- | --- |
 | `model.flash_attention_dense` | `true` | dense attention 直接用 FlashAttention |
-| `model.compile_causal_attention_block` | `true` | 编译 causal attention block |
+| `model.compile_causal_attention_block`（5B） | `true` | 使用 `torch.compile` 编译完整的 `CausalWanAttentionBlock` forward |
 | `model.batch_vae_encode` | `true` | 批量 VAE 编码，吞吐更高但显存峰值更大，OOM 时关闭 |
 | `model.prompt_emb_cache` | `gpu` | 缓存冻结 Text Encoder 输出，可设 `cpu` 或空字符串关闭 |
 | `model.compile_causal_cross_attention`（14B） | `true` | `torch.compile` 编译 causal cross-attention |

--- a/docs/source_zh/embodied_tutorial/quick_start_dreamzero.md
+++ b/docs/source_zh/embodied_tutorial/quick_start_dreamzero.md
@@ -144,30 +144,30 @@ cd "$LOONGFORGE_PATH"
 export DATA_PATH=$DROID_DATA_ROOT
 export WANDB_MODE=disabled
 
-# 5B Full，默认 200000 步
-bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+# 5B Full（FSDP + Delta-FP8），默认 200000 步
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 
 # 5B LoRA
 TRAIN_ITERS=10000 SAVE_INTERVAL=1000 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_fsdp_finetune.sh
 
 # 14B Full
-bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_finetune.sh
+bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_fsdp_finetune.sh
 
 # 14B LoRA，DROID
 TRAIN_ITERS=10000 SAVE_INTERVAL=1000 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 
 # LIBERO 5B Full
 MODEL_NAME=dreamzero_libero_wan22_5b DATA_PATH="$LIBERO_DATA_ROOT" \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 
 # AgiBot / YAM 14B LoRA（从 DreamZero-AgiBot 初始化）
 MODEL_NAME=dreamzero_agibot_wan21_14b DATA_PATH=/path/to/agibot_lerobot \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 
 MODEL_NAME=dreamzero_yam_wan21_14b DATA_PATH=/path/to/yam_lerobot \
-    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_lora_fsdp_finetune.sh
 ```
 
 DROID 场景无需设置 `MODEL_NAME`，训练脚本会自动选择对应配置；仅切换到 LIBERO、AgiBot 或 YAM 时需要按示例覆盖。
@@ -176,7 +176,7 @@ DROID 场景无需设置 `MODEL_NAME`，训练脚本会自动选择对应配置�
 
 | 场景 | 分布式策略 | 每卡 batch | 默认 global batch | 默认 LR |
 | --- | --- | --- | --- | --- |
-| 5B Full | 8 卡 DDP + ZeRO-1 | 1 | 8 | `1e-5` |
+| 5B Full | 8 卡 FSDP + Delta-FP8 | 1 | 8 | `1e-5` |
 | 5B LoRA | 8 卡 FSDP | 1 | 8 | `1e-5` |
 | 14B Full | 8 卡 FSDP | 1 | 8 | `1e-5` |
 | 14B DROID LoRA | 8 卡 FSDP | 1 | 8 | `1e-4` |
@@ -188,7 +188,7 @@ DROID 场景无需设置 `MODEL_NAME`，训练脚本会自动选择对应配置�
 ```bash
 TRAIN_ITERS=20000 SAVE_INTERVAL=1000 \
 OUTPUT_DIR=/workspace/outputs/dreamzero/droid_wan22_5b_lora \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_finetune.sh \
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_lora_fsdp_finetune.sh \
     --resume
 ```
 
@@ -204,24 +204,24 @@ GPUS_PER_NODE=8 SAMPLE_TRANSFORM_SEED=0 VALIDATION_REQUIRE_FULL_COVERAGE=1 \
 
 # 使用 cache 训练（须与生成时 SAMPLE_TRANSFORM_SEED、分辨率、语言 chunk 配置一致）
 CACHE_DIR=$DREAMZERO_CACHE_ROOT/dreamzero_full_wan22_5b SAMPLE_TRANSFORM_SEED=0 \
-    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh
+    bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
 ```
 
 训练脚本会在启动阶段严格校验 cache。manifest、`_SUCCESS` 或 transform 配置不匹配时，训练会在执行首步前终止。
 
 ### 2.4 性能优化开关
-DROID 5B / 14B 配置已启用经过验证的默认性能优化。LIBERO、AgiBot 和 YAM 默认采用保守配置；调整性能开关后，建议先运行 3～10 步，检查 loss、grad norm 和显存占用。
+DROID 5B / 14B 配置已启用经过验证的默认性能优化。5B Full FSDP recipe 在支持的 CUDA/NCCL 设备上默认开启 Delta-FP8 AllGather；可传入 `--no-fsdp-delta-fp8-allgather` 与原生 BF16 通信做 A/B 对比。LIBERO、AgiBot 和 YAM 默认采用保守配置；调整性能开关后，建议先运行 3～10 步，检查 loss、grad norm 和显存占用。
 
 对照组（关闭全部内核优化，用于定位 loss / 性能问题）：
 
 ```bash
 # Wan2.2 5B
-bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_finetune.sh \
-    model.flash_attention_dense=false model.avoid_rope_reconcat=false \
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    model.flash_attention_dense=false model.compile_causal_attention_block=false \
     model.batch_vae_encode=false 'model.prompt_emb_cache=""'
 
 # Wan2.1 14B
-bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_finetune.sh \
+bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_fsdp_finetune.sh \
     model.skip_single_state_attention=false model.compile_causal_cross_attention=false \
     model.compile_cross_attention_emulate_precision_casts=false model.compile_block_norm_modulate=false \
     model.qk_rmsnorm_impl=wan model.manual_self_attn_linear_backward=false model.fused_rope=false \
@@ -235,7 +235,7 @@ bash examples/embodied/dreamzero/run_dreamzero_wan21_14b_full_finetune.sh \
 | 开关 | 默认值 | 作用 |
 | --- | --- | --- |
 | `model.flash_attention_dense` | `true` | dense attention 直接用 FlashAttention |
-| `model.avoid_rope_reconcat` | `true` | 复用分段 RoPE 结果，减少临时张量 |
+| `model.compile_causal_attention_block` | `true` | 编译 causal attention block |
 | `model.batch_vae_encode` | `true` | 批量 VAE 编码，吞吐更高但显存峰值更大，OOM 时关闭 |
 | `model.prompt_emb_cache` | `gpu` | 缓存冻结 Text Encoder 输出，可设 `cpu` 或空字符串关闭 |
 | `model.compile_causal_cross_attention`（14B） | `true` | `torch.compile` 编译 causal cross-attention |

--- a/docs/source_zh/features/delta_fp8_allgather.md
+++ b/docs/source_zh/features/delta_fp8_allgather.md
@@ -1,0 +1,89 @@
+# Delta-FP8 AllGather
+
+Delta-FP8 AllGather 是 LoongForge embodied 训练栈中一项可选的 FSDP2 通信优化。它通过传输按 block 量化的 FP8 参数差值，代替完整 BF16 参数，从而减少参数 AllGather 通信量。该功能只改变通信精度，forward 和 backward 计算仍使用 FSDP 混合精度策略配置的 dtype。
+
+Delta-FP8 AllGather 与 LoongForge 的端到端 [FP8 训练](fp8_training.md) 是两项独立功能。启用本功能不会将模型权重、激活或 GEMM 计算转为 FP8。
+
+## 1. 使用条件
+
+Delta-FP8 需同时满足以下条件：
+
+- 通过 `--distributed-strategy fsdp` 使用 FSDP2
+- 使用 CUDA 设备和 NCCL 分布式 backend
+- NVIDIA GPU 的 compute capability 不低于 8.9
+- PyTorch 支持 FP8 E4M3
+- CUDA Triton backend 提供 `tl.float8e4nv`
+- FSDP 参数通信使用 BF16 和默认 AllGather 实现
+
+FSDP group 注册时会执行运行时能力检查。不支持的设备或 backend 会在启动阶段报错，并在错误中输出检测到的设备和 backend。非 BF16 参数组或自定义 AllGather 实现保留原生 FSDP 行为。
+
+## 2. 使用方法
+
+### 2.1 DreamZero Wan2.2-5B
+
+DreamZero Wan2.2-5B Full FSDP recipe 已默认启用 Delta-FP8 及验证过的参数，无需额外传入 Delta-FP8 参数：
+
+```bash
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh
+```
+
+如需使用原生 BF16 AllGather 进行 A/B 对比：
+
+```bash
+bash examples/embodied/dreamzero/run_dreamzero_wan22_5b_full_fsdp_finetune.sh \
+    --no-fsdp-delta-fp8-allgather
+```
+
+### 2.2 其他 Embodied 模型
+
+框架级默认为关闭。在 FSDP 启动脚本后追加以下参数，即可为符合条件的参数组启用 Delta-FP8：
+
+```bash
+bash path/to/fsdp_launcher.sh \
+    --fsdp-delta-fp8-allgather
+```
+
+通信路径能够运行不代表已证明该功能适合所有模型的精度和性能要求。将它用于其他 recipe 前，需与同一模型的 BF16 FSDP baseline 对比 loss、step time 和峰值显存。
+
+## 3. 参数说明
+
+| 参数 | 默认值 | 说明 |
+| --- | --- | --- |
+| `--fsdp-delta-fp8-allgather` | `False` | 为当前模型符合条件的 FSDP group 启用 Delta-FP8 |
+| `--fsdp-delta-fp8-block` | `256` | 共享一个 FP32 scale 的元素数；必须是不大于 1,048,576 的正整数 2 次幂 |
+| `--fsdp-delta-fp8-prime-steps` | `1` | 转入差值通信前，用于初始化每个 FSDP unit 的完整 BF16 AllGather 次数 |
+| `--fsdp-delta-fp8-reprime-interval` | `0` | 每 N 次 unshard 执行一次完整 BF16 AllGather；`0` 表示关闭周期性重新初始化 |
+
+除非同配置的 loss 和性能验证支持修改，建议保持默认 block size 和 prime 设置。更小的 block 能提供更精细的量化 scale，但会传输更多 scale 数据。周期性重新初始化可在参数非连续变化后重新锚定 reference，但也会增加完整 BF16 collective。
+
+## 4. 工作原理
+
+对于每个符合条件的 FSDP unit：
+
+1. 通过完整 BF16 AllGather 初始化持久 BF16 reference。
+2. 将本地参数 shard 与 reference 中对应的 shard 进行比较。
+3. 将差值按 block 量化为 FP8 E4M3 payload，并为每个 block 生成 FP32 scale。
+4. 在 rank 之间 gather FP8 payload 和 scale，并保留调用方的异步 collective 语义。
+5. 反量化 gathered delta，并将其累加到 FSDP 使用的 BF16 reference。
+
+将重建后的差值累加回 reference，可以使量化残差进入后续更新，而不是每次都相对固定初始值量化。reference 直接复用 FSDP unsharded 参数存储，量化 scratch buffer 在 FSDP unit 间共享，以避免为每个 unit 持久分配 staging buffer。
+
+## 5. 验证建议
+
+Delta-FP8 使用有损通信。对新模型、优化器、block size 或重新初始化策略，应使用相同的权重、数据顺序、batch 配置、精度、硬件和测量区间，与 canonical 原生 BF16 FSDP 运行进行对比。至少检查：
+
+- 代表性训练区间内的逐步 loss 和 gradient norm
+- 排除初始化和编译 warmup 后的稳定 step time
+- 每个 rank 的 GPU 峰值显存
+- NaN、Inf、通信和分布式运行时错误
+
+不应仅根据一次短测成功就认定该模型已完成支持。只有在该 workload 的数值和性能行为完成验证后，才应将该配置纳入默认 recipe。
+
+## 6. 常见问题
+
+| 现象 | 处理方式 |
+| --- | --- |
+| 启动时报设备、backend 或 Triton FP8 类型不支持 | 使用原生 BF16 AllGather，或切换到支持的 CUDA/NCCL 环境 |
+| 性能没有提升 | 确认通信使用 BF16 默认 FSDP AllGather，并确认 AllGather 是当前主要瓶颈 |
+| loss 偏离 BF16 reference | 恢复默认 block 和 prime 设置；若差异仍不可接受，对该 workload 关闭 Delta-FP8 |
+| 参数非连续更新后行为改变 | 验证非零 `--fsdp-delta-fp8-reprime-interval`，或重启训练以重新初始化 reference |

--- a/docs/source_zh/features/delta_fp8_allgather.md
+++ b/docs/source_zh/features/delta_fp8_allgather.md
@@ -66,24 +66,13 @@ bash path/to/fsdp_launcher.sh \
 4. 在 rank 之间 gather FP8 payload 和 scale，并保留调用方的异步 collective 语义。
 5. 反量化 gathered delta，并将其累加到 FSDP 使用的 BF16 reference。
 
-将重建后的差值累加回 reference，可以使量化残差进入后续更新，而不是每次都相对固定初始值量化。reference 直接复用 FSDP unsharded 参数存储，量化 scratch buffer 在 FSDP unit 间共享，以避免为每个 unit 持久分配 staging buffer。
+将重建后的差值累加回 reference，可以使量化残差进入后续更新，而不是每次都相对固定初始值量化。对于标准连续 dim-0 FSDP 布局，reference 会复用 FSDP unsharded 参数存储，FP8 payload/scale scratch buffer 也会在 FSDP unit 间共享。不支持的布局会回退到独立 reference，非连续输入则会按需为对应 unit 分配 BF16 copy buffer。
 
-## 5. 验证建议
-
-Delta-FP8 使用有损通信。对新模型、优化器、block size 或重新初始化策略，应使用相同的权重、数据顺序、batch 配置、精度、硬件和测量区间，与 canonical 原生 BF16 FSDP 运行进行对比。至少检查：
-
-- 代表性训练区间内的逐步 loss 和 gradient norm
-- 排除初始化和编译 warmup 后的稳定 step time
-- 每个 rank 的 GPU 峰值显存
-- NaN、Inf、通信和分布式运行时错误
-
-不应仅根据一次短测成功就认定该模型已完成支持。只有在该 workload 的数值和性能行为完成验证后，才应将该配置纳入默认 recipe。
-
-## 6. 常见问题
+## 5. 常见问题
 
 | 现象 | 处理方式 |
 | --- | --- |
 | 启动时报设备、backend 或 Triton FP8 类型不支持 | 使用原生 BF16 AllGather，或切换到支持的 CUDA/NCCL 环境 |
-| 性能没有提升 | 确认通信使用 BF16 默认 FSDP AllGather，并确认 AllGather 是当前主要瓶颈 |
+| 性能没有提升 | 确认启动日志显示已注册 FSDP group、这些 group 使用 BF16 和默认 AllGather 实现，并确认 AllGather 是当前主要瓶颈 |
 | loss 偏离 BF16 reference | 恢复默认 block 和 prime 设置；若差异仍不可接受，对该 workload 关闭 Delta-FP8 |
 | 参数非连续更新后行为改变 | 验证非零 `--fsdp-delta-fp8-reprime-interval`，或重启训练以重新初始化 reference |

--- a/docs/source_zh/index.rst
+++ b/docs/source_zh/index.rst
@@ -46,6 +46,7 @@ LoongForge 中文文档
    :caption: Embodied 训练
 
    embodied_tutorial/overview.md
+   features/delta_fp8_allgather.md
    embodied_tutorial/quick_start_pi05.md
    embodied_tutorial/quick_start_groot_n1_6.md
    embodied_tutorial/quick_start_groot_n1_7.md


### PR DESCRIPTION
## What does this PR do?

- Add standalone English and Chinese usage guides for Delta-FP8 AllGather.
- Document its prerequisites, configuration, communication flow, fallback behavior, and troubleshooting.
- Update the English and Chinese DreamZero Quick Start guides to use the current FSDP launch scripts.
- Document the default Delta-FP8 behavior of the DreamZero Wan2.2-5B recipe and how to switch back to native BF16 AllGather.
- Add Delta-FP8 entries to the README, Embodied Overview, and documentation navigation.
- Document the ignored frozen module configuration used by the DreamZero FSDP recipe.

## Validation

- `pre-commit` passed for all changed documentation files.
- `git diff --check` passed.
- Referenced DreamZero scripts and local documentation links were verified.

Closes #212